### PR TITLE
SN-968 Clean up bootloader

### DIFF
--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -13,6 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <asf.h>
 #include "../../../hw-libs/communications/CAN_comm.h"
 #include "../../../hw-libs/drivers/CAN.h"
+#include "../../../hw-libs/drivers/d_flash.h"
 #include "../../../hw-libs/misc/bootloaderApp.h"
 #include "../../../src/ISUtilities.h"
 #include "../../../src/ISLogger.h"
@@ -566,6 +567,7 @@ void update_flash_cfg(evb_flash_cfg_t &newCfg)
 void handle_data_from_host(is_comm_instance_t *comm, protocol_type_t ptype, uint32_t srcPort)
 {
 	uint8_t *dataPtr = comm->dataPtr + comm->dataHdr.offset;
+	static uint8_t manfUnlock = false;
 
 	switch(ptype)
 	{
@@ -577,19 +579,22 @@ void handle_data_from_host(is_comm_instance_t *comm, protocol_type_t ptype, uint
 
 			switch (g_status.sysCommand)
 			{
-			case SYS_CMD_SOFTWARE_RESET:
-			#if 0
-				// Write flash config now
-				//  nvr_flash_config_write_now_before_reset();
-				BEGIN_CRITICAL_SECTION
-				g_nvr_manage_config.flash_write_needed = true;
-				g_nvr_manage_config.flash_write_enable = true;
-				END_CRITICAL_SECTION
-				nvr_slow_maintenance();
-			#endif
-
-				// Reset processor
+			case SYS_CMD_SOFTWARE_RESET:			// Reset processor
 				soft_reset_backup_register(SYS_FAULT_STATUS_USER_RESET);
+				break;
+
+			case SYS_CMD_MANF_UNLOCK:				// Unlock process for chip erase
+				manfUnlock = true;
+				break;
+
+			case SYS_CMD_MANF_CHIP_ERASE:			// chip erase and reboot - do NOT reset calibration!
+				if(manfUnlock)
+				{
+					BEGIN_CRITICAL_SECTION
+					
+					// erase chip
+					flash_erase_chip();
+				}
 				break;
 			}
 			g_status.sysCommand = 0;

--- a/ExampleProjects/Bootloader/ISBootloaderExample.c
+++ b/ExampleProjects/Bootloader/ISBootloaderExample.c
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
 
 	// STEP 4: Run bootloader
 
-	if (bootloadFileEx(&param))
+	if (bootloadFileEx(&param)==0)
 	{
 		printf("Bootloader success on port %s with file %s\n", serialPort.port, param.fileName);
 		return 0;

--- a/ExampleProjects/Bootloader/README.md
+++ b/ExampleProjects/Bootloader/README.md
@@ -74,7 +74,7 @@ This [ISBootloaderExample](https://github.com/inertialsense/inertial-sense-sdk/t
 ### Step 4: Run bootloader
 
 ```C++
-	if (bootloadFileEx(&param))
+	if (bootloadFileEx(&param)==0)
 	{
 		printf("Bootloader success on port %s with file %s\n", serialPort.port, param.fileName);
 		return 0;

--- a/cltool/VS_project/cltool.vcxproj.user
+++ b/cltool/VS_project/cltool.vcxproj.user
@@ -5,13 +5,11 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-c COM81 -uf ../../../cpp/hdw-src/uINS-3/IS_uINS/Release/IS_uINS-3.hex -ub ../../../cpp/hdw-src/SAMx70-Bootloader/SAMx70-Bootloader/Release/SAMx70-Bootloader.bin</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-c COM81 -uf ../../../cpp/hdw-src/uINS-3/IS_uINS/Release/IS_uINS-3.hex -ub ../../../cpp/hdw-src/SAMx70-Bootloader/SAMx70-Bootloader/Release/SAMx70-Bootloader.bin</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/cltool/VS_project/cltool.vcxproj.user
+++ b/cltool/VS_project/cltool.vcxproj.user
@@ -5,13 +5,11 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-c COM81 -ub SAMx70-Bootloader_v4b_20200429.bin -uf IS_uINS-3_v1.8.6_b338_2021-09-03_123421.hex</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-c COM81 -ub SAMx70-Bootloader_v4b_20200429.bin -uf IS_uINS-3_v1.8.6_b338_2021-09-03_123421.hex</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/cltool/VS_project/cltool.vcxproj.user
+++ b/cltool/VS_project/cltool.vcxproj.user
@@ -5,11 +5,13 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-c COM81 -ub SAMx70-Bootloader_v4b_20200429.bin -uf IS_uINS-3_v1.8.6_b338_2021-09-03_123421.hex</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>-c COM81 -ub SAMx70-Bootloader_v4b_20200429.bin -uf IS_uINS-3_v1.8.6_b338_2021-09-03_123421.hex</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/src/ISDisplay.h
+++ b/src/ISDisplay.h
@@ -39,7 +39,7 @@ class cInertialSenseDisplay
 public:
 	typedef struct
 	{
-		const map_name_to_info_t 			*mapInfo = NULL;
+		const map_name_to_info_t 			*mapInfo;
 		map_name_to_info_t::const_iterator 	mapInfoSelection;
 		map_name_to_info_t::const_iterator 	mapInfoBegin;
 		map_name_to_info_t::const_iterator 	mapInfoEnd;

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -26,7 +26,7 @@ typedef struct
 static void bootloaderUpdateBootloaderThread(void* state)
 {
     bootload_state_t* s = (bootload_state_t*)state;
-	s->success = (bootloadFileEx(&s->param) == 0);
+    s->success = (bootloadFileEx(&s->param) == 0);
     serialPortClose(&s->serial);
 }
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -18,30 +18,15 @@ using namespace std;
 typedef struct
 {
 	bootload_params_t param;
-	bool result;
+	bool success;
 	serial_port_t serial;
 	void* thread;
-} bootloader_state_t;
-
-static void bootloaderThread(void* state)
-{
-	bootloader_state_t* s = (bootloader_state_t*)state;
-	serialPortOpen(&s->serial, s->serial.port, s->param.baudRate, 1);
-	if (!enableBootloader(&s->serial, s->param.baudRate, s->param.error, BOOTLOADER_ERROR_LENGTH, s->param.bootloadEnableCmd))
-	{
-		serialPortClose(&s->serial);
-		s->result = false;
-		return;
-	}
-	s->result = (bootloadFileEx(&s->param) != 0);
-	serialPortClose(&s->serial);
-}
+} bootload_state_t;
 
 static void bootloaderUpdateBootloaderThread(void* state)
 {
-    bootloader_state_t* s = (bootloader_state_t*)state;
-    serialPortOpen(&s->serial, s->serial.port, s->param.baudRate, 1);
-    s->result = (bootloadUpdateBootloaderEx(&s->param) != 0);
+    bootload_state_t* s = (bootload_state_t*)state;
+	s->success = (bootloadFileEx(&s->param) == 0);
     serialPortClose(&s->serial);
 }
 
@@ -723,16 +708,14 @@ void InertialSense::BroadcastBinaryDataRmcPreset(uint64_t rmcPreset, uint32_t rm
 	}
 }
 
-vector<InertialSense::bootloader_result_t> InertialSense::BootloadFile(const string& comPort, const string& fileName, int baudRate, pfnBootloadProgress uploadProgress, pfnBootloadProgress verifyProgress, bool updateBootloader)
+vector<InertialSense::bootload_result_t> InertialSense::BootloadFile(const string& comPort, const string& fileName, int baudRate, pfnBootloadProgress uploadProgress, pfnBootloadProgress verifyProgress, pfnBootloadStatus infoProgress, const string& bootloaderFileName, bool forceBootloaderUpdate)
 {
-	return BootloadFile(comPort, fileName, "", baudRate, uploadProgress, verifyProgress, NULLPTR, updateBootloader);
-}
-
-vector<InertialSense::bootloader_result_t> InertialSense::BootloadFile(const string& comPort, const string& fileName, const string& bootloaderFileName, int baudRate, pfnBootloadProgress uploadProgress, pfnBootloadProgress verifyProgress, pfnBootloadStatus infoProgress, bool updateBootloader)
-{
-	vector<bootloader_result_t> results;
+	vector<bootload_result_t> results;
 	vector<string> portStrings;
-	vector<bootloader_state_t> state;
+	vector<bootload_state_t> state;
+
+	// Initialize as failure and clear at end if successful
+	//results.push_back({ fileName, "Failed to load." });
 
 	if (comPort == "*")
 	{
@@ -746,6 +729,7 @@ vector<InertialSense::bootloader_result_t> InertialSense::BootloadFile(const str
 	state.resize(portStrings.size());
 
 	// test file exists
+	if (fileName.size() > 0)
 	{
 		ifstream tmpStream(fileName);
 		if (!tmpStream.good())
@@ -770,6 +754,7 @@ vector<InertialSense::bootloader_result_t> InertialSense::BootloadFile(const str
 			state[i].param.statusText = infoProgress;
 			state[i].param.fileName = fileName.c_str();
 			state[i].param.bootName = bootloaderFileName.c_str();
+			state[i].param.forceBootloaderUpdate = forceBootloaderUpdate;
 			state[i].param.port = &state[i].serial;
 			state[i].param.verifyFileName = NULLPTR;
 			state[i].param.flags.bitFields.enableVerify = (verifyProgress != NULLPTR);
@@ -784,14 +769,8 @@ vector<InertialSense::bootloader_result_t> InertialSense::BootloadFile(const str
 				strncpy(state[i].param.bootloadEnableCmd, "BLEN", 4);
 			}
 
-            if (updateBootloader)
-            {   // Update bootloader firmware
-                state[i].thread = threadCreateAndStart(bootloaderUpdateBootloaderThread, &state[i]);
-            }
-            else
-            {   // Update application firmware
-                state[i].thread = threadCreateAndStart(bootloaderThread, &state[i]);
-            }
+            // Update application and bootloader firmware
+            state[i].thread = threadCreateAndStart(bootloaderUpdateBootloaderThread, &state[i]);
 		}
 
 		// wait for all threads to finish

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -714,9 +714,6 @@ vector<InertialSense::bootload_result_t> InertialSense::BootloadFile(const strin
 	vector<string> portStrings;
 	vector<bootload_state_t> state;
 
-	// Initialize as failure and clear at end if successful
-	//results.push_back({ fileName, "Failed to load." });
-
 	if (comPort == "*")
 	{
 		cISSerialPort::GetComPorts(portStrings);
@@ -728,8 +725,7 @@ vector<InertialSense::bootload_result_t> InertialSense::BootloadFile(const strin
 	sort(portStrings.begin(), portStrings.end());
 	state.resize(portStrings.size());
 
-	// test file exists
-	if (fileName.size() > 0)
+	// file exists?
 	{
 		ifstream tmpStream(fileName);
 		if (!tmpStream.good())

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -95,7 +95,7 @@ public:
 	{
 		string port;
 		string error;
-	} bootloader_result_t;
+	} bootload_result_t;
 
 	/**
 	* Constructor
@@ -369,10 +369,19 @@ public:
 	* @param baudRate the baud rate to bootload at
 	* @param uploadProgress optional callback for upload progress
 	* @param verifyProgress optional callback for verify progress
+	* @param bootloaderFileName optional bootloader firmware filename
+	* @param forceBootloaderUpdate optional force bootloader firmware to be updated
 	* @return ports and errors, error will be empty if success
 	*/
-	static vector<bootloader_result_t> BootloadFile(const string& comPort, const string& fileName, const string& bootloaderFileName, int baudRate = IS_BAUD_RATE_BOOTLOADER, pfnBootloadProgress uploadProgress = NULLPTR, pfnBootloadProgress verifyProgress = NULLPTR, pfnBootloadStatus infoProgress = NULLPTR, bool updateBootloader = false);
-	static vector<bootloader_result_t> BootloadFile(const string& comPort, const string& fileName, int baudRate = IS_BAUD_RATE_BOOTLOADER, pfnBootloadProgress uploadProgress = NULLPTR, pfnBootloadProgress verifyProgress = NULLPTR, bool updateBootloader = false);
+	static vector<bootload_result_t> BootloadFile(
+		const string& comPort, 
+		const string& fileName, 
+		int baudRate = IS_BAUD_RATE_BOOTLOADER, 
+		pfnBootloadProgress uploadProgress = NULLPTR, 
+		pfnBootloadProgress verifyProgress = NULLPTR, 
+		pfnBootloadStatus infoProgress = NULLPTR, 
+		const string& bootloaderFileName = "",
+		bool forceBootloaderUpdate = false);
 
 	string getServerMessageStatsSummary() { return messageStatsSummary(m_serverMessageStats); }
 	string getClientMessageStatsSummary() { return messageStatsSummary(m_clientMessageStats); }

--- a/src/cltool.cpp
+++ b/src/cltool.cpp
@@ -50,6 +50,12 @@ static bool startsWith(const char* str, const char* pre)
 	return lenstr < lenpre ? false : strncasecmp(pre, str, lenpre) == 0;
 }
 
+static bool matches(const char* str, const char* pre)
+{
+	size_t lenpre = strlen(pre), lenstr = strlen(str);
+	return lenstr != lenpre ? false : strncasecmp(pre, str, lenpre) == 0;
+}
+
 #define CL_DEFAULT_BAUD_RATE				IS_COM_BAUDRATE_DEFAULT 
 #define CL_DEFAULT_COM_PORT					"*"
 #define CL_DEFAULT_DISPLAY_MODE				cInertialSenseDisplay::DMODE_PRETTY 
@@ -143,29 +149,29 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         }
         
 		if (startsWith(a, "-asciiMessages="))
-        {
-            g_commandLineOptions.asciiMessages = &a[15];
-        }
+		{
+			g_commandLineOptions.asciiMessages = &a[15];
+		}
 		else if (startsWith(a, "-base="))
 		{
 			g_commandLineOptions.baseConnection = &a[6];
 		}
-        else if (startsWith(a, "-baud="))
+		else if (startsWith(a, "-baud="))
 		{
 			g_commandLineOptions.baudRate = strtol(&a[6], NULL, 10);
-		}
-		else if (startsWith(a, "-c"))
-		{
-			g_commandLineOptions.comPort = argv[++i];	// use next argument
 		}
 		else if (startsWith(a, "-chipEraseEvb"))
 		{
 			g_commandLineOptions.chipEraseEvb2 = true;
-		}		
+		}
 		else if (startsWith(a, "-chipEraseUins"))
 		{
 			g_commandLineOptions.chipEraseUins = true;
-		}		
+		}
+		else if (matches(a, "-c") && (i + 1) < argc)
+		{
+			g_commandLineOptions.comPort = argv[++i];	// use next argument
+		}
 		else if (startsWith(a, "-dboc"))
 		{
 			g_commandLineOptions.disableBroadcastsOnClose = true;
@@ -183,31 +189,30 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 			cltool_outputHelp();
 			return false;
 		}
-		else if (startsWith(a, "-did"))
+		else if (startsWith(a, "-did") && (i + 1) < argc)
 		{
-				while ((i + 1) < argc && !startsWith(argv[i + 1], "-"))	// next argument doesn't start with "-"
+			while ((i + 1) < argc && !startsWith(argv[i + 1], "-"))	// next argument doesn't start with "-"
+			{
+				if (g_commandLineOptions.outputOnceDid)
 				{
-					if (g_commandLineOptions.outputOnceDid)
+					i++;
+				}
+				else
+				{
+					stream_did_t dataset = {};
+					if (read_did_argument(&dataset, argv[++i]))		// use next argument
 					{
-						i++;
-					}
-					else
-					{
-						stream_did_t dataset = {};
-						if (read_did_argument(&dataset, argv[++i]))		// use next argument
+						if (dataset.periodMultiple == 0)
 						{
-							if (dataset.periodMultiple == 0)
-							{
-								g_commandLineOptions.outputOnceDid = dataset.did;
-								g_commandLineOptions.datasets.clear();
-							}
-							g_commandLineOptions.datasets.push_back(dataset);
+							g_commandLineOptions.outputOnceDid = dataset.did;
+							g_commandLineOptions.datasets.clear();
 						}
+						g_commandLineOptions.datasets.push_back(dataset);
 					}
 				}
-			
+			}			
 		}
-		else if (startsWith(a, "-edit"))
+		else if (startsWith(a, "-edit") && (i + 1) < argc)
 		{
 			stream_did_t dataset = {};
 			if (read_did_argument(&dataset, argv[++i]))	// use next argument
@@ -272,7 +277,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 				g_commandLineOptions.logSubFolder = subFolder;
 			}
 		}
-		else if (startsWith(a, "-lp"))
+		else if (startsWith(a, "-lp") && (i + 1) < argc)
 		{
 			g_commandLineOptions.logPath = argv[++i];	// use next argument;
 		}
@@ -306,7 +311,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 		{
 			g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_QUIET;
 		}
-		else if (startsWith(a, "-rp"))
+		else if (startsWith(a, "-rp") && (i + 1) < argc)
 		{
 			g_commandLineOptions.replayDataLog = true;
 			g_commandLineOptions.logPath = argv[++i];	// use next argument
@@ -355,11 +360,11 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 		{
 			g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_SCROLL;
 		}
-		else if (startsWith(a, "-ub"))
+		else if (startsWith(a, "-ub") && (i + 1) < argc)
 		{
 			g_commandLineOptions.updateBootloaderFilename = argv[++i];	// use next argument
 		}
-        else if (startsWith(a, "-uf"))
+        else if (startsWith(a, "-uf") && (i + 1) < argc)
         {
             g_commandLineOptions.updateAppFirmwareFilename = argv[++i];	// use next argument
         }

--- a/src/cltool.cpp
+++ b/src/cltool.cpp
@@ -215,6 +215,10 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 		{
 			g_commandLineOptions.evbFlashCfg = ".";
 		}
+		else if (startsWith(a, "-fb"))
+		{
+			g_commandLineOptions.forceBootloaderUpdate = true;
+		}
 		else if (startsWith(a, "-flashCfg="))
 		{
 			g_commandLineOptions.flashCfg = &a[10];
@@ -446,8 +450,9 @@ void cltool_outputUsage()
 	cout << "    -stats" << boldOff << "          Display statistics of data received" << endlbOn;
     cout << "    -survey=[s],[d]" << boldOff << " Survey-in and store base position to refLla: s=[" << SURVEY_IN_STATE_START_3D << "=3D, " << SURVEY_IN_STATE_START_FLOAT << "=float, " << SURVEY_IN_STATE_START_FIX << "=fix], d=durationSec" << endlbOn;
 	cout << "    -uf " << boldOff << "FILEPATH    Update application firmware using .hex file FILEPATH.  Add -baud=115200 for systems w/ baud rate limits." << endlbOn;
-	cout << "    -ub " << boldOff << "FILEPATH    Update bootloader using .bin file FILEPATH if version is old." << endlbOn;
-	cout << "    -uv" << boldOff << "             Run verification after application firmware update." << endlbOn;
+	cout << "    -ub " << boldOff << "FILEPATH    Update bootloader using .bin file FILEPATH if version is old. Must be used along with option -uf." << endlbOn;
+	cout << "    -fb " << boldOff << "            Force bootloader update regardless of the version." << endlbOn;
+	cout << "    -uv " << boldOff << "            Run verification after application firmware update." << endlbOn;
 
 	cout << endlbOn;
 	cout << "OPTIONS (Message Streaming)" << endl;

--- a/src/cltool.cpp
+++ b/src/cltool.cpp
@@ -158,6 +158,14 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 		{
 			g_commandLineOptions.comPort = argv[++i];	// use next argument
 		}
+		else if (startsWith(a, "-chipEraseEvb"))
+		{
+			g_commandLineOptions.chipEraseEvb2 = true;
+		}		
+		else if (startsWith(a, "-chipEraseUins"))
+		{
+			g_commandLineOptions.chipEraseUins = true;
+		}		
 		else if (startsWith(a, "-dboc"))
 		{
 			g_commandLineOptions.disableBroadcastsOnClose = true;
@@ -215,6 +223,10 @@ bool cltool_parseCommandLine(int argc, char* argv[])
 		{
 			g_commandLineOptions.evbFlashCfg = ".";
 		}
+		else if (startsWith(a, "-factoryReset"))
+		{
+			g_commandLineOptions.factoryResetUins = true;
+		}		
 		else if (startsWith(a, "-fb"))
 		{
 			g_commandLineOptions.forceBootloaderUpdate = true;
@@ -310,7 +322,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         }
         else if (startsWith(a, "-reset"))
         {
-            g_commandLineOptions.softwareReset = true;
+            g_commandLineOptions.softwareResetUins = true;
         }
 		else if (startsWith(a, "-rover="))
 		{
@@ -453,6 +465,9 @@ void cltool_outputUsage()
 	cout << "    -ub " << boldOff << "FILEPATH    Update bootloader using .bin file FILEPATH if version is old. Must be used along with option -uf." << endlbOn;
 	cout << "    -fb " << boldOff << "            Force bootloader update regardless of the version." << endlbOn;
 	cout << "    -uv " << boldOff << "            Run verification after application firmware update." << endlbOn;
+	cout << "    -factoryReset " << boldOff << "  Reset uINS flash config to factory defaults." << endlbOn;
+	cout << "    -chipEraseUins " << boldOff << " CAUTION!!! Erase everything on uINS (firmware, config, calibration, etc.)" << endlbOn;
+	cout << "    -chipEraseEvb2 " << boldOff << " CAUTION!!! Erase everything on EVB2 (firmware, config, etc.)" << endlbOn;
 
 	cout << endlbOn;
 	cout << "OPTIONS (Message Streaming)" << endl;

--- a/src/cltool.h
+++ b/src/cltool.h
@@ -59,7 +59,7 @@ typedef struct
 	bool forceBootloaderUpdate;				// -fb
     bool bootloaderVerify; 					// -bv
     bool replayDataLog;
-    bool softwareReset;
+    bool softwareResetUins;
     bool softwareResetEvb;
     bool magRecal;
     uint32_t magRecalMode;
@@ -90,6 +90,10 @@ typedef struct
 
 	uint32_t timeoutFlushLoggerSeconds;
 	uint32_t outputOnceDid;
+
+	bool factoryResetUins;
+	bool chipEraseUins;
+	bool chipEraseEvb2;
 } cmd_options_t;
 
 extern cmd_options_t g_commandLineOptions;

--- a/src/cltool.h
+++ b/src/cltool.h
@@ -54,8 +54,9 @@ typedef struct
 typedef struct
 {
 	string comPort; 						// -c com_port
-	string updateAppFirmwareFilename; 		// -b file_name
+	string updateAppFirmwareFilename; 		// -uf file_name
     string updateBootloaderFilename; 		// -ub file_name
+	bool forceBootloaderUpdate;				// -fb
     bool bootloaderVerify; 					// -bv
     bool replayDataLog;
     bool softwareReset;
@@ -70,7 +71,7 @@ typedef struct
 	uint64_t rmcPreset;
     bool persistentMessages;
 	stream_did_t datasetEdit;				// -edit DID#=periodMultiple
-	vector<stream_did_t> datasets = {};		// -did DID#=periodMultiple
+	vector<stream_did_t> datasets;			// -did DID#=periodMultiple
 
 	bool enableLogging;
 	string logType; 						// -lt=dat
@@ -88,7 +89,7 @@ typedef struct
 	string evbFlashCfg;
 
 	uint32_t timeoutFlushLoggerSeconds;
-	uint32_t outputOnceDid = 0;
+	uint32_t outputOnceDid;
 } cmd_options_t;
 
 extern cmd_options_t g_commandLineOptions;

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -255,21 +255,27 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     }
     if (g_commandLineOptions.chipEraseUins)
     {   // Chip erase uINS
-        uint32_t sysCommand;
-		
-		sysCommand = SYS_CMD_MANF_UNLOCK;
-        inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
-        sysCommand = SYS_CMD_MANF_CHIP_ERASE;
-        inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
+		system_command_t cfg;
+
+		cfg.command = SYS_CMD_MANF_UNLOCK;
+		cfg.invCommand = ~cfg.command;
+		inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&cfg, sizeof(system_command_t), 0);
+
+		cfg.command = SYS_CMD_MANF_CHIP_ERASE;
+		cfg.invCommand = ~cfg.command;
+		inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&cfg, sizeof(system_command_t), 0);
     }
     if (g_commandLineOptions.factoryResetUins)
     {   // Reset flash config defaults on uINS
-        uint32_t sysCommand;
-		
-		sysCommand = SYS_CMD_MANF_UNLOCK;
-        inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
-        sysCommand = SYS_CMD_MANF_FACTORY_RESET;
-        inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
+		system_command_t cfg;
+
+		cfg.command = SYS_CMD_MANF_UNLOCK;
+		cfg.invCommand = ~cfg.command;
+		inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&cfg, sizeof(system_command_t), 0);
+
+		cfg.command = SYS_CMD_MANF_FACTORY_RESET;
+		cfg.invCommand = ~cfg.command;
+		inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&cfg, sizeof(system_command_t), 0);
     }
 
 	if (g_commandLineOptions.roverConnection.length() != 0)

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -279,17 +279,23 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
 	return true;
 }
 
-static int cltool_updateAppFirmware()
+static int cltool_updateFirmware()
 {
 	// [BOOTLOADER INSTRUCTION] Update firmware
-	cout << "Updating application firmware using file at " << g_commandLineOptions.updateAppFirmwareFilename << endl;
-	vector<InertialSense::bootloader_result_t> results = InertialSense::BootloadFile(g_commandLineOptions.comPort, 
+	if (g_commandLineOptions.updateBootloaderFilename.size() > 0)
+	{
+		cout << "Checking bootloader firmware: " << g_commandLineOptions.updateBootloaderFilename << endl;
+	}
+	cout << "Updating application firmware: " << g_commandLineOptions.updateAppFirmwareFilename << endl;
+	vector<InertialSense::bootload_result_t> results = InertialSense::BootloadFile(g_commandLineOptions.comPort,
         g_commandLineOptions.updateAppFirmwareFilename, 
-		g_commandLineOptions.updateBootloaderFilename,
         g_commandLineOptions.baudRate, 
         bootloadUploadProgress,
 		(g_commandLineOptions.bootloaderVerify ? bootloadVerifyProgress : 0),
-		bootloadStatusInfo);
+		bootloadStatusInfo,
+		g_commandLineOptions.updateBootloaderFilename,
+		g_commandLineOptions.forceBootloaderUpdate
+		);
 	cout << endl << "Results:" << endl;
 	int errorCount = 0;
 	for (size_t i = 0; i < results.size(); i++)
@@ -302,31 +308,6 @@ static int cltool_updateAppFirmware()
 		cout << endl << errorCount << " ports failed." << endl;
 	}
 	return (errorCount == 0 ? 0 : -1);
-}
-
-static int cltool_updateBootloader()
-{
-    cout << "Updating bootloader using file at " << g_commandLineOptions.updateBootloaderFilename << endl;
-    vector<InertialSense::bootloader_result_t> results = InertialSense::BootloadFile(g_commandLineOptions.comPort, 
-        g_commandLineOptions.updateBootloaderFilename,
-		"",
-        g_commandLineOptions.baudRate, 
-        bootloadUploadProgress,
-        (g_commandLineOptions.bootloaderVerify ? bootloadVerifyProgress : 0), 
-		bootloadStatusInfo,
-        true);
-    cout << endl << "Results:" << endl;
-    int errorCount = 0;
-    for (size_t i = 0; i < results.size(); i++)
-    {
-        cout << results[i].port << ": " << (results[i].error.size() == 0 ? "Success\n" : results[i].error);
-        errorCount += (int)(results[i].error.size() != 0);
-    }
-    if (errorCount != 0)
-    {
-        cout << endl << errorCount << " ports failed." << endl;
-    }
-    return (errorCount == 0 ? 0 : -1);
 }
 
 static int cltool_createHost()
@@ -397,25 +378,26 @@ static int inertialSenseMain()
 	{
         if (g_commandLineOptions.updateAppFirmwareFilename.substr(g_commandLineOptions.updateAppFirmwareFilename.length() - 4) != ".hex")
         {
-            cout << "Incorrect file extension." << endl;
+            cout << "Incorrect firmware file extension: " << g_commandLineOptions.updateAppFirmwareFilename << endl;
             return -1;
         }
+
+		if (g_commandLineOptions.updateBootloaderFilename.length() != 0 &&
+			g_commandLineOptions.updateBootloaderFilename.substr(g_commandLineOptions.updateBootloaderFilename.length() - 4) != ".bin")
+		{
+			cout << "Incorrect bootloader file extension: " << g_commandLineOptions.updateBootloaderFilename << endl;
+			return -1;
+		}
 
 		// [BOOTLOADER INSTRUCTION] 1.) Run bootloader
-		return cltool_updateAppFirmware();
+		return cltool_updateFirmware();
 	}
-    // if bootloader filename was specified on the command line, do that now and return
-    else if (g_commandLineOptions.updateBootloaderFilename.length() != 0)
-    {
-        if (g_commandLineOptions.updateBootloaderFilename.substr(g_commandLineOptions.updateBootloaderFilename.length() - 4) != ".bin")
-        {
-            cout << "Incorrect file extension." << endl;
-            return -1;
-        }
-
-        return cltool_updateBootloader();
-    }
-    // if host was specified on the command line, create a tcp server
+	else if (g_commandLineOptions.updateBootloaderFilename.length() != 0)
+	{
+		cout << "option -uf [FILENAME] must be used with option -ub [FILENAME] " << endl;
+		return -1;
+	}
+	// if host was specified on the command line, create a tcp server
 	else if (g_commandLineOptions.baseConnection.length() != 0)
 	{
 		return cltool_createHost();

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -232,7 +232,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         cfg.invCommand = ~cfg.command;
         inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&cfg, sizeof(system_command_t), 0);
     }
-    if (g_commandLineOptions.softwareReset)
+    if (g_commandLineOptions.softwareResetUins)
     {   // Issue software reset
         system_command_t cfg;
         cfg.command = SYS_CMD_SOFTWARE_RESET;
@@ -243,6 +243,33 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     {   // Issue software reset to EVB
         uint32_t sysCommand = SYS_CMD_SOFTWARE_RESET;
         inertialSenseInterface.SendRawData(DID_EVB_STATUS, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
+    }
+    if (g_commandLineOptions.chipEraseEvb2)
+    {   // Chip erase EVB
+        uint32_t sysCommand;
+		
+		sysCommand = SYS_CMD_MANF_UNLOCK;
+        inertialSenseInterface.SendRawData(DID_EVB_STATUS, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
+        sysCommand = SYS_CMD_MANF_CHIP_ERASE;
+        inertialSenseInterface.SendRawData(DID_EVB_STATUS, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
+    }
+    if (g_commandLineOptions.chipEraseUins)
+    {   // Chip erase uINS
+        uint32_t sysCommand;
+		
+		sysCommand = SYS_CMD_MANF_UNLOCK;
+        inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
+        sysCommand = SYS_CMD_MANF_CHIP_ERASE;
+        inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
+    }
+    if (g_commandLineOptions.factoryResetUins)
+    {   // Reset flash config defaults on uINS
+        uint32_t sysCommand;
+		
+		sysCommand = SYS_CMD_MANF_UNLOCK;
+        inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
+        sysCommand = SYS_CMD_MANF_FACTORY_RESET;
+        inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
     }
 
 	if (g_commandLineOptions.roverConnection.length() != 0)

--- a/src/inertialSenseBootLoader.c
+++ b/src/inertialSenseBootLoader.c
@@ -1218,9 +1218,9 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
             if (!bootloadUpdateBootloaderSendFile(&params))
                 return -1;
 
-            //Restart process now bootloader is updated
             SLEEP_MS(1000);
-            return 0;
+            //Bootloader updated successfully.  Return 1 to indicate firmware update is now needed.
+            return 1;
         }
 
         return -1;
@@ -1304,8 +1304,8 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
                         if (!bootloadUpdateBootloaderSendFile(&params))
                             return -1;
 
-                        //Success.  Return 1 to indicate restart process now bootloader is updated
                         SLEEP_MS(1000);
+                        //Bootloader updated successfully.  Return 1 to indicate firmware update is now needed.
                         return 1;
                     }
                     else
@@ -1558,9 +1558,8 @@ int bootloadFileEx(bootload_params_t* params)
 
     result = bootloadFileInternal(file, params);
 
-    //Restart if we updated bootloader
     if (result == 1)
-    {
+    {    // Bootloader was just updated.  Start firmware update. 
         params->forceBootloaderUpdate = 0;
         result = bootloadFileInternal(file, params);
     }

--- a/src/inertialSenseBootLoader.c
+++ b/src/inertialSenseBootLoader.c
@@ -16,7 +16,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISConstants.h"
 #include "ISUtilities.h"
 
-#define ENABLE_HEX_BOOT_LOADER 1
 #define MAX_SEND_COUNT 510
 #define MAX_VERIFY_CHUNK_SIZE 1024
 #define BOOTLOADER_TIMEOUT_DEFAULT 1000
@@ -750,7 +749,7 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
             if (lineLength > BUFFER_SIZE * 4)
             {
                 bootloader_perror(state->param->port, "Line length of %d was too large\n", lineLength);
-                return 0;
+                return -1;
             }
 
             // we need to know the offset that this line was supposed to be stored at so we can check if offsets are skipped
@@ -767,7 +766,7 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
                 if (outputPtr + pad >= outputPtrEnd)
                 {
                     bootloader_perror(state->param->port, "FF padding overflowed output buffer\n");
-                    return 0;
+                    return -1;
                 }
 
                 while (pad-- != 0)
@@ -783,7 +782,7 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
             if (outputPtr + pad >= outputPtrEnd)
             {
                 bootloader_perror(state->param->port, "Line data overflowed output buffer\n");
-                return 0;
+                return -1;
             }
 
             for (i = 9; i < lineLength - 2; i++)
@@ -805,7 +804,7 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
             // upload this chunk
             else if (!bootloaderUploadHexData(state->param->port, output, (outputSize > MAX_SEND_COUNT ? MAX_SEND_COUNT : outputSize), &currentOffset, &currentPage, &totalBytes, &verifyCheckSum))
             {
-                return 0;
+                return -1;
             }
 
             outputSize -= MAX_SEND_COUNT;
@@ -813,7 +812,7 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
             if (outputSize < 0 || outputSize > BUFFER_SIZE)
             {
                 bootloader_perror(state->param->port, "Output size of %d was too large\n", outputSize);
-                return 0;
+                return -1;
             }
             else if (outputSize > 0)
             {
@@ -839,19 +838,19 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
                 if (outputSize < 0 || outputSize > BUFFER_SIZE)
                 {
                     bootloader_perror(state->param->port, "Output size of %d was too large\n", outputSize);
-                    return 0;
+                    return -1;
                 }
 
                 // flush the remainder of data to the page
                 else if (bootloaderUploadHexData(state->param->port, output, outputSize, &currentOffset, &currentPage, &totalBytes, &verifyCheckSum) == 0)
                 {
-                    return 0;
+                    return -1;
                 }
 
                 // fill the remainder of the current page, the next time that bytes try to be written the page will be automatically incremented
                 else if (bootloaderFillCurrentPage(state->param->port, &currentPage, &currentOffset, &totalBytes, &verifyCheckSum) == 0)
                 {
-                    return 0;
+                    return -1;
                 }
 
                 // set the output ptr back to the beginning, no more data is in the queue
@@ -866,7 +865,7 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
             if (state->param->uploadProgress(state->param->obj, percent) == 0)
             {
                 bootloader_perror(state->param->port, "Upload firmware cancelled\n");
-                return 0;
+                return -1;
             }
         }
     }
@@ -875,13 +874,13 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
     outputSize = (int)(outputPtr - output);
     if (bootloaderUploadHexData(state->param->port, output, outputSize, &currentOffset, &currentPage, &totalBytes, &verifyCheckSum) == 0)
     {
-        return 0;
+        return -1;
     }
 
     // pad the remainder of the page with fill bytes
     if (currentOffset != 0 && bootloaderFillCurrentPage(state->param->port, &currentPage, &currentOffset, &totalBytes, &verifyCheckSum) == 0)
     {
-        return 0;
+        return -1;
     }
 
     if (state->param->uploadProgress != 0 && percent != 1.0f)
@@ -896,7 +895,7 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
 
         if (state->param->verifyProgress != 0 && bootloaderVerify(currentPage, verifyCheckSum, state) == 0)
         {
-            return 0;
+            return -1;
         }
     }
 
@@ -906,7 +905,7 @@ static int bootloaderProcessHexFile(FILE* file, bootloader_state_t* state)
     serialPortWrite(state->param->port, (unsigned char*)":020000040300F7", 15);
     serialPortSleep(state->param->port, 250);
 
-    return 1;
+    return 0;   // Success
 }
 
 static int bootloaderProcessBinFile(FILE* file, bootload_params_t* p)
@@ -1188,11 +1187,11 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
 {
     if (p->statusText)
         p->statusText(p->obj, "Starting bootloader...");
-    if (!enableBootloader(p->port, p->baudRate, p->error, BOOTLOADER_ERROR_LENGTH, p->bootloadEnableCmd))
+    if (enableBootloader(p->port, p->baudRate, p->error, BOOTLOADER_ERROR_LENGTH, p->bootloadEnableCmd))
     {
         //If we have an error, exit
         if (p->error[0] != 0)
-            return 0;
+            return -1;
 
         if (p->statusText)
             p->statusText(p->obj, "Unable to find bootloader.");
@@ -1216,20 +1215,20 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
             params.flags.bitFields.enableVerify = 1;
 
             if (!bootloadUpdateBootloaderSendFile(&params))
-                return 0;
+                return -1;
 
             //Restart process now bootloader is updated
             SLEEP_MS(1000);
-            return -1;
+            return 0;
         }
 
-        return 0;
+        return -1;
     }
 
     // Sync with bootloader
     if (!bootloaderHandshake(p))
     {
-        return 0;
+        return -1;
     }
 
     int fileNameLength = (int)strnlen(p->fileName, 255);
@@ -1237,23 +1236,17 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
     {
         //At this time, binary files are not supported for updating firmware
         bootloader_snprintf(p->error, BOOTLOADER_ERROR_LENGTH, "Binary firmware files are not supported.");
-        return 0;
-
-        // it's a .bin file, we will use a far more optimized and memory efficient uploader
-        //return bootloaderProcessBinFile(file, p);
+        return -1;
     }
     else
     {
-
-#if ENABLE_HEX_BOOT_LOADER
-
         bootloader_state_t state;
         memset(&state, 0, sizeof(state));
         state.param = p;
 
 		if(!bootloaderNegotiateVersion(&state)) // negotiate version
 		{
-			return 0;
+			return -1;
 		}
 
         int blVerMajor, sambaSupport;
@@ -1266,13 +1259,13 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
                 p->statusText(p->obj, str);
         }
 
-        if ((p->bootName != 0))
+        if (p->bootName[0] != 0)
         {
             int fileVerMajor = 0;
             char fileVerMinor = 0;
             //Retrieve version from file
             //Only check if we find valid version info in file
-            if (bootloadGetBootloaderVersionFromFile(p->bootName, &fileVerMajor, &fileVerMinor) || p->forceBootloaderUpdate > 0)
+            if (!bootloadGetBootloaderVersionFromFile(p->bootName, &fileVerMajor, &fileVerMinor) || p->forceBootloaderUpdate > 0)
             {
                 //printf("Bootloader file version: %d%c.\n", fileVerMajor, fileVerMinor);
 
@@ -1308,18 +1301,18 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
                         params.flags.bitFields.enableVerify = 1;
 
                         if (!bootloadUpdateBootloaderSendFile(&params))
-                            return 0;
+                            return -1;
 
-                        //Restart process now bootloader is updated
+                        //Success.  Return 1 to indicate restart process now bootloader is updated
                         SLEEP_MS(1000);
-                        return -1;
+                        return 1;
                     }
                     else
                     {   //Bootloader is out of date but SAM-BA is not supported on port
                         if (p->statusText)
                             p->statusText(p->obj, "WARNING!  Bootloader is out of date. Port used to communicate with bootloader does not support updating the bootloader. To force firmware update, run update without including the bootloader file.");
                         bootloader_snprintf(p->error, BOOTLOADER_ERROR_LENGTH, "Bootloader is out of date but current port does not support updating bootloader. To force update, run firmware update without including the bootloader file.\n");
-                        return 0;
+                        return -1;
                     }
                 }
             }            
@@ -1328,24 +1321,15 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
         if (p->statusText)
             p->statusText(p->obj, "Erasing flash...");
         if ( !bootloaderEraseFlash(p->port) /*erase all flash */ || !bootloaderSelectPage(p->port, 0) /*select the first page*/)
-            return 0;
-
+            return -1;
 
         if (p->statusText)
             p->statusText(p->obj, "Programming flash...");
         // begin programming the first page
         if(!bootloaderBeginProgramForCurrentPage(p->port, state.firstPageSkipBytes, FLASH_PAGE_SIZE - 1))
-            return 0;
+            return -1;
 
         return bootloaderProcessHexFile(file, &state);
-
-#else
-
-        bootloader_snprintf(lastError, ERROR_BUFFER_SIZE, "Hex bootloader is disabled");
-        return 0;
-
-#endif
-
     }
 }
 
@@ -1519,13 +1503,12 @@ int bootloadFileEx(bootload_params_t* params)
 		strncpy(params->bootloadEnableCmd, "BLEN", 4);
 	}
 
-	int result = 0;
+	int result = -1;    // 0 = success
 
     if (params->error != 0 && BOOTLOADER_ERROR_LENGTH > 0)
     {
         *params->error = '\0';
-    }
-    
+    }   
 
     // open the file
     FILE* file = 0;
@@ -1575,14 +1558,16 @@ int bootloadFileEx(bootload_params_t* params)
     result = bootloadFileInternal(file, params);
 
     //Restart if we updated bootloader
-    if (result == -1)
+    if (result == 1)
     {
         params->forceBootloaderUpdate = 0;
         result = bootloadFileInternal(file, params);
     }
 
-    if (result == 0)
+    if (result == -1)
     {
+        bootloader_snprintf(params->error, BOOTLOADER_ERROR_LENGTH, "Update failed");
+
         // reboot the device back into boot-loader mode
         serialPortWrite(params->port, (unsigned char*)":020000040500F5", 15);
         serialPortSleep(params->port, 500);
@@ -1609,7 +1594,7 @@ int bootloadGetBootloaderVersionFromFile(const char* bootName, int* verMajor, ch
 #endif
 
     if (blfile == 0)
-        return 0;
+        return -1;
 
     fseek(blfile, 0x3DFC, SEEK_SET);
     unsigned char ver_info[4];
@@ -1628,24 +1613,7 @@ int bootloadGetBootloaderVersionFromFile(const char* bootName, int* verMajor, ch
     }
 
     //No version found
-    return 0;
-}
-
-int bootloadUpdateBootloader(serial_port_t* port, const char* fileName,
-    const void* obj, pfnBootloadProgress uploadProgress, pfnBootloadProgress verifyProgress)
-{
-    bootload_params_t params;
-    memset(&params, 0, sizeof(params));
-    params.fileName = fileName;
-    params.port = port;
-	memset(params.error, 0, sizeof(BOOTLOADER_ERROR_LENGTH));
-    params.obj = obj;
-    params.uploadProgress = uploadProgress;
-    params.verifyProgress = verifyProgress;
-    params.numberOfDevices = 1;
-    params.flags.bitFields.enableVerify = (verifyProgress != 0);
-
-    return bootloadUpdateBootloaderEx(&params);
+    return -1;
 }
 
 static int bootloadUpdateBootloaderSendFile(bootload_params_t* p)
@@ -1787,63 +1755,6 @@ static int bootloadUpdateBootloaderSendFile(bootload_params_t* p)
     return 1;
 }
 
-int bootloadUpdateBootloaderEx(bootload_params_t* p)
-{
-    strncpy(p->bootloadEnableCmd, "NELB,!!SAM-BA!!\0", 16);
-    serialPortWriteAscii(p->port, p->bootloadEnableCmd, 16);
-    serialPortSleep(p->port, 250);
-    serialPortClose(p->port);
-
-    //Send command to enter SAM-BA mode across different baud rates
-    if (!serialPortOpenRetry(p->port, p->port->port, BAUDRATE_3000000, 1))
-    {
-        bootloader_perror(p, "Failed to open port.\n");
-        serialPortClose(p->port);
-        return 0;
-    }
-    serialPortWriteAscii(p->port, p->bootloadEnableCmd, 16);
-    serialPortSleep(p->port, 250);
-
-    if (!serialPortOpenRetry(p->port, p->port->port, BAUDRATE_921600, 1))
-    {
-        bootloader_perror(p, "Failed to open port.\n");
-        serialPortClose(p->port);
-        return 0;
-    }
-    serialPortWriteAscii(p->port, p->bootloadEnableCmd, 16);
-    serialPortSleep(p->port, 250);
-
-    if (!serialPortOpenRetry(p->port, p->port->port, BAUDRATE_460800, 1))
-    {
-        bootloader_perror(p, "Failed to open port.\n");
-        serialPortClose(p->port);
-        return 0;
-    }
-    serialPortWriteAscii(p->port, p->bootloadEnableCmd, 16);
-    serialPortSleep(p->port, 250);
-
-    if (!serialPortOpenRetry(p->port, p->port->port, BAUDRATE_230400, 1))
-    {
-        bootloader_perror(p, "Failed to open port.\n");
-        serialPortClose(p->port);
-        return 0;
-    }
-    serialPortWriteAscii(p->port, p->bootloadEnableCmd, 16);
-    serialPortSleep(p->port, 250);
-
-    serialPortClose(p->port);
-    if (!serialPortOpenRetry(p->port, p->port->port, BAUDRATE_115200, 1))
-    {
-        bootloader_perror(p, "Failed to open port.\n");
-        serialPortClose(p->port);
-        return 0;
-    }
-    serialPortWriteAscii(p->port, p->bootloadEnableCmd, 16);
-
-    //Should be in SAM-BA mode, start sending data
-    return bootloadUpdateBootloaderSendFile(p);
-}
-
 int enableBootloader(serial_port_t* port, int baudRate, char* error, int errorLength, const char* bootloadEnableCmd)
 {
     int baudRates[] = { baudRate, IS_BAUD_RATE_BOOTLOADER, IS_BAUD_RATE_BOOTLOADER_RS232, IS_BAUD_RATE_BOOTLOADER_SLOW };
@@ -1902,7 +1813,7 @@ int enableBootloader(serial_port_t* port, int baudRate, char* error, int errorLe
         {
             // failure
             serialPortClose(port);
-            return 0;
+            return -1;
         }
     }
 
@@ -1911,7 +1822,7 @@ int enableBootloader(serial_port_t* port, int baudRate, char* error, int errorLe
 
     // by this point the bootloader should be enabled
     serialPortClose(port);
-    return 1;
+    return 0;
 }
 
 static int disableBootloaderInternal(serial_port_t* port, char* error, int errorLength, int baud)
@@ -1919,22 +1830,22 @@ static int disableBootloaderInternal(serial_port_t* port, char* error, int error
     // open the serial port
     if (serialPortOpenInternal(port, baud, error, errorLength) == 0)
     {
-        return 0;
+        return -1;
     }
 
     // send the "reboot to program mode" command and the device should start in program mode
     serialPortWrite(port, (unsigned char*)":020000040300F7", 15);
     serialPortSleep(port, 250);
     serialPortClose(port);
-    return 1;
+    return 0;
 }
 
 
 int disableBootloader(serial_port_t* port, char* error, int errorLength)
 {
-    int result = 0;
-    result |= disableBootloaderInternal(port, error, errorLength, IS_BAUD_RATE_BOOTLOADER);
-    result |= disableBootloaderInternal(port, error, errorLength, IS_BAUD_RATE_BOOTLOADER_RS232);
-	result |= disableBootloaderInternal(port, error, errorLength, IS_BAUD_RATE_BOOTLOADER_SLOW);
+    int result = -1;
+    result &= disableBootloaderInternal(port, error, errorLength, IS_BAUD_RATE_BOOTLOADER);
+    result &= disableBootloaderInternal(port, error, errorLength, IS_BAUD_RATE_BOOTLOADER_RS232);
+	result &= disableBootloaderInternal(port, error, errorLength, IS_BAUD_RATE_BOOTLOADER_SLOW);
 	return result;
 }

--- a/src/inertialSenseBootLoader.c
+++ b/src/inertialSenseBootLoader.c
@@ -1610,7 +1610,7 @@ int bootloadGetBootloaderVersionFromFile(const char* bootName, int* verMajor, ch
             *verMajor = ver_info[2];
         if (verMinor)
             *verMinor = ver_info[3];
-        return 1;
+        return 0;
     }
 
     //No version found

--- a/src/inertialSenseBootLoader.h
+++ b/src/inertialSenseBootLoader.h
@@ -86,26 +86,11 @@ Boot load a .hex or .bin file to a device
 @param uploadProgress called periodically during firmware upload - can be NULL
 @param verifyProgress called periodically during firmware verification - can be NULL
 
-@return 0 if failure, non-zero if success
+@return 0 on success, -1 on failure
 */
 int bootloadFile(serial_port_t* port, const char* fileName, const char* bootName,
     const void* obj, pfnBootloadProgress uploadProgress, pfnBootloadProgress verifyProgress);
 int bootloadFileEx(bootload_params_t* params);
-
-/**
-Boot load a new bootloader .bin file to device. Device must be in application or bootloader assist mode, not bootloader mode.
-@param port the serial port, must be initialized and have the port set
-@param fileName the new bootloader .bin file
-@param error a buffer to store any error messages in - can be NULL
-@param errorLength the number of bytes available in error
-@param obj custom user object that will be passed in the callback
-@param uploadProgress called periodically during firmware upload - can be NULL
-@param verifyProgress called periodically during firmware verification - can be NULL
-@retur 0 if failure, non-zero if success
-*/
-int bootloadUpdateBootloader(serial_port_t* port, const char* fileName, 
-    const void* obj, pfnBootloadProgress uploadProgress, pfnBootloadProgress verifyProgress);
-int bootloadUpdateBootloaderEx(bootload_params_t* p);
 
 /**
 Retrieve the bootloader version from .bin file
@@ -114,7 +99,7 @@ Retrieve the bootloader version from .bin file
 @param pointer to int to store major version
 @param pointer to char to store minor version
 
-@return 0 if failure, 1 if success
+@return 0 on success, -1 on failure
 */
 int bootloadGetBootloaderVersionFromFile(const char* bootName, int* verMajor, char* verMinor);
 
@@ -126,7 +111,7 @@ Enable bootloader mode for a device
 @param error a buffer to store any error messages - can be NULL
 @param errorLength the number of bytes available in error
 
-@return 0 if failure, non-zero if success
+@return 0 on success, -1 on failure
 */
 int enableBootloader(serial_port_t* port, int baudRate, char* error, int errorLength, const char* bootloadEnableCmd);
 
@@ -137,7 +122,7 @@ Disables the bootloader and goes back to program mode
 @error a buffer to store any error messages - can be NULL
 @errorLength the number of bytes available in error
 
-@return 0 if failure, non-zero if success
+@return 0 on success, -1 on failure
 */
 int disableBootloader(serial_port_t* port, char* error, int errorLength);
 


### PR DESCRIPTION
- Fixed issues with using cltool to update bootloader firmware.
- Remove old unused code from bootloader.  Updating bootloader firmware must be done along with updating application firmware.
- Consolidated application and bootloader firmware update in cltool.
- Added -fb forceBootloaderUpdate option to cltool.
- Fix failed to update firmware error status.
- Added error checking to catch invalid filename or if force update option is supplied without a file name. 
- Change return state of bootloadFileEx() to 0 on success, -1 on failure.