### PR TITLE
SN-453 Fixed bootloader non-standard baudrate issue

### DIFF
--- a/ExampleProjects/Bootloader/ISBootloaderExample.c
+++ b/ExampleProjects/Bootloader/ISBootloaderExample.c
@@ -47,10 +47,10 @@ static void bootloaderStatusText(const void* obj, const char* info)
 
 int main(int argc, char* argv[])
 {
-	if (argc < 3 || argc > 4)
+	if (argc < 4 || argc > 5)
 	{
-		printf("Please pass the com port, firmware file name to bootload, and optionally bootloader file name as the only arguments\r\n");
-		printf("usage: %s {COMx} {Firmware file} {Bootloader file (optional)}\r\n", argv[0]);
+		printf("Please pass the com port, baudrate, firmware file name to bootload, and optionally bootloader file name as the only arguments\r\n");
+		printf("usage: %s {COMx} {Baudrate} {Firmware file} {Bootloader file (optional)}\r\n", argv[0]);
 		// In Visual Studio IDE, this can be done through "Project Properties -> Debugging -> Command Arguments: COM3 IS_uINS-3.hex" 
 		return -1;
 	}
@@ -75,18 +75,19 @@ int main(int argc, char* argv[])
 	// very important - initialize the bootloader params to zeros
 	memset(&param, 0, sizeof(param));
 
+	// the serial port
+	param.port = &serialPort;
+	param.baudRate = atoi(argv[2]);
+
 	// the file to bootload, *.hex
-	param.fileName = argv[2];
+	param.fileName = argv[3];
 
 	// optional - bootloader file, *.bin
 	param.forceBootloaderUpdate = 0;	//do not force update of bootloader
-	if (argc == 4)
-		param.bootName = argv[3];
+	if (argc == 5)
+		param.bootName = argv[4];
 	else
 		param.bootName = 0;
-
-	// the serial port
-	param.port = &serialPort;
 
 	// progress indicators
 	param.uploadProgress = bootloaderUploadProgress;
@@ -95,15 +96,6 @@ int main(int argc, char* argv[])
 
 	// enable verify to read back the firmware and ensure it is correct
 	param.flags.bitFields.enableVerify = 1;
-
-	// optional - define baudrate. If not defined standard baud rates will be attempted.
-	// The default bootloader baudrate is 921600.  If using a system with known baud limits it is best to specify a lower baudrate.
-//	param.baudRate = IS_BAUD_RATE_BOOTLOADER_RS232;
-// 	param.baudRate = IS_BAUD_RATE_BOOTLOADER_SLOW;
-
-	// enable auto-baud, in the event that fast serial communications is not available,
-	//  the bootloader will attempt to fall back to a slower speed
-	// 	param.flags.bitFields.enableAutoBaud = 1;
 
 	// STEP 4: Run bootloader
 

--- a/ExampleProjects/Bootloader/README.md
+++ b/ExampleProjects/Bootloader/README.md
@@ -52,32 +52,23 @@ This [ISBootloaderExample](https://github.com/inertialsense/inertial-sense-sdk/t
 ```C++
 	// bootloader parameters
 	bootload_params_t param;
-	// buffer to show any errors
-	char errorBuffer[512];
 
 	// very important - initialize the bootloader params to zeros
 	memset(&param, 0, sizeof(param));
 
-	// error buffer, useful if something fails
-	param.error = errorBuffer;
-	param.errorLength = sizeof(errorBuffer);
-
-	// the file to bootload, *.hex
-	param.fileName = argv[2];
-
 	// the serial port
 	param.port = &serialPort;
+	param.baudRate = atoi(argv[2]);
 
-	// progress indicators
-	param.uploadProgress = bootloaderUploadProgress;
-	param.verifyProgress = bootloaderVerifyProgress;
+	// the file to bootload, *.hex
+	param.fileName = argv[3];
 
-	// enable verify to read back the firmware and ensure it is correct
-	param.flags.bitFields.enableVerify = 1;
-
-	// enable auto-baud, in the event that fast serial communications is not available,
-	//  the bootloader will attempt to fall back to a slower speed
-	param.flags.bitFields.enableAutoBaud = 1;
+	// optional - bootloader file, *.bin
+	param.forceBootloaderUpdate = 0;	//do not force update of bootloader
+	if (argc == 5)
+		param.bootName = argv[4];
+	else
+		param.bootName = 0;
 ```
 
 ### Step 4: Run bootloader
@@ -120,7 +111,7 @@ $ sudo systemctl disable ModemManager.service && sudo systemctl stop ModemManage
 ```
 5. Run executable
 ``` bash
-$ ./bin/ISBootloaderExample /dev/ttyUSB0 IS_uINS-3.hex
+$ ./bin/ISBootloaderExample /dev/ttyUSB0 921600 IS_uINS-3.hex
 ```
 ## Compile & Run (Windows MS Visual Studio)
 
@@ -128,7 +119,7 @@ $ ./bin/ISBootloaderExample /dev/ttyUSB0 IS_uINS-3.hex
 2. Build (F7)
 3. Run executable
 ``` bash
-C:\inertial-sense-sdk\ExampleProjects\Bootloader\VS_project\Release\ISBootloaderExample.exe COM3 IS_uINS-3.hex
+C:\inertial-sense-sdk\ExampleProjects\Bootloader\VS_project\Release\ISBootloaderExample.exe COM3 921600 IS_uINS-3.hex
 ```
 
 ## Summary

--- a/cltool/VS_project/cltool.vcxproj.user
+++ b/cltool/VS_project/cltool.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LocalDebuggerCommandArguments>-c COM8 -did 21 -rover=TCP:RTCM3:192.168.1.100:7777:mountpoint:username:password</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-c COM5 -baud=3000000 -uf C:\Users\walt\Documents\Inertial_Sense\Firmware\IS_uINS-3_v1.8.4_b1194_2021-03-30_172439.hex</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/src/inertialSenseBootLoader.c
+++ b/src/inertialSenseBootLoader.c
@@ -1100,7 +1100,7 @@ static int bootloaderSync(serial_port_t* s)
     for (int i = 0; i < BOOTLOADER_RETRIES; i++)
     {
         if (serialPortWriteAndWaitForTimeout(s, &handshakerChar, 1, &handshakerChar, 1, BOOTLOADER_RESPONSE_DELAY))
-        {
+        {	// Success
             serialPortSleep(s, BOOTLOADER_REFRESH_DELAY);
             return 1;
         }
@@ -1114,10 +1114,13 @@ static int bootloaderHandshake(bootload_params_t* p)
     //Port should already be closed, but make sure
     serialPortClose(p->port);
 
+	// Ensure we use closest baudrate supported by bootloader
+	p->baudRate = bootloaderClosestBaudRate(p->baudRate);
+
 #if ENABLE_BOOTLOADER_BAUD_DETECTION
 
-    // ensure that we start off with a valid baud rate
-    if (p->baudRate == 0)
+	// ensure that we start off with a valid baud rate
+	if (p->baudRate == 0)
     {
         p->baudRate = bootloaderCycleBaudRate(p->baudRate);
     }


### PR DESCRIPTION
Previously, enabling the bootloader would only work for supported bootloader baudrates (921600, 230400, 115200, 2000000) but now works for all supported IS baudrates.