### PR TITLE
fixes for building logInspector

### DIFF
--- a/src/message_stats.cpp
+++ b/src/message_stats.cpp
@@ -107,7 +107,7 @@ static void updateTimeMs(msg_stats_t &s, int timeMs)
 	s.timeMs = timeMs;
 }
 
-void messageStatsAppend(string message, mul_msg_stats_t &msgStats, int ptype, int id, int timeMs)
+void messageStatsAppend(string message, mul_msg_stats_t &msgStats, unsigned int ptype, int id, int timeMs)
 {
 	switch (ptype)
 	{

--- a/src/message_stats.h
+++ b/src/message_stats.h
@@ -40,7 +40,7 @@ typedef struct
 unsigned int messageStatsGetbitu(const unsigned char *buff, int pos, int len);
 string messageDescriptionUblox(uint8_t msgClass, uint8_t msgID);
 string messageDescriptionRtcm3(int id);
-void messageStatsAppend(string message, mul_msg_stats_t &msgStats, int ptype, int id, int timeMs);
+void messageStatsAppend(string message, mul_msg_stats_t &msgStats, unsigned int ptype, int id, int timeMs);
 string messageStatsSummary(mul_msg_stats_t &msgStats);
 
 


### PR DESCRIPTION
This fixes the following errors when building python log inspector:

```
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fPIC -Iinclude -I../src -I../../src -I/usr/lib/python3.9/site-packages/pybind11/include -I/usr/lib/python3.9/site-packages/pybind11/include -I/usr/include/python3.9 -c ../../src/message_stats.cpp -o build/temp.linux-x86_64-3.9/../../src/message_stats.o -O3 -DVERSION_INFO="0.0.1" -std=c++14
../../src/message_stats.cpp: In function ‘void messageStatsAppend(std::string, mul_msg_stats_t&, int, int, int)’:
../../src/message_stats.cpp:114:14: error: narrowing conversion of ‘_PTYPE_INERTIAL_SENSE_CMD’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
  114 |         case _PTYPE_INERTIAL_SENSE_CMD:
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~
../../src/message_stats.cpp:115:14: error: narrowing conversion of ‘_PTYPE_INERTIAL_SENSE_DATA’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
  115 |         case _PTYPE_INERTIAL_SENSE_DATA:
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/message_stats.cpp:126:14: error: narrowing conversion of ‘_PTYPE_ASCII_NMEA’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
  126 |         case _PTYPE_ASCII_NMEA:
      |              ^~~~~~~~~~~~~~~~~
../../src/message_stats.cpp:137:14: error: narrowing conversion of ‘_PTYPE_UBLOX’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
  137 |         case _PTYPE_UBLOX:
      |              ^~~~~~~~~~~~
../../src/message_stats.cpp:150:14: error: narrowing conversion of ‘_PTYPE_RTCM3’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
  150 |         case _PTYPE_RTCM3:
      |              ^~~~~~~~~~~~
../../src/message_stats.cpp:167:14: error: narrowing conversion of ‘_PTYPE_INERTIAL_SENSE_ACK’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
  167 |         case _PTYPE_INERTIAL_SENSE_ACK:
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~
../../src/message_stats.cpp:174:14: error: narrowing conversion of ‘_PTYPE_PARSE_ERROR’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
  174 |         case _PTYPE_PARSE_ERROR:
      |              ^~~~~~~~~~~~~~~~~~
error: command '/usr/bin/gcc' failed with exit code 1
```