### PR TITLE
add namespaced target name for the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ target_include_directories(InertialSense PUBLIC src external)
 target_link_libraries(InertialSense pthread)
 target_compile_options(InertialSense PUBLIC -fPIC)
 
+add_library( InertialSense::libinertialsense ALIAS InertialSense )
+
 add_subdirectory(CLTool)
 add_subdirectory(ExampleProjects)
 


### PR DESCRIPTION
This makes much easier integrating this project as a subdirectory on other cmake projects.

Just add the dependency:

<pre>
target_link_libraries( yourproject
   PRIVATE
      InertialSense::libinertialsense
      Boost::date_time
)
</pre>

other changes using the target_xxxx cmake functions would be welcome, but this is the minimal change required

feel free to use a alias name, but it needs to be "namespaced"