### PR TITLE
Fixed issue where RTK base info would scroll at bottom

### DIFF
--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -333,11 +333,11 @@ void cInertialSenseDisplay::SetExitProgram()
 }
 
 // Return true on refresh
-bool cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, double replaySpeedX)
+void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, double replaySpeedX)
 {
 	if (m_displayMode == DMODE_QUIET)
 	{
-		return false;
+		return;
 	}
 
 	unsigned int curTimeMs = current_timeMs();
@@ -481,12 +481,10 @@ bool cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 		cout << DataToString(data) << endl;
 		break;
 	}
-
-	return true;
 }
 
-// Print data to standard out at the following refresh rate.
-void cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
+// Print data to standard out at the following refresh rate.  Return true to refresh display.
+bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 {
 	unsigned int curTimeMs = current_timeMs();
 	static unsigned int timeSinceRefreshMs = 0;
@@ -494,7 +492,7 @@ void cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 	// Limit display refresh rate
 	if (curTimeMs - timeSinceRefreshMs < refreshPeriodMs)
 	{
-		return;
+		return false;
 	}
 	timeSinceRefreshMs = curTimeMs;
 
@@ -512,7 +510,7 @@ void cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 			cout << Connected() << endl;
 
 		cout << VectortoString();
-		break;
+		return true;
 
 	case DMODE_EDIT:
 		Home();
@@ -523,17 +521,19 @@ void cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 
 		// Generic column format
 		cout << DatasetToString(&m_editData.pData);
-		break;
+		return true;
 
 	case DMODE_STATS:
 		Home();
 		cout << Connected() << endl;
 		PrintStats();
-		break;
+		return true;
 
 	case DMODE_SCROLL:	// Scroll display 
 		break;
 	}
+
+	return false;
 }
 
 string cInertialSenseDisplay::VectortoString()

--- a/src/ISDisplay.h
+++ b/src/ISDisplay.h
@@ -86,8 +86,8 @@ public:
 	void SetExitProgram();
 
 	// for the binary protocol, this processes a packet of data
-	bool ProcessData(p_data_t *data, bool enableReplay = false, double replaySpeedX = 1.0);
-	void PrintData(unsigned int refreshPeriodMs = 100);		// 100ms = 10Hz
+	void ProcessData(p_data_t *data, bool enableReplay = false, double replaySpeedX = 1.0);
+	bool PrintData(unsigned int refreshPeriodMs = 100);		// 100ms = 10Hz
 	void DataToStats(const p_data_t* data);
 	void PrintStats();
 	string DataToString(const p_data_t* data);

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -36,7 +36,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "cltool.h"
 
 
-static void display_server_client_status(InertialSense* i, bool server=false, bool showMessageSummary=false, bool refresh=false)
+static void display_server_client_status(InertialSense* i, bool server=false, bool showMessageSummary=false, bool refreshDisplay=false)
 {
 	if (g_inertialSenseDisplay.GetDisplayMode() == cInertialSenseDisplay::DMODE_QUIET ||
 		g_inertialSenseDisplay.GetDisplayMode() == cInertialSenseDisplay::DMODE_SCROLL)
@@ -87,7 +87,7 @@ static void display_server_client_status(InertialSense* i, bool server=false, bo
 			{
  				outstream << i->getServerMessageStatsSummary();
 			}
-			refresh = true;
+			refreshDisplay = true;
 		}
 		else
 		{	// Client
@@ -103,7 +103,7 @@ static void display_server_client_status(InertialSense* i, bool server=false, bo
 		}
 	}
 
-	if (refresh)
+	if (refreshDisplay)
 	{
 		cout << outstream.str();
 	}
@@ -121,12 +121,7 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
     (void)pHandle;
 
 	// Print data to terminal
-	bool refresh = g_inertialSenseDisplay.ProcessData(data);
-
-	
-
-	// Collect and print summary list of client messages received
-	display_server_client_status(i, false, false, refresh);
+	g_inertialSenseDisplay.ProcessData(data);
 
 #if 0
 
@@ -493,13 +488,15 @@ static int inertialSenseMain()
 
 					// [C++ COMM INSTRUCTION] STEP 4: Read data
 					if (!inertialSenseInterface.Update())
-					{
-						// device disconnected, exit
+					{	// device disconnected, exit
 						break;
 					}
 
 					// Print to standard output
-					g_inertialSenseDisplay.PrintData();
+					bool refreshDisplay = g_inertialSenseDisplay.PrintData();
+
+					// Collect and print summary list of client messages received
+					display_server_client_status(&inertialSenseInterface, false, false, refreshDisplay);
 				}
 			}
 			catch (...)


### PR DESCRIPTION
This fixes a screen refresh problem with the CLtool, introduced recently when I added the ability to the CLTool to set write only DIDs.