### PR TITLE
SN-1004 Update idle task to work on uINS-5

### DIFF
--- a/hw-libs/misc/rtos.c
+++ b/hw-libs/misc/rtos.c
@@ -129,8 +129,11 @@ void vApplicationIdleHook(void)
 {
     // Sleep to reduce power consumption
 #ifndef uINS_5
-    pmc_enable_sleepmode(0);	// TODO: Implement this function for uINS_5
+	PMC->PMC_FSMR &= (uint32_t) ~PMC_FSMR_LPM; // Enter Sleep mode
 #endif
+    SCB->SCR &= (uint32_t) ~SCB_SCR_SLEEPDEEP_Msk;	// Common to both Cortex M4 and M7
+    __DSB();
+    __WFI();
 }
 
 #ifndef uINS_5


### PR DESCRIPTION
The method to put the Microchip and STM32 chips we have in our products are almost exactly the same. I broke out the calls in the pmc_enable_sleepmode function. @rudomorg, I need your help to test the following:

- uINS-3 power consumption with the sleep lines commented and uncommented
- uINS-5 power consumption with the sleep lines commented and uncommented

Once we can confirm that these lines are indeed putting us into sleep mode, we can go ahead and merge this.