### PR TITLE
Bugfix/sn 232 u ins presistent messages not working

### DIFF
--- a/EVB-2/IS_EVB-2/src/communications.h
+++ b/EVB-2/IS_EVB-2/src/communications.h
@@ -20,6 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "../hw-libs/communications/CAN_comm.h"
 
 
+extern is_comm_instance_t 		g_commTx;
 extern bool                     g_usb_cdc_open;
 
 typedef void(*pfnHandleUinsData)(p_data_hdr_t &dataHdr, uDatasets &data);
@@ -33,9 +34,9 @@ void callback_cdc_set_config(uint8_t port, usb_cdc_line_coding_t * cfg);
 void callback_cdc_disable(void);
 void callback_cdc_set_dtr(uint8_t port, bool b_enable);
 
-void uINS_stream_stop_all(is_comm_instance_t &comm);
-void uINS_stream_enable_std(is_comm_instance_t &comm);
-void uINS_stream_enable_PPD(is_comm_instance_t &comm);
+void uINS_stream_stop_all(void);
+void uINS_stream_enable_std(void);
+void uINS_stream_enable_PPD(void);
 
 void log_uINS_data(cISLogger &logger, is_comm_instance_t &comm);
 

--- a/EVB-2/IS_EVB-2/src/evb_tasks.cpp
+++ b/EVB-2/IS_EVB-2/src/evb_tasks.cpp
@@ -17,9 +17,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 is_comm_instance_t& evbTaskCommInit(void *pvParameters)
 {	
     UNUSED(pvParameters);
-    static is_comm_instance_t   comm;
-    static uint8_t              comm_buffer[PKT_BUF_SIZE];
-    is_comm_init(&comm, comm_buffer, PKT_BUF_SIZE);
+    static uint8_t comm_buffer[PKT_BUF_SIZE];
+    is_comm_init(&g_commTx, comm_buffer, PKT_BUF_SIZE);
 
 #ifdef CONF_BOARD_CAN_TEST
 	//if(/*g_can_test == CAN_TEST_MASTER - or something like that*/ 1)
@@ -36,7 +35,7 @@ is_comm_instance_t& evbTaskCommInit(void *pvParameters)
     vTaskDelay(200);
 	evbUiRefreshLedCfg();
 
-    return comm;
+    return g_commTx;
 }
 
 
@@ -71,15 +70,15 @@ is_comm_instance_t& evbTaskLoggerInit(void *pvParameters)
     static uint8_t              comm_buffer[PKT_BUF_SIZE];
     is_comm_init(&comm, comm_buffer, PKT_BUF_SIZE);
 
-    uINS_stream_stop_all(comm);
+    // uINS_stream_stop_all(comm);  // this interferes with the uINS presistent messages
 
     vTaskDelay(200);
     LED_LOG_OFF();
     vTaskDelay(800);
 
 #if STREAM_INS_FOR_TIME_SYNC  // Stream INS message on startup.  Necessary to update EVB RTC for correct data log date and time.
-    //uINS0_stream_stop_all(comm);
-    //uINS0_stream_enable_std(comm);
+    //uINS_stream_stop_all(comm);
+    //uINS_stream_enable_std(comm);
 #endif
 
     return comm;

--- a/EVB-2/IS_EVB-2/src/sd_card_logger.cpp
+++ b/EVB-2/IS_EVB-2/src/sd_card_logger.cpp
@@ -85,8 +85,8 @@ static void start_logger(cISLogger& logger, is_comm_instance_t &comm)
     g_status.evbStatus |= EVB_STATUS_SD_LOG_ENABLED;
 	evbUiRefreshLedLog();
 
-//     uINS0_stream_stop_all(comm);
-    uINS_stream_enable_PPD(comm);
+//     uINS_stream_stop_all();
+    uINS_stream_enable_PPD();
 
 //     logger.InitSave(LOGTYPE_DAT, cISLogger::g_emptyString, 1, 0.5f, 1024 * 1024 * 5, 131072);
     logger.InitSave(cISLogger::LOGTYPE_DAT, "IS_logs", 1, 0.5f, 1024 * 1024 * 5, 16384);
@@ -102,8 +102,8 @@ static void stop_logger(cISLogger& logger, is_comm_instance_t &comm)
     g_status.evbStatus &= ~EVB_STATUS_SD_LOG_ENABLED;
 	evbUiRefreshLedLog();
 
-//     uINS0_stream_stop_all(comm);
-//     uINS0_stream_enable_std(comm);
+//     uINS_stream_stop_all(comm);
+//     uINS_stream_enable_std(comm);
 
     logger.EnableLogging(false);
     logger.CloseAllFiles();

--- a/EVB-2/IS_EVB-2/src/user_interface.cpp
+++ b/EVB-2/IS_EVB-2/src/user_interface.cpp
@@ -13,6 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <asf.h>
 #include "globals.h"
 #include "sd_card_logger.h"
+#include "communications.h"
 #include "user_interface.h"
 
 
@@ -59,7 +60,7 @@ static void on_cfg_button_release()
     {
         g_flashCfg->cbPreset = 1;
     }
-        
+
     com_bridge_apply_preset(g_flashCfg);
     board_IO_config();
     g_nvr_manage_config.flash_write_needed = true;
@@ -77,10 +78,11 @@ static void on_log_button_release()
 {
     if( logger_ready() )
     {
+        uINS_stream_stop_all();         // 
+        uINS_stream_enable_PPD();       // Consider commenting this out and using the uINS persistent message feature instead
+        
         // Toggle logger enable
         enable_logger(!g_loggerEnabled);
-//         if(g_loggerEnabled){    g_enableLogger = -1;    }
-//         else{                   g_enableLogger = 1;     }
     }
 }
 


### PR DESCRIPTION
Move the command that stops uINS data streaming from always running to only when the log button is pressed.  This way uINS persistent messages will stream and not be interfered with and we can still ensure PPD data is streamed and logged with the log button is pressed.