### PR TITLE
Luna 1118 encoder direction config

### DIFF
--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -11,18 +11,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 */
 
 #include <asf.h>
+#include "../../../hw-libs/communications/CAN_comm.h"
+#include "../../../hw-libs/drivers/CAN.h"
+#include "../../../hw-libs/misc/bootloaderApp.h"
 #include "../../../src/ISUtilities.h"
 #include "../../../src/ISLogger.h"
-#include "../../../hw-libs/misc/bootloaderApp.h"
 #include "../drivers/d_quadEnc.h"
+#include "../src/protocol_nmea.h"
 #include "ISLogFileFatFs.h"
 #include "xbee.h"
 #include "wifi.h"
 #include "sd_card_logger.h"
-#include "../hw-libs/drivers/CAN.h"
-#include "../hw-libs/communications/CAN_comm.h"
-#include "../src/protocol_nmea.h"
 #include "user_interface.h"
+#include "wheel_encoder.h"
 #include "communications.h"
 
 typedef struct
@@ -400,6 +401,7 @@ void update_flash_cfg(evb_flash_cfg_t &newCfg)
     bool reinitXBee = false;
     bool reinitWiFi = false;
 	bool reinitCAN = false;
+	bool reinitWheelEncoder = false;
 
     // Detect changes
     if (newCfg.cbPreset != g_flashCfg->cbPreset ||
@@ -450,7 +452,11 @@ void update_flash_cfg(evb_flash_cfg_t &newCfg)
 	{
 		g_flashCfg->can_receive_address = newCfg.can_receive_address;
 		reinitCAN = true;
-	}    
+	}
+	if (g_flashCfg->wheelCfgBits != newCfg.wheelCfgBits)
+	{
+		reinitWheelEncoder = true;
+	}
     
     // Copy data from message to working location
     *g_flashCfg = newCfg;
@@ -475,6 +481,10 @@ void update_flash_cfg(evb_flash_cfg_t &newCfg)
 	if (reinitCAN)
 	{
 		CAN_init(g_flashCfg->CANbaud_kbps*1000, g_flashCfg->can_receive_address);
+	}
+	if (reinitWheelEncoder)
+	{
+		init_wheel_encoder();
 	}
 	evbUiRefreshLedCfg();
     

--- a/EVB-2/IS_EVB-2/src/drivers/d_quadEnc.c
+++ b/EVB-2/IS_EVB-2/src/drivers/d_quadEnc.c
@@ -216,10 +216,6 @@ void quadEncReadPeriodAll(float *period0, float *period1)
 	{
 		*period0 = s_tc2sec * ra_capture[0];
 		*period1 = s_tc2sec * ra_capture[1];
-
-		// Reverse direction
-		if (s_direction_reverse_0) { *period0 *= -1.0f; }
-		if (s_direction_reverse_1) { *period1 *= -1.0f; }
 	}
 	else
 	{	// Return zero if encoder pulses occur slower than 100ms

--- a/EVB-2/IS_EVB-2/src/drivers/d_quadEnc.h
+++ b/EVB-2/IS_EVB-2/src/drivers/d_quadEnc.h
@@ -27,10 +27,15 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 void quadEncInit(uint32_t pck6_pres);
 
 /**
+ * \brief Apply a direction reversal to encoder output.
+ */
+void quadEncSetDirectionReverse( bool reverse_0, bool reverse_1 );
+
+/**
  * \brief Reads the current position of the encoders.
  */
 void quadEncReadPositionAll(int *pos0, bool *dir0, int *pos1, bool *dir1);
-void quadEncReadPeriodAll(float *speed0, float *speed1);
+void quadEncReadPeriodAll(float *period0, float *period1);
 
 void test_quad_encoders(void);
 

--- a/EVB-2/IS_EVB-2/src/wheel_encoder.cpp
+++ b/EVB-2/IS_EVB-2/src/wheel_encoder.cpp
@@ -30,6 +30,8 @@ void init_wheel_encoder(void)
 		{	// High-resolution encoders
 	    	quadEncInit(7);		// Sensing range w/ 400 cnt encoder and 3x gearhead: > 7 deg/s 
 		}
+
+		quadEncSetDirectionReverse(g_flashCfg->wheelCfgBits&WHEEL_CFG_BITS_DIRECTION_REVERSE_LEFT, g_flashCfg->wheelCfgBits&WHEEL_CFG_BITS_DIRECTION_REVERSE_RIGHT);
     }
 #endif
 }

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -76,9 +76,9 @@ typedef enum
 {
 	_PTYPE_NONE                 = 0,						/** No complete valid data available yet */
 	_PTYPE_PARSE_ERROR          = 0xFFFFFFFF,				/** Invalid data or checksum error */
-	_PTYPE_INERTIAL_SENSE_DATA  = 0xEFFFFFFF,				/** Protocol Type: Inertial Sense binary data */
-	_PTYPE_INERTIAL_SENSE_CMD   = 0xDFFFFFFF,				/** Protocol Type: Inertial Sense binary command (i.e. query data) */
-	_PTYPE_INERTIAL_SENSE_ACK   = 0xCFFFFFFF,				/** Protocol Type: Inertial Sense binary acknowledge (ack) or negative acknowledge (nack)  */
+	_PTYPE_INERTIAL_SENSE_DATA  = 0xEFFFFFFF,				/** Protocol Type: Inertial Sense binary data (PID_SET_DATA, PID_DATA) */
+	_PTYPE_INERTIAL_SENSE_CMD   = 0xDFFFFFFF,				/** Protocol Type: Inertial Sense binary command (PID_GET_DATA, PID_STOP_BROADCASTS...) */
+	_PTYPE_INERTIAL_SENSE_ACK   = 0xCFFFFFFF,				/** Protocol Type: Inertial Sense binary acknowledge (ack) or negative acknowledge (PID_ACK, PID_NACK)  */
 	_PTYPE_ASCII_NMEA           = 0xBFFFFFFF,				/** Protocol Type: ASCII NMEA (National Marine Electronics Association) */
 	_PTYPE_UBLOX                = 0xAFFFFFFF,				/** Protocol Type: uBlox binary */
 	_PTYPE_RTCM3                = 0x9FFFFFFF,				/** Protocol Type: RTCM3 binary (Radio Technical Commission for Maritime Services) */

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -790,6 +790,7 @@ static void PopulateEvbFlashCfgMappings(map_name_to_info_t mappings[DID_COUNT])
     ADD_MAP(m, totalSize, "h3sp330BaudRate", h3sp330BaudRate, 0, DataTypeUInt32, uint32_t);
     ADD_MAP(m, totalSize, "h4xRadioBaudRate", h4xRadioBaudRate, 0, DataTypeUInt32, uint32_t);
     ADD_MAP(m, totalSize, "h8gpioBaudRate", h8gpioBaudRate, 0, DataTypeUInt32, uint32_t);
+    ADD_MAP(m, totalSize, "wheelCfgBits", wheelCfgBits, 0, DataTypeUInt32, uint32_t);
 
     ASSERT_SIZE(totalSize);
 }

