### PR TITLE
Bypass IS parsing EVB2 firmware

### DIFF
--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -787,6 +787,11 @@ void com_bridge_smart_forward(uint32_t srcPort, uint32_t ledPin)
 
 	if ((n = comRead(srcPort, comm.buf.tail, n, ledPin)) > 0)
 	{
+		if (g_flashCfg->cbPreset == EVB2_CB_PRESET_USB_HUB_RS422)
+		{
+			com_bridge_forward(srcPort, comm.buf.head, n);
+			return;
+		}
 		if (g_uInsBootloaderEnableTimeMs)
 		{	// When uINS bootloader is enabled forwarding is disabled below is_comm_parse(), so forward bootloader data here.
 			switch (srcPort)


### PR DESCRIPTION
When using white config it's more useful to have a true passthrough (IMO) instead of everything parsed for IS packets. All of that can be done using any of the other presets. This also makes the EVB2 a more useful USB-Serial converter.