### PR TITLE
LUNA-1904 Added d_dma.c to gcc Makefile

### DIFF
--- a/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
+++ b/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
@@ -1335,14 +1335,6 @@
       <SubType>compile</SubType>
       <Link>src\inertial-sense-sdk\hw-libs\communications\CAN_comm.h</Link>
     </Compile>
-    <Compile Include="..\..\hw-libs\drivers\d_dma.c">
-      <SubType>compile</SubType>
-      <Link>src\inertial-sense-sdk\hw-libs\drivers\d_dma.c</Link>
-    </Compile>
-    <Compile Include="..\..\hw-libs\drivers\d_dma.h">
-      <SubType>compile</SubType>
-      <Link>src\inertial-sense-sdk\hw-libs\drivers\d_dma.h</Link>
-    </Compile>
     <Compile Include="..\..\hw-libs\printf-master\printf.c">
       <SubType>compile</SubType>
       <Link>src\inertial-sense-sdk\hw-libs\printf-master\printf.c</Link>
@@ -1487,6 +1479,14 @@
     <Compile Include="..\..\hw-libs\drivers\CAN.h">
       <SubType>compile</SubType>
       <Link>src\inertial-sense-sdk\hw-libs\drivers\CAN.h</Link>
+    </Compile>
+    <Compile Include="..\..\hw-libs\drivers\d_dma.c">
+      <SubType>compile</SubType>
+      <Link>src\inertial-sense-sdk\hw-libs\drivers\d_dma.c</Link>
+    </Compile>
+    <Compile Include="..\..\hw-libs\drivers\d_dma.h">
+      <SubType>compile</SubType>
+      <Link>src\inertial-sense-sdk\hw-libs\drivers\d_dma.h</Link>
     </Compile>
     <Compile Include="..\..\hw-libs\drivers\d_flash.c">
       <SubType>compile</SubType>

--- a/EVB-2/Makefile
+++ b/EVB-2/Makefile
@@ -114,6 +114,7 @@ C_SRCS += \
           $(ASF_DIR)/thirdparty/freertos/freertos-10.0.0/Source/timers.c                                 \
           $(HW_LIBS_DIR)/FreeRTOS_new.cpp                                                                \
           $(HW_LIBS_DIR)/drivers/CAN.c                                                                   \
+          $(HW_LIBS_DIR)/drivers/d_dma.c                                                                 \
           $(HW_LIBS_DIR)/drivers/d_flash.c                                                               \
           $(HW_LIBS_DIR)/drivers/d_i2c.c                                                                 \
           $(HW_LIBS_DIR)/drivers/d_usartDMA.c                                                            \
@@ -121,7 +122,7 @@ C_SRCS += \
           $(HW_LIBS_DIR)/misc/rtos.c                                                                     \
           $(HW_LIBS_DIR)/printf-master/printf.c                                                          \
           $(SRC_DIR)/communications.cpp                                                                  \
-          $(SRC_DIR)/wheel_encoder.cpp                                                                     \
+          $(SRC_DIR)/wheel_encoder.cpp                                                                   \
           $(SRC_DIR)/drivers/d_time.c                                                                    \
           $(SRC_DIR)/drivers/d_quadEnc.c                                                                 \
           $(SRC_DIR)/drivers/d_adc.c                                                                     \


### PR DESCRIPTION
The XDMA handler is not found and a hard fault occurs when d_dma.c is not included in the project.