### PR TITLE
Switch encoderTickToWheelRad to represent single channel encoder count

### DIFF
--- a/EVB-2/IS_EVB-2/src/control_law.cpp
+++ b/EVB-2/IS_EVB-2/src/control_law.cpp
@@ -64,13 +64,13 @@ void velocity_control(is_comm_instance_t &comm)
 		}
 				
 		// Convert encoder ticks to radians.
-		g_wheelEncoder.theta_l = (chL * g_flashCfg->encoderTickToWheelRad)/2; /*Division by 2 to account for 4x encoding*/
-		g_wheelEncoder.theta_r = (chR * g_flashCfg->encoderTickToWheelRad)/2;
+		g_wheelEncoder.theta_l = chL * 0.25f * g_flashCfg->encoderTickToWheelRad; 	/* Division by 4 to account for 4x encoding */
+		g_wheelEncoder.theta_r = chR * 0.25f * g_flashCfg->encoderTickToWheelRad;
 
-        // Convert TC pulse period to rad/sec.  20us per TC LSB x 2 (measure rising to rising edge).
+        // Convert TC pulse period to rad/sec.  40us per TC LSB (measure rising to rising edge).
         if(speedL)
         {
-            g_wheelEncoder.omega_l = g_flashCfg->encoderTickToWheelRad / (0.00002f * (float)speedL);
+            g_wheelEncoder.omega_l = g_flashCfg->encoderTickToWheelRad / (0.00004f * (float)speedL);
         }
         else
         {
@@ -78,7 +78,7 @@ void velocity_control(is_comm_instance_t &comm)
         }
         if(speedR)
 		{
-            g_wheelEncoder.omega_r = g_flashCfg->encoderTickToWheelRad / (0.00002f * (float)speedR);
+            g_wheelEncoder.omega_r = g_flashCfg->encoderTickToWheelRad / (0.00004f * (float)speedR);
         }
         else
         {

--- a/EVB-2/IS_EVB-2/src/globals.c
+++ b/EVB-2/IS_EVB-2/src/globals.c
@@ -460,8 +460,8 @@ void reset_config_defaults( evb_flash_cfg_t *cfg )
 	cfg->server[0].port = 7778;
 	cfg->server[1].ipAddr.u32 = nmi_inet_addr((void*)"192.168.1.144");
 	cfg->server[1].port = 2000;
-// 	cfg->encoderTickToWheelRad = 0.0179999f;	// Husqvarna lawnmower
-	cfg->encoderTickToWheelRad = 0.054164998f;	// Husqvarna lawnmower
+// 	cfg->encoderTickToWheelRad = 0.0359998f;	// Husqvarna lawnmower
+	cfg->encoderTickToWheelRad = 0.108329996f;	// Husqvarna lawnmower
 	
 	com_bridge_apply_preset(cfg);
 	

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3168,7 +3168,7 @@ typedef struct
     /** Server IP and port */
     evb_server_t            server[NUM_WIFI_PRESETS];
 
-    /** Encoder tick to wheel rotation conversion factor (in radians).  (encoder tick count per revolution x gear ratio x 2pi) */
+    /** Encoder tick to wheel rotation conversion factor (in radians).  (encoder tick count per revolution x gear ratio x 2pi).  Only one encoder channel, don't multiple by number of channels. */
     float                   encoderTickToWheelRad;
 
 	/** CAN baudrate */


### PR DESCRIPTION
This converts all encoderTickToWheelRad constants to represent the rated encoder count without multiplying by 2.