### PR TITLE
Improve GPS velocity validation

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -811,7 +811,7 @@ typedef struct PACKED
 	/** Speed accuracy in meters / second */
 	float					sAcc;
 	
-	/** NMEA input if status flag GPS_STATUS_FLAGS_GPS_NMEA_DATA */
+	/** (see eGpsStatus) GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags, NMEA input flag */
 	uint32_t                status;
 } gps_vel_t;
 

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -1100,7 +1100,7 @@ int parse_nmea_gga(const char msg[], int msgSize, gps_pos_t *gpsPos, double date
 /* G_RMC Message
 * Provides speed (speed and course over ground)
 */
-int parse_nmea_rmc(const char msg[], int msgSize, gps_vel_t *gpsVel, double datetime[6])
+int parse_nmea_rmc(const char msg[], int msgSize, gps_vel_t *gpsVel, double datetime[6], uint32_t statusFlags)
 {
 	(void)msgSize;
 	char *ptr = (char *)&msg[7];
@@ -1138,7 +1138,7 @@ int parse_nmea_rmc(const char msg[], int msgSize, gps_vel_t *gpsVel, double date
 	//dependencies_.gpsVel->sAcc = 0;
 			
 	//Indicate it is coming from NMEA
-	gpsVel->status |= GPS_STATUS_FLAGS_GPS_NMEA_DATA;
+	gpsVel->status = GPS_STATUS_FLAGS_GPS_NMEA_DATA | statusFlags;
 
 	return 0;	
 }

--- a/src/protocol_nmea.h
+++ b/src/protocol_nmea.h
@@ -51,7 +51,7 @@ uint32_t parse_nmea_ascb(int pHandle, const char msg[], int msgSize, ascii_msgs_
 int parse_nmea_zda(const char msgBuf[], int msgSize, double &day, double &month, double &year);
 int parse_nmea_gns(const char msgBuf[], int msgSize, gps_pos_t *gpsPos, double datetime[6], int *satsUsed, uint32_t statusFlags=0);
 int parse_nmea_gga(const char msg[], int msgSize, gps_pos_t *gpsPos, double datetime[6], int *satsUsed, uint32_t statusFlags=0);
-int parse_nmea_rmc(const char msg[], int msgSize, gps_vel_t *gpsVel, double datetime[6]);
+int parse_nmea_rmc(const char msg[], int msgSize, gps_vel_t *gpsVel, double datetime[6], uint32_t statusFlags=0);
 int parse_nmea_gsa(const char msg[], int msgSize, gps_pos_t *gpsPos, int *navMode);
 int parse_nmea_gsv(const char msg[], int msgSize, gps_sat_t* gpsSat, int lastGSVmsg[2], int *satPointer, uint32_t *cnoSum, uint32_t *cnoCount);
 


### PR DESCRIPTION
This addresses an issue we discovered in Fortem's data where GPS2 which didn't have an antenna connected reported a bogus ECEF velocity when the speed accuracy (sAcc) said it was valid yet the GPS position did not have fix and the GPS time was obviously incorrect.

Now we use the same status flags from GPS pos in the GPS vel message so we can use the GPS position status to validate the GPS velocity.