### PR TITLE
add partial support for Rad Studio C++ formerly known as C++ Builder

### DIFF
--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -195,7 +195,9 @@ extern void vPortFree(void* pv);
 #if PLATFORM_IS_WINDOWS
 
 #include <direct.h>
+#if ! defined ( __BORLANDC__ )
 #include <sys/utime.h>
+#endif
 #define _MKDIR(dir) _mkdir(dir)
 #define _RMDIR(dir) _rmdir(dir)
 #define _GETCWD(buf, len) _getcwd(buf, len)

--- a/src/time_conversion.c
+++ b/src/time_conversion.c
@@ -140,7 +140,7 @@ int TIMECONV_GetSystemTime(
 {
   int result;
 
-#ifdef WIN32
+#if defined WIN32 && ! defined ( __BORLANDC__ )
   struct _timeb timebuffer; // found in <sys/timeb.h>   
 #else
   struct timeb timebuffer;
@@ -149,7 +149,7 @@ int TIMECONV_GetSystemTime(
   double timebuffer_time_in_seconds;
   //char *timeline; // for debugging
 
-#ifdef WIN32
+#if defined WIN32 && ! defined ( __BORLANDC__ )
   _ftime( &timebuffer );
 #else
   ftime( &timebuffer );


### PR DESCRIPTION
Hi.

I am adding support for the uINS device in an application. The application is running on linux ( gcc and clang ) and 
windows ( RadStudio 10.3 ).  

For the linux application I use the SDK as an external library and everything is fine. 

Meanwhile, on windows I am just using some files from the SDK ( not the full SDK ) until I can work on getting the SDK
compiling in RadStudio.

The tiny changes I propose here are almost enough to have the code ( the .c files ) working under Rad Studio 10.3
I would be nice to have them merged into the official SDK.