--- a/src/cltool.cpp
+++ b/src/cltool.cpp
@@ -49,6 +49,18 @@ static bool startsWith(const char* str, const char* pre)
 	return lenstr < lenpre ? false : strncasecmp(pre, str, lenpre) == 0;
 }
 
+// Returns number of characters until the next space.  This is used to skip arguments.
+static int countToSpace(const char* str)
+{
+	const char *ptr = strchr(str, ' ');
+	if(ptr) 
+	{
+   		return ptr - str;	
+	}
+
+	return 0;
+}
+
 #define CL_DEFAULT_BAUD_RATE				IS_COM_BAUDRATE_DEFAULT 
 #define CL_DEFAULT_COM_PORT					"*"
 #define CL_DEFAULT_DISPLAY_MODE				cInertialSenseDisplay::DMODE_PRETTY 
@@ -98,13 +110,14 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         {
             g_commandLineOptions.asciiMessages = &a[15];
         }
-        else if (startsWith(a, "-baud="))
+        else if (startsWith(a, "-baud"))
 		{
 			g_commandLineOptions.baudRate = strtol(&a[6], NULL, 10);
 		}
-		else if (startsWith(a, "-c="))
+		else if (startsWith(a, "-c"))
 		{
 			g_commandLineOptions.comPort = &a[3];
+			i += countToSpace(&a[3]);
 		}
 		else if (startsWith(a, "-dboc"))
 		{
@@ -135,11 +148,11 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 			cltool_outputUsage();
 			return false;
 		}
-		else if (startsWith(a, "-lms="))
+		else if (startsWith(a, "-lms"))
 		{
 			g_commandLineOptions.maxLogSpacePercent = (float)atof(&a[5]);
 		}
-		else if (startsWith(a, "-lmf="))
+		else if (startsWith(a, "-lmf"))
 		{
 			g_commandLineOptions.maxLogFileSize = (uint32_t)strtoul(&a[5], NULL, 10);
 		}
@@ -147,7 +160,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         {
             g_commandLineOptions.timeoutFlushLoggerSeconds = strtoul(&a[19], NULLPTR, 10);
         }
-        else if (startsWith(a, "-lts="))
+        else if (startsWith(a, "-lts"))
 		{
 			const char* subFolder = &a[5];
 			if (*subFolder == '1' || startsWith(subFolder, "true"))
@@ -163,11 +176,11 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 				g_commandLineOptions.logSubFolder = subFolder;
 			}
 		}
