### PR TITLE
Fixed pimu and ppimu ASCII broadcast issue

### DIFF
--- a/ExampleProjects/Ascii/ISAsciiExample.c
+++ b/ExampleProjects/Ascii/ISAsciiExample.c
@@ -73,13 +73,13 @@ int main(int argc, char* argv[])
 	// please see the user manual for additional updates and notes
 
     // Get PINS1 @ 10Hz on the connected serial port, leave all other broadcasts the same, and save persistent messages.
-	const char* asciiMessage = "ASCB,512,,,1000,,,,,,,";
+	const char* asciiMessage = "ASCB,512,,,1000,,,,,,,,,";
 
     // Get PINS1 @ 50Hz and PGPSP @ 5Hz on the connected serial port, leave all other broadcasts the same
-//     const char* asciiMessage = "ASCB,,,,20,,200,,,,,";
+//     const char* asciiMessage = "ASCB,,,,20,,200,,,,,,,";
 
 	// Get PIMU @ 50Hz, GPGGA @ 5Hz, both serial ports, set all other periods to 0
-//     const char* asciiMessage = "ASCB,3,20,0,0,0,0,0,100,0,0,0";
+//     const char* asciiMessage = "ASCB,3,20,0,0,0,0,0,100,0,0,0,0,0";
 
     if (!serialPortWriteAscii(&serialPort, asciiMessage, (int)strnlen(asciiMessage, 128)))
 	{

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -719,7 +719,7 @@ int gps_to_nmea_pashr(char a[], const int aSize, gps_pos_t &pos, ins_1_t &ins1, 
 // Parse NMEA Functions
 //////////////////////////////////////////////////////////////////////////
 
-uint32_t parse_nmea_ascb(int pHandle, const char msg[], int msgSize, ascii_msgs_t asciiPeriod[NUM_COM_PORTS])
+uint32_t parse_nmea_ascb(int pHandle, const char msg[], int msgSize, ascii_msgs_t asciiPeriod[NUM_COM_PORTS], uint32_t *asciiPeriodPPIMU)
 {
 	if(pHandle >= NUM_COM_PORTS)
 	{
@@ -737,6 +737,9 @@ uint32_t parse_nmea_ascb(int pHandle, const char msg[], int msgSize, ascii_msgs_
 	if(*ptr!=','){ tmp.pimu = atoi(ptr);	}	
 	ptr = ASCII_find_next_field(ptr);			// PPIMU
 	if(*ptr!=','){ tmp.ppimu = atoi(ptr);	}
+
+	if (asciiPeriodPPIMU) { *asciiPeriodPPIMU = (uint32_t)_MAX(tmp.pimu, tmp.ppimu); }	// Global ascii IMU broadcast period
+
 	ptr = ASCII_find_next_field(ptr);			// PINS1
 	if(*ptr!=','){ tmp.pins1 = atoi(ptr);	}
 	ptr = ASCII_find_next_field(ptr);			// PINS2
@@ -757,6 +760,7 @@ uint32_t parse_nmea_ascb(int pHandle, const char msg[], int msgSize, ascii_msgs_
 	if(*ptr!=','){ tmp.gpzda = atoi(ptr);	}
 	ptr = ASCII_find_next_field(ptr);			// pashr
 	if(*ptr!=','){ tmp.pashr = atoi(ptr);	}
+
 		
 	// Copy tmp to corresponding port(s)
 	switch(options&RMC_OPTIONS_PORT_MASK)

--- a/src/protocol_nmea.h
+++ b/src/protocol_nmea.h
@@ -47,7 +47,7 @@ int gps_to_nmea_pashr(char a[], const int aSize, gps_pos_t &pos, ins_1_t &ins1, 
 //////////////////////////////////////////////////////////////////////////
 // NMEA parse
 //////////////////////////////////////////////////////////////////////////
-uint32_t parse_nmea_ascb(int pHandle, const char msg[], int msgSize, ascii_msgs_t asciiPeriod[]);
+uint32_t parse_nmea_ascb(int pHandle, const char msg[], int msgSize, ascii_msgs_t asciiPeriod[], uint32_t *asciiPeriodPPIMU);
 int parse_nmea_zda(const char msgBuf[], int msgSize, double &day, double &month, double &year);
 int parse_nmea_gns(const char msgBuf[], int msgSize, gps_pos_t *gpsPos, double datetime[6], int *satsUsed, int navMode);
 int parse_nmea_gga(const char msg[], int msgSize, gps_pos_t *gpsPos, double datetime[6], int *satsUsed, int navMode);


### PR DESCRIPTION
- Fixed issue were g_asciiPeriodPPIMU wasn't getting set properly when the ASCB enable broadcast message was used.
- Added correct number of commas to ASCB message in AsciiExampleProject.