-		else if (startsWith(a, "-lp="))
+		else if (startsWith(a, "-lp"))
 		{
 			g_commandLineOptions.logPath = &a[4];
 		}
-		else if (startsWith(a, "-lt="))
+		else if (startsWith(a, "-lt"))
 		{
 			g_commandLineOptions.logType = &a[4];
 		}
@@ -351,12 +364,12 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 		{
 			g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_QUIET;
 		}
-		else if (startsWith(a, "-rp="))
+		else if (startsWith(a, "-rp"))
 		{
 			g_commandLineOptions.replayDataLog = true;
 			g_commandLineOptions.logPath = &a[4];
 		}
-		else if (startsWith(a, "-rs="))
+		else if (startsWith(a, "-rs"))
 		{
 			g_commandLineOptions.replayDataLog = true;
 			g_commandLineOptions.replaySpeed = (float)atof(&a[4]);
@@ -373,7 +386,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 		{
 			g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_STATS;
 		}
-		else if (startsWith(a, "-svr=") || startsWith(a, "-srv="))
+		else if (startsWith(a, "-svr") || startsWith(a, "-srv"))
 		{
 			g_commandLineOptions.serverConnection = &a[5];
 		}
@@ -381,11 +394,11 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 		{
 			g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_SCROLL;
 		}
-		else if (startsWith(a, "-ub="))
+		else if (startsWith(a, "-ub"))
 		{
 			g_commandLineOptions.updateBootloaderFilename = &a[4];
 		}
-        else if (startsWith(a, "-uf="))
+        else if (startsWith(a, "-uf"))
         {
             g_commandLineOptions.updateAppFirmwareFilename = &a[4];
         }
@@ -409,12 +422,12 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 	}
 	else if (g_commandLineOptions.updateAppFirmwareFilename.length() != 0 && g_commandLineOptions.comPort.length() == 0)
 	{
-		cout << "Use COM_PORT option \"-c=\" with bootloader" << endl;
+		cout << "Use COM_PORT option \"-c \" with bootloader" << endl;
 		return false;
 	}
     else if (g_commandLineOptions.updateBootloaderFilename.length() != 0 && g_commandLineOptions.comPort.length() == 0)
     {
-        cout << "Use COM_PORT option \"-c=\" with bootloader" << endl;
+        cout << "Use COM_PORT option \"-c \" with bootloader" << endl;
         return false;
     }
         
@@ -463,17 +476,17 @@ void cltool_outputUsage()
 	cout << "    firmware with Inertial Sense product line." << endl;
 	cout << endlbOn;
 	cout << "EXAMPLES" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -c="  <<     EXAMPLE_PORT << " -msgPresetPPD            " << EXAMPLE_SPACE_1 << boldOff << " # stream post processing data (PPD) with INS2" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -c="  <<     EXAMPLE_PORT << " -msgPresetPPD -lon       " << EXAMPLE_SPACE_1 << boldOff << " # stream PPD + INS2 data, logging" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -c="  <<     EXAMPLE_PORT << " -msgPresetPPD -lon -lts=1" << EXAMPLE_SPACE_1 << boldOff << " # stream PPD + INS2 data, logging, dir timestamp" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -c="  <<     EXAMPLE_PORT << " -baud=115200 -msgINS2 -msgGPS=10 -msgBaro" << boldOff << " # stream multiple at 115200 bps, GPS data streamed at 10 times the base period (200ms x 10 = 2 sec)" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -rp=" <<     EXAMPLE_LOG_DIR                                           << boldOff << " # replay log files from a folder" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -c="  <<     EXAMPLE_PORT << " -b=" << EXAMPLE_FIRMWARE_FILE << " -bl=" << EXAMPLE_BOOTLOADER_FILE << " -bv" << boldOff << " # bootload application firmware and update bootloader if needed" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -c=* -baud=921600              "                    << EXAMPLE_SPACE_2 << boldOff << " # 921600 bps baudrate on all serial ports" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -msgPresetPPD            " << EXAMPLE_SPACE_1 << boldOff << " # stream post processing data (PPD) with INS2" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -msgPresetPPD -lon       " << EXAMPLE_SPACE_1 << boldOff << " # stream PPD + INS2 data, logging" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -msgPresetPPD -lon -lts=1" << EXAMPLE_SPACE_1 << boldOff << " # stream PPD + INS2 data, logging, dir timestamp" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -baud=115200 -msgINS2 -msgGPS=10 -msgBaro" << boldOff << " # stream multiple at 115200 bps, GPS data streamed at 10 times the base period (200ms x 10 = 2 sec)" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -rp " <<     EXAMPLE_LOG_DIR                                           << boldOff << " # replay log files from a folder" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -b " << EXAMPLE_FIRMWARE_FILE << " -bl " << EXAMPLE_BOOTLOADER_FILE << " -bv" << boldOff << " # bootload application firmware and update bootloader if needed" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -c * -baud=921600              "                    << EXAMPLE_SPACE_2 << boldOff << " # 921600 bps baudrate on all serial ports" << endlbOn;
 	cout << endlbOn;
 	cout << "OPTIONS (General)" << endl;
 	cout << "    -h --help" << boldOff << "       display this help menu" << endlbOn;
-	cout << "    -c=" << boldOff << "COM_PORT     select the serial port. Set COM_PORT to \"*\" for all ports and \"*4\" to use" << endlbOn;
+	cout << "    -c " << boldOff << "COM_PORT     select the serial port. Set COM_PORT to \"*\" for all ports and \"*4\" to use" << endlbOn;
 	cout << "       " << boldOff << "             only the first four ports. " <<  endlbOn;
 	cout << "    -baud=" << boldOff << "BAUDRATE  set serial port baudrate.  Options: " << IS_BAUDRATE_115200 << ", " << IS_BAUDRATE_230400 << ", " << IS_BAUDRATE_460800 << ", " << IS_BAUDRATE_921600 << " (default)" << endlbOn;
 	cout << "    -magRecal[n]" << boldOff << "    recalibrate magnetometers: 0=multi-axis, 1=single-axis" << endlbOn;
@@ -523,8 +536,8 @@ void cltool_outputUsage()
 	cout << "   \"-evbFlashCfg=key=value|key=value\" " << boldOff <<  endlbOn;
 	cout << "        " << boldOff << "            set key / value pairs in flash config. Surround with \"quotes\" when using pipe operator." << endlbOn;
 	cout << "EXAMPLES" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -c=" << EXAMPLE_PORT << " -flashCfg  " << boldOff << "# Read from device and print all keys and values" << endlbOn;
-	cout << "    " << APP_NAME << APP_EXT << " -c=" << EXAMPLE_PORT << " -flashCfg=insRotation[0]=1.5708|insOffset[1]=1.2  " << boldOff << "# Set multiple flashCfg values" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -c " << EXAMPLE_PORT << " -flashCfg  " << boldOff << "# Read from device and print all keys and values" << endlbOn;
+	cout << "    " << APP_NAME << APP_EXT << " -c " << EXAMPLE_PORT << " -flashCfg=insRotation[0]=1.5708|insOffset[1]=1.2  " << boldOff << "# Set multiple flashCfg values" << endlbOn;
 	cout << endlbOn;
 	cout << "OPTIONS (Client / Server)" << endl;
 	cout << "    -svr=" << boldOff << "INFO       used to retrieve external data and send to the uINS. Examples:" << endl;

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1916,6 +1916,8 @@ enum eWheelCfgBits
     WHEEL_CFG_BITS_ENABLE_KINEMATIC_CONST   = (int)0x00000001,
     WHEEL_CFG_BITS_ENABLE_ENCODER           = (int)0x00000002,
     WHEEL_CFG_BITS_ENABLE_MASK              = (int)0x0000000F,
+    WHEEL_CFG_BITS_DIRECTION_REVERSE_LEFT   = (int)0x00000100,
+    WHEEL_CFG_BITS_DIRECTION_REVERSE_RIGHT  = (int)0x00000200,
 };
 
 /** (DID_WHEEL_CONFIG) [NOT SUPPORTED, INTERNAL USE ONLY] Configuration of wheel encoders and kinematic constraints. */
@@ -3168,7 +3170,7 @@ typedef struct
     /** Server IP and port */
     evb_server_t            server[NUM_WIFI_PRESETS];
 
-    /** Encoder tick to wheel rotation conversion factor (in radians).  (encoder tick count per revolution x gear ratio x 2pi).  Only one encoder channel, don't multiple by number of channels. */
+    /** Encoder tick to wheel rotation conversion factor (in radians).  Encoder tick count per revolution on 1 channel x gear ratio x 2pi. */
     float                   encoderTickToWheelRad;
 
 	/** CAN baudrate */
@@ -3197,7 +3199,10 @@ typedef struct
 
 	/** Baud rate for EVB serial port H8 (TLL). */
 	uint32_t                h8gpioBaudRate;
-	
+
+	/** Wheel encoder configuration (see eWheelCfgBits) */
+	uint32_t                wheelCfgBits;
+
 } evb_flash_cfg_t;
 
 


### PR DESCRIPTION
- Ability to reverse wheel encoder direction on EVB2.
- CLTool now accepts a space between -c and part name so we can use tab completion.  Old method is still supported for compatibility.