### PR TITLE
bugfix/SN-1012 logger drops data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(InertialSense
   src/ISFileManager.cpp
   src/ISLogFile.cpp
   src/ISLogger.cpp
+  src/ISLogStats.cpp
   src/ISMatrix.c
   src/ISPose.c
   src/ISSerialPort.cpp

--- a/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
+++ b/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
@@ -1416,6 +1416,14 @@
       <SubType>compile</SubType>
       <Link>src\inertial-sense-sdk\src\ISLogger.h</Link>
     </Compile>
+    <Compile Include="..\..\src\ISLogStats.cpp">
+      <SubType>compile</SubType>
+      <Link>src\inertial-sense-sdk\src\ISLogStats.cpp</Link>
+    </Compile>
+    <Compile Include="..\..\src\ISLogStats.h">
+      <SubType>compile</SubType>
+      <Link>src\inertial-sense-sdk\src\ISLogStats.h</Link>
+    </Compile>
     <Compile Include="..\..\src\DeviceLog.cpp">
       <SubType>compile</SubType>
       <Link>src\inertial-sense-sdk\src\DeviceLog.cpp</Link>

--- a/EVB-2/IS_EVB-2/src/ISLogFileFatFs.cpp
+++ b/EVB-2/IS_EVB-2/src/ISLogFileFatFs.cpp
@@ -216,3 +216,20 @@ std::size_t cISLogFileFatFs::read(void* bytes, std::size_t len)
     f_read(&m_file, bytes, len, &bytes_read);
     return bytes_read;
 }
+
+int cISLogFileFatFs::seek(long int offset, int origin)
+{
+	return f_lseek(&m_file, offset);
+}
+
+long int cISLogFileFatFs::tell()
+{
+	return f_tell(&m_file);
+}
+
+int cISLogFileFatFs::eof()
+{
+	return f_eof(&m_file);
+}
+
+

--- a/EVB-2/IS_EVB-2/src/ISLogFileFatFs.h
+++ b/EVB-2/IS_EVB-2/src/ISLogFileFatFs.h
@@ -39,6 +39,9 @@ public:
 
     int getch() OVERRIDE;
     std::size_t read(void* bytes, std::size_t len) OVERRIDE;
+	int seek(long int offset, int origin) OVERRIDE;
+	long int tell() OVERRIDE;
+    int eof() OVERRIDE;
 
 private:
     FIL m_file;

--- a/EVB-2/Makefile
+++ b/EVB-2/Makefile
@@ -40,6 +40,7 @@ C_SRCS += \
           $(SDK_DIR)/src/ISUtilities.cpp                                                                 \
           $(SDK_DIR)/src/ISFileManager.cpp                                                               \
           $(SDK_DIR)/src/ISLogger.cpp                                                                    \
+          $(SDK_DIR)/src/ISLogStats.cpp                                                                  \
           $(SDK_DIR)/src/DeviceLog.cpp                                                                   \
           $(SDK_DIR)/src/DeviceLogSerial.cpp                                                             \
           $(SDK_DIR)/src/DataChunk.cpp                                                                   \

--- a/ExampleProjects/LogReader/CMakeLists.txt
+++ b/ExampleProjects/LogReader/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(ISLogReaderExample
 	../../src/ISFileManager.cpp
 	../../src/ISLogFile.cpp
 	../../src/ISLogger.cpp
+	../../src/ISLogStats.cpp
 	../../src/ISMatrix.c
 	../../src/ISPose.c
 	../../src/ISSerialPort.cpp

--- a/ExampleProjects/LogReader/VS_Project/ISLogReader.vcxproj.filters
+++ b/ExampleProjects/LogReader/VS_Project/ISLogReader.vcxproj.filters
@@ -64,6 +64,9 @@
     <ClCompile Include="..\..\..\src\ISLogger.cpp">
       <Filter>Source Files\SDK</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\ISLogStats.cpp">
+      <Filter>Source Files\SDK</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\src\tinyxml.cpp">
       <Filter>Source Files\SDK</Filter>
     </ClCompile>
@@ -163,6 +166,9 @@
       <Filter>Source Files\SDK</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\ISLogger.h">
+      <Filter>Source Files\SDK</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\ISLogStats.h">
       <Filter>Source Files\SDK</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\tinyxml.h">

--- a/ExampleProjects/LogReader/VS_Project/ISLogReaderExample.vcxproj
+++ b/ExampleProjects/LogReader/VS_Project/ISLogReaderExample.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="..\..\..\src\ISDisplay.cpp" />
     <ClCompile Include="..\..\..\src\ISEarth.c" />
     <ClCompile Include="..\..\..\src\ISLogger.cpp" />
+    <ClCompile Include="..\..\..\src\ISLogStats.cpp" />
     <ClCompile Include="..\..\..\src\ISMatrix.c" />
     <ClCompile Include="..\..\..\src\ISPose.c" />
     <ClCompile Include="..\..\..\src\ISSerialPort.cpp" />
@@ -73,6 +74,7 @@
     <ClInclude Include="..\..\..\src\ISDisplay.h" />
     <ClInclude Include="..\..\..\src\ISEarth.h" />
     <ClInclude Include="..\..\..\src\ISLogger.h" />
+    <ClInclude Include="..\..\..\src\ISLogStats.h" />
     <ClInclude Include="..\..\..\src\ISMatrix.h" />
     <ClInclude Include="..\..\..\src\ISPose.h" />
     <ClInclude Include="..\..\..\src\ISSerialPort.h" />

--- a/ExampleProjects/Logger/CMakeLists.txt
+++ b/ExampleProjects/Logger/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(ISLoggerExample
 	../../src/ISFileManager.cpp
 	../../src/ISLogFile.cpp
 	../../src/ISLogger.cpp
+	../../src/ISLogStats.cpp
 	../../src/ISMatrix.c
 	../../src/ISPose.c
 	../../src/ISSerialPort.cpp

--- a/ExampleProjects/Logger/VS_Project/ISLoggerExample.vcxproj
+++ b/ExampleProjects/Logger/VS_Project/ISLoggerExample.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="..\..\..\src\ISFileManager.cpp" />
     <ClCompile Include="..\..\..\src\ISLogFile.cpp" />
     <ClCompile Include="..\..\..\src\ISLogger.cpp" />
+    <ClCompile Include="..\..\..\src\ISLogStats.cpp" />
     <ClCompile Include="..\..\..\src\ISMatrix.c" />
     <ClCompile Include="..\..\..\src\ISPose.c" />
     <ClCompile Include="..\..\..\src\ISSerialPort.cpp" />
@@ -87,6 +88,7 @@
     <ClInclude Include="..\..\..\src\ISLogFileBase.h" />
     <ClInclude Include="..\..\..\src\ISLogFileFactory.h" />
     <ClInclude Include="..\..\..\src\ISLogger.h" />
+    <ClInclude Include="..\..\..\src\ISLogStats.h" />
     <ClInclude Include="..\..\..\src\ISMatrix.h" />
     <ClInclude Include="..\..\..\src\ISPose.h" />
     <ClInclude Include="..\..\..\src\ISSerialPort.h" />

--- a/ExampleProjects/Logger/VS_Project/ISLoggerExample.vcxproj.filters
+++ b/ExampleProjects/Logger/VS_Project/ISLoggerExample.vcxproj.filters
@@ -64,6 +64,9 @@
     <ClCompile Include="..\..\..\src\ISLogger.cpp">
       <Filter>Source Files\SDK</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\ISLogStats.cpp">
+      <Filter>Source Files\SDK</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\src\tinyxml.cpp">
       <Filter>Source Files\SDK</Filter>
     </ClCompile>
@@ -184,6 +187,9 @@
       <Filter>Source Files\SDK</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\ISLogger.h">
+      <Filter>Source Files\SDK</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\ISLogStats.h">
       <Filter>Source Files\SDK</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\tinyxml.h">

--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(cltool
 	../src/ISFileManager.cpp
 	../src/ISLogFile.cpp
 	../src/ISLogger.cpp
+	../src/ISLogStats.cpp
 	../src/ISMatrix.c
 	../src/ISPose.c
 	../src/ISSerialPort.cpp

--- a/cltool/CodeLite_project/CLTool.project
+++ b/cltool/CodeLite_project/CLTool.project
@@ -31,6 +31,8 @@
     <File Name="../../src/ISDisplay.h"/>
     <File Name="../../src/ISLogger.cpp"/>
     <File Name="../../src/ISLogger.h"/>
+    <File Name="../../src/ISLogStats.cpp"/>
+    <File Name="../../src/ISLogStats.h"/>
     <File Name="../../src/ISMatrix.c"/>
     <File Name="../../src/ISMatrix.h"/>
     <File Name="../../src/ISPose.c"/>

--- a/cltool/VS_project/cltool.vcxproj
+++ b/cltool/VS_project/cltool.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="..\..\src\ISFileManager.cpp" />
     <ClCompile Include="..\..\src\ISLogFile.cpp" />
     <ClCompile Include="..\..\src\ISLogger.cpp" />
+    <ClCompile Include="..\..\src\ISLogStats.cpp" />
     <ClCompile Include="..\..\src\ISMatrix.c" />
     <ClCompile Include="..\..\src\ISPose.c" />
     <ClCompile Include="..\..\src\ISSerialPort.cpp" />
@@ -236,6 +237,7 @@
     <ClInclude Include="..\..\src\ISLogFileBase.h" />
     <ClInclude Include="..\..\src\ISLogFileFactory.h" />
     <ClInclude Include="..\..\src\ISLogger.h" />
+    <ClInclude Include="..\..\src\ISLogStats.h" />
     <ClInclude Include="..\..\src\ISMatrix.h" />
     <ClInclude Include="..\..\src\ISPose.h" />
     <ClInclude Include="..\..\src\ISSerialPort.h" />

--- a/cltool/VS_project/cltool.vcxproj.filters
+++ b/cltool/VS_project/cltool.vcxproj.filters
@@ -77,6 +77,9 @@
     <ClCompile Include="..\..\src\ISLogger.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ISLogStats.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ISMatrix.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -223,6 +226,9 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ISLogger.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ISLogStats.h">
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ISMatrix.h">

--- a/python/logInspector/setup.py
+++ b/python/logInspector/setup.py
@@ -51,6 +51,7 @@ ext_modules = [
          '../../src/ISFileManager.cpp',
          '../../src/ISLogFile.cpp',
          '../../src/ISLogger.cpp',
+         '../../src/ISLogStats.cpp',
          '../../src/ISMatrix.c',
          '../../src/ISPose.c',
          '../../src/ISSerialPort.cpp',

--- a/src/DataChunk.cpp
+++ b/src/DataChunk.cpp
@@ -56,14 +56,14 @@ void cDataChunk::SetName(const char name[4])
 }
 
 
-bool cDataChunk::PushBack(uint8_t* d1, int32_t d1Size, uint8_t* d2, int32_t d2Size)
+int32_t cDataChunk::PushBack(uint8_t* d1, int32_t d1Size, uint8_t* d2, int32_t d2Size)
 {
 	// Ensure data will fit
-	int32_t count = d1Size + d2Size;
+	int32_t nBytes = d1Size + d2Size;
 	if (m_dataHead == NULLPTR ||
-		count > GetBuffFree())
+		nBytes > GetBuffFree())
 	{
-		return false;
+		return 0;
 	}
 	if (d1Size > 0)
 	{
@@ -78,7 +78,7 @@ bool cDataChunk::PushBack(uint8_t* d1, int32_t d1Size, uint8_t* d2, int32_t d2Si
 		m_hdr.dataSize += d2Size;
 	}
 	m_hdr.invDataSize = ~m_hdr.dataSize;
-	return true;
+	return nBytes;
 }
 
 

--- a/src/DataChunk.cpp
+++ b/src/DataChunk.cpp
@@ -84,7 +84,7 @@ int32_t cDataChunk::PushBack(uint8_t* d1, int32_t d1Size, uint8_t* d2, int32_t d
 
 uint8_t* cDataChunk::GetDataPtr()
 {
-	return (GetDataSize() == 0 ? NULLPTR : m_dataHead);
+	return (GetDataSize() <= 0 ? NULLPTR : m_dataHead);
 }
 
 

--- a/src/DataChunk.h
+++ b/src/DataChunk.h
@@ -83,7 +83,7 @@ public:
 	bool PopFront(int32_t size);
     int32_t WriteToFile(cISLogFileBase* pFile, int groupNumber = 0); // Returns number of bytes written to file and clears the chunk
 	int32_t ReadFromFile(cISLogFileBase* pFile);
-	bool PushBack(uint8_t* d1, int32_t d1Size, uint8_t* d2 = NULL, int32_t d2Size = 0);
+	int32_t PushBack(uint8_t* d1, int32_t d1Size, uint8_t* d2 = NULL, int32_t d2Size = 0);
 
 	virtual void Clear();
 

--- a/src/DataChunkSorted.cpp
+++ b/src/DataChunkSorted.cpp
@@ -44,7 +44,7 @@ int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_
 	Clear();
 
 	int32_t nBytes = -1;
-	fpos_t restorePos;
+	long int restorePos;
 
 	// Search through all files for chunk with matching DID
 	for (int i = 0; i < pFiles.size(); )
@@ -52,7 +52,7 @@ int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_
 		cISLogFileBase* pFile = pFiles[i];
 
 		// Set backup file pointer
-		pFile->getpos(&restorePos);
+		restorePos = pFile->tell();
 
 		// Search through single file for chunk with matching DID
 		bool allowFileTrim = true;	// This flag indicates there is/are new chunk(s) that should not be trimmed from the restorePos file pointer position. 
@@ -100,7 +100,7 @@ int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_
 
 		if (pFile)
 		{ 	// Restore file pointer if file is still opened
-			pFile->setpos(&restorePos);
+			pFile->seek(restorePos);
 		}
 
 		if (nBytes > 0)
@@ -116,14 +116,15 @@ int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_
 }
 
 
-cISLogFileBase* cSortedDataChunk::TrimFile(int i, vector<cISLogFileBase*>& pFiles, fpos_t &restorePos)
+cISLogFileBase* cSortedDataChunk::TrimFile(int i, vector<cISLogFileBase*>& pFiles, long int &restorePos)
 {
 	cISLogFileBase* pFile = pFiles[i];
 
 	// Move file pointer past old chunks
-	pFile->getpos(&restorePos);
+	//pFile->getpos(&restorePos);
+	restorePos = pFile->tell();
 
-	if (pFile->isEmpty())
+	if (pFile->eof())
 	{	// No more data in file
 		pFile->close();
 

--- a/src/DataChunkSorted.cpp
+++ b/src/DataChunkSorted.cpp
@@ -71,8 +71,8 @@ int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_
 				break;
 			}
 
-			if (m_subHdr.dHdr.id == id)
-			{	// Found chunk
+			if (m_subHdr.dHdr.id == id && GetDataSerNum() >= dataSerNum)
+			{	// Found matching chunk
 				if (allowFileTrim)
 				{	
 					pFile = TrimFile(i, pFiles, restorePos);
@@ -86,8 +86,9 @@ int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_
 
 			if (allowFileTrim)
 			{
-				if (cnkData->dataSerNum < dataSerNum)
-				{	// Move file pointer past old chunks
+				uint32_t readDataSerNum = GetDataSerNum();
+				if (readDataSerNum < dataSerNum || readDataSerNum == UINT_MAX)
+				{	// Move file pointer past old/invalid chunks
 					pFile = TrimFile(i, pFiles, restorePos);
 				}
 				else
@@ -158,4 +159,18 @@ int32_t cSortedDataChunk::ReadAdditionalChunkHeader(cISLogFileBase* pFile)
 int32_t cSortedDataChunk::GetHeaderSize()
 {
     return int32_t((sizeof(sChunkHeader) + sizeof(sChunkSubHeader)));
+}
+
+
+uint32_t cSortedDataChunk::GetDataSerNum()
+{
+	p_cnk_data_t* cnkData = (p_cnk_data_t*)GetDataPtr();
+	if (cnkData == NULLPTR)
+	{
+		return UINT_MAX;
+	}
+	else
+	{
+		return cnkData->dataSerNum;
+	}
 }

--- a/src/DataChunkSorted.cpp
+++ b/src/DataChunkSorted.cpp
@@ -47,7 +47,7 @@ int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_
 	long int restorePos;
 
 	// Search through all files for chunk with matching DID
-	for (int i = 0; i < pFiles.size(); )
+	for (unsigned int i = 0; i < pFiles.size(); )
 	{
 		cISLogFileBase* pFile = pFiles[i];
 
@@ -116,7 +116,7 @@ int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_
 }
 
 
-cISLogFileBase* cSortedDataChunk::TrimFile(int i, vector<cISLogFileBase*>& pFiles, long int &restorePos)
+cISLogFileBase* cSortedDataChunk::TrimFile(unsigned int i, vector<cISLogFileBase*>& pFiles, long int &restorePos)
 {
 	cISLogFileBase* pFile = pFiles[i];
 

--- a/src/DataChunkSorted.cpp
+++ b/src/DataChunkSorted.cpp
@@ -29,6 +29,107 @@ void cSortedDataChunk::Clear()
 }
 
 
+// This function reads the next sorted chunk matching the specified DID from all of the files.  The file pointers are advanced 
+// if the current chunk dataSerNum is older than the current m_dataSerNum.  Files are closed if the last chuch dataSerNum 
+// is older than the current m_dataSerNum.
+// Returns number of bytes read, or -1 for error
+int32_t cSortedDataChunk::ReadFromFiles(vector<cISLogFileBase*>& pFiles, uint32_t id, uint32_t dataSerNum)
+{
+	if (pFiles.size() == 0 || pFiles.front() == NULLPTR)
+	{
+		return -1;
+	}
+
+
+
+
+
+
+	// reset state, prepare to read from file
+	Clear();
+
+	// Read chunk header
+	int32_t nBytes = static_cast<int32_t>(pFile->read(&m_hdr, sizeof(sChunkHeader)));
+
+	// Error checking
+	if (m_hdr.dataSize != ~(m_hdr.invDataSize) || nBytes <= 0)
+	{
+		return -1;
+	}
+
+	// Read additional chunk header
+	nBytes += ReadAdditionalChunkHeader(pFile);
+
+	//     // Error check data size
+	//     if (m_hdr.dataSize > MAX_DATASET_SIZE)
+	//     {
+	//         return -1;
+	//     }
+
+		// Read chunk data
+	m_dataTail += static_cast<int32_t>(pFile->read(m_buffHead, m_hdr.dataSize));
+	nBytes += GetDataSize();
+
+#if LOG_DEBUG_CHUNK_READ
+	static int totalBytes = 0;
+	totalBytes += nBytes;
+	printf("cDataChunk::ReadFromFile %d : %d  -  %x %d  ", totalBytes, nBytes, m_hdr.marker, m_hdr.dataSize);
+	if ((nBytes > 0) && (m_hdr.marker != DATA_CHUNK_MARKER))
+	{
+		printf("MARKER MISMATCH!");
+	}
+	printf("\n");
+#endif
+
+	if (m_hdr.marker == DATA_CHUNK_MARKER && nBytes == static_cast<int>(GetHeaderSize() + m_hdr.dataSize))
+	{
+
+#if LOG_CHUNK_STATS
+		static bool start = true;
+		int totalBytes = 0;
+		for (int id = 0; id < DID_COUNT; id++)
+			if (m_stats[id].total)
+			{
+				if (start)
+				{
+					start = false;
+					logStats("------------------------------------------------\n");
+					logStats("Chunk Data Summary\n");
+					logStats("   ID:  Count:  Sizeof:  Total:\n");
+				}
+				logStats(" %4d%8d    %5d %7d\n", id, m_stats[id].count, m_stats[id].size, m_stats[id].total);
+				totalBytes += m_stats[id].total;
+			}
+		start = true;
+		if (totalBytes)
+		{
+			logStats("------------------------------------------------\n");
+			logStats("                      %8d Total bytes\n", totalBytes);
+		}
+		logStats("\n");
+		logStats("================================================\n");
+		logStats("            *.dat Data Log File\n");
+		logStats("================================================\n");
+		m_Hdr.print();
+#if LOG_CHUNK_STATS==2
+		logStats("------------------------------------------------\n");
+		logStats("Chunk Data\n");
+#endif
+		memset(m_stats, 0, sizeof(m_stats));
+#endif
+
+		return nBytes;
+	}
+	else
+	{
+		Clear();
+
+		// Error reading from file
+		return -1;
+	}
+}
+
+
 int32_t cSortedDataChunk::WriteAdditionalChunkHeader(cISLogFileBase* pFile)
 {
 	// Write sub header to file

--- a/src/DataChunkSorted.h
+++ b/src/DataChunkSorted.h
@@ -50,6 +50,7 @@ public:
 	void Clear() OVERRIDE;
 
 	int32_t ReadFromFiles(vector<cISLogFileBase*> &pFiles, uint32_t id, uint32_t dataSerNum);
+	cISLogFileBase* TrimFile(int i, vector<cISLogFileBase*>& pFiles, fpos_t& restorePos);
 
 	int32_t WriteAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;
 	int32_t ReadAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;

--- a/src/DataChunkSorted.h
+++ b/src/DataChunkSorted.h
@@ -50,7 +50,7 @@ public:
 	void Clear() OVERRIDE;
 
 	int32_t ReadFromFiles(vector<cISLogFileBase*> &pFiles, uint32_t id, uint32_t dataSerNum);
-	cISLogFileBase* TrimFile(int i, vector<cISLogFileBase*>& pFiles, long int& restorePos);
+	cISLogFileBase* TrimFile(unsigned int i, vector<cISLogFileBase*>& pFiles, long int& restorePos);
 
 	int32_t WriteAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;
 	int32_t ReadAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;

--- a/src/DataChunkSorted.h
+++ b/src/DataChunkSorted.h
@@ -50,7 +50,7 @@ public:
 	void Clear() OVERRIDE;
 
 	int32_t ReadFromFiles(vector<cISLogFileBase*> &pFiles, uint32_t id, uint32_t dataSerNum);
-	cISLogFileBase* TrimFile(int i, vector<cISLogFileBase*>& pFiles, fpos_t& restorePos);
+	cISLogFileBase* TrimFile(int i, vector<cISLogFileBase*>& pFiles, long int& restorePos);
 
 	int32_t WriteAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;
 	int32_t ReadAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;

--- a/src/DataChunkSorted.h
+++ b/src/DataChunkSorted.h
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define DATA_CHUNK_SORTED_H
 
 #include <stdint.h>
+#include <vector>
 
 #include "com_manager.h"
 #include "DataChunk.h"
@@ -47,6 +48,8 @@ class cSortedDataChunk : public cDataChunk
 public:
     cSortedDataChunk(const char* name = "EMPT");
 	void Clear() OVERRIDE;
+
+	int32_t ReadFromFiles(vector<cISLogFileBase*> &pFiles, uint32_t id, uint32_t dataSerNum);
 
 	int32_t WriteAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;
 	int32_t ReadAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;

--- a/src/DataChunkSorted.h
+++ b/src/DataChunkSorted.h
@@ -55,6 +55,7 @@ public:
 	int32_t WriteAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;
 	int32_t ReadAdditionalChunkHeader(cISLogFileBase* pFile) OVERRIDE;
 	int32_t GetHeaderSize() OVERRIDE;
+	uint32_t GetDataSerNum();
 
 	sChunkSubHeader m_subHdr;
 };

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -78,14 +78,17 @@ void cDeviceLog::InitDeviceForReading()
 
 bool cDeviceLog::CloseAllFiles()
 {
+	if (m_writeMode)
+	{
 #if 1
-    string str = m_directory + "/stats_SN" + to_string(m_devInfo.serialNumber) + ".txt";
-    m_logStats.WriteToFile(str);
+		string str = m_directory + "/stats_SN" + to_string(m_devInfo.serialNumber) + ".txt";
+		m_logStats.WriteToFile(str);
 #else   // stringstream not working on embedded platform
-	ostringstream serialNumString;
-	serialNumString << m_devInfo.serialNumber;
-    m_logStats.WriteToFile(m_directory + "/stats_SN" + serialNumString.str() + ".txt");
+		ostringstream serialNumString;
+		serialNumString << m_devInfo.serialNumber;
+		m_logStats.WriteToFile(m_directory + "/stats_SN" + serialNumString.str() + ".txt");
 #endif
+	}
     return true;
 }
 

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -23,7 +23,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "DeviceLog.h"
 #include "ISFileManager.h"
-#include "ISLogger.h"
 #include "ISConstants.h"
 #include "ISDataMappings.h"
 #include "ISLogFileFactory.h"
@@ -39,11 +38,11 @@ cDeviceLog::cDeviceLog()
     m_logSize = 0;
     m_fileCount = 0;
     memset(&m_devInfo, 0, sizeof(dev_info_t));
-    m_logStats = new cLogStats;
 	m_altClampToGround = true;
 	m_showTracks = true;
 	m_showPointTimestamps = true;
 	m_pointUpdatePeriodSec = 1.0f;
+	m_logStats.Clear();
 }
 
 cDeviceLog::~cDeviceLog()
@@ -51,7 +50,6 @@ cDeviceLog::~cDeviceLog()
     // Close open files
     CloseISLogFile(m_pFile);
     CloseAllFiles();
-    delete m_logStats;
 }
 
 void cDeviceLog::InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize)
@@ -64,6 +62,7 @@ void cDeviceLog::InitDeviceForWriting(int pHandle, std::string timestamp, std::s
 	m_maxFileSize = maxFileSize;
 	m_logSize = 0;
 	m_writeMode = true;
+	m_logStats.Clear();
 }
 
 
@@ -73,6 +72,7 @@ void cDeviceLog::InitDeviceForReading()
 	m_logSize = 0;
 	m_fileCount = 0;
 	m_writeMode = false;
+	m_logStats.Clear();
 }
 
 
@@ -80,13 +80,12 @@ bool cDeviceLog::CloseAllFiles()
 {
 #if 1
     string str = m_directory + "/stats_SN" + to_string(m_devInfo.serialNumber) + ".txt";
-    m_logStats->WriteToFile(str);
+    m_logStats.WriteToFile(str);
 #else   // stringstream not working on embedded platform
 	ostringstream serialNumString;
 	serialNumString << m_devInfo.serialNumber;
-    m_logStats->WriteToFile(m_directory + "/stats_SN" + serialNumString.str() + ".txt");
+    m_logStats.WriteToFile(m_directory + "/stats_SN" + serialNumString.str() + ".txt");
 #endif
-    m_logStats->Clear();
     return true;
 }
 
@@ -110,7 +109,7 @@ bool cDeviceLog::SaveData(p_data_hdr_t *dataHdr, const uint8_t* dataBuf)
     if (dataHdr != NULL)
     {
         double timestamp = cISDataMappings::GetTimestamp(dataHdr, dataBuf);
-        m_logStats->LogDataAndTimestamp(dataHdr->id, timestamp);
+        m_logStats.LogDataAndTimestamp(dataHdr->id, timestamp);
 	}
     return true;
 }
@@ -271,7 +270,7 @@ void cDeviceLog::OnReadData(p_data_t* data)
     if (data != NULL)
     {
         double timestamp = cISDataMappings::GetTimestamp(&data->hdr, data->buf);
-        m_logStats->LogDataAndTimestamp(data->hdr.id, timestamp);
+        m_logStats.LogDataAndTimestamp(data->hdr.id, timestamp);
     }
 }
 

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -80,14 +80,8 @@ bool cDeviceLog::CloseAllFiles()
 {
 	if (m_writeMode)
 	{
-#if 1
 		string str = m_directory + "/stats_SN" + to_string(m_devInfo.serialNumber) + ".txt";
 		m_logStats.WriteToFile(str);
-#else   // stringstream not working on embedded platform
-		ostringstream serialNumString;
-		serialNumString << m_devInfo.serialNumber;
-		m_logStats.WriteToFile(m_directory + "/stats_SN" + serialNumString.str() + ".txt");
-#endif
 	}
     return true;
 }

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -63,6 +63,7 @@ void cDeviceLog::InitDeviceForWriting(int pHandle, std::string timestamp, std::s
 	m_maxDiskSpace = maxDiskSpace;
 	m_maxFileSize = maxFileSize;
 	m_logSize = 0;
+	m_writeMode = true;
 }
 
 
@@ -71,6 +72,7 @@ void cDeviceLog::InitDeviceForReading()
 	m_fileSize = 0;
 	m_logSize = 0;
 	m_fileCount = 0;
+	m_writeMode = false;
 }
 
 

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <string.h>
 #include <vector>
 #include "ISLogFileBase.h"
+#include "ISLogStats.h"
 
 extern "C"
 {
@@ -30,7 +31,6 @@ using namespace std;
 #define IS_LOG_FILE_PREFIX_LENGTH 6
 #define IS_LOG_TIMESTAMP_LENGTH 15
 
-class cLogStats;
 
 class cDeviceLog
 {
@@ -87,7 +87,7 @@ protected:
 	double                  m_pointUpdatePeriodSec;
 
 private:
-    cLogStats*              m_logStats;
+    cLogStats               m_logStats;
 };
 
 #endif // DEVICE_LOG_H

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -72,6 +72,7 @@ protected:
 	string                  m_directory;
 	string                  m_timeStamp;
 	string                  m_fileName;
+	bool                    m_writeMode;	// Logger initialized for writting
 	dev_info_t              m_devInfo;
 	int                     m_pHandle;
 	uint64_t                m_fileSize;

--- a/src/DeviceLogCSV.cpp
+++ b/src/DeviceLogCSV.cpp
@@ -230,7 +230,7 @@ bool cDeviceLogCSV::SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf)
 	}
 
 	// Write date to file
-    int nBytes = m_csv.WriteDataToFile(++m_nextId, log.pFile, *dataHdr, dataBuf);
+    int nBytes = m_csv.WriteDataToFile(m_nextId++, log.pFile, *dataHdr, dataBuf);
 	if (ferror(log.pFile) != 0)
 	{
 		return false;

--- a/src/DeviceLogSerial.cpp
+++ b/src/DeviceLogSerial.cpp
@@ -30,6 +30,7 @@ using namespace std;
 void cDeviceLogSerial::InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize)
 {
 //     m_chunk.Init(chunkSize);
+	m_chunk.Clear();
 	m_chunk.m_hdr.pHandle = pHandle;
 
 	cDeviceLog::InitDeviceForWriting(pHandle, timestamp, directory, maxDiskSpace, maxFileSize);

--- a/src/DeviceLogSerial.cpp
+++ b/src/DeviceLogSerial.cpp
@@ -41,8 +41,10 @@ bool cDeviceLogSerial::CloseAllFiles()
 {
     cDeviceLog::CloseAllFiles();
 
-	// Write any remaining chunk data to file
-	WriteChunkToFile();
+	if (m_writeMode)
+	{	// Write any remaining chunk data to file
+		WriteChunkToFile();
+	}
 
 	// Close file
 	CloseISLogFile(m_pFile);

--- a/src/DeviceLogSorted.cpp
+++ b/src/DeviceLogSorted.cpp
@@ -82,7 +82,7 @@ void cDeviceLogSorted::InitDeviceForReading()
 bool cDeviceLogSorted::OpenAllReadFiles()
 {
 	// Close files if open
-	for (int i = 0; i < m_pFiles.size(); i++)
+	for (unsigned int i = 0; i < m_pFiles.size(); i++)
 	{	
 		CloseISLogFile(m_pFiles[i]);
 	}
@@ -131,7 +131,7 @@ bool cDeviceLogSorted::CloseAllFiles()
 	CloseISLogFile(m_pFile);
 
 	// Close file pointer array used for reading
-	for (int i = 0; i < m_pFiles.size(); i++)
+	for (unsigned int i = 0; i < m_pFiles.size(); i++)
 	{
 		CloseISLogFile(m_pFiles[i]);
 	}

--- a/src/DeviceLogSorted.cpp
+++ b/src/DeviceLogSorted.cpp
@@ -28,10 +28,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISDataMappings.h"
 #include "DeviceLogSorted.h"
 
-#define LOG_DEBUG_PRINT_CHUNK_SAVE		1
-#define LOG_DEBUG_PRINT_CHUNK_READ		1
+#define LOG_DEBUG_PRINT_CHUNK_SAVE		0
+#define LOG_DEBUG_PRINT_CHUNK_READ		0
 #define LOG_DEBUG_PRINT_DID_SAVE		0
 #define LOG_DEBUG_PRINT_DID_READ		0
+
 
 cDeviceLogSorted::cDeviceLogSorted()
 {
@@ -246,13 +247,6 @@ bool cDeviceLogSorted::WriteChunkToFile(uint32_t id)
 #if LOG_DEBUG_PRINT_CHUNK_SAVE
 	p_cnk_data_t* cnkData = (p_cnk_data_t*)(m_chunks[id]->GetDataPtr());
 	printf("sorted chunk save:   DID:%3d  dCount: %5d  nBytes: %6d   dataSN: %2d\n", m_chunks[id]->m_subHdr.dHdr.id, m_chunks[id]->m_subHdr.dCount, nBytes, cnkData->dataSerNum);
-
-	//if (m_dataSerNum >= 1250)
-	if (m_dataSerNum >= 2500)
-	{
-		int j = 0;
-		j++;
-	}
 #endif
 
 	if (nBytes != 0)
@@ -317,15 +311,6 @@ tryAgain:
 	uint32_t minSerialNum = UINT_MAX;
     cSortedDataChunk *chunk;
 	p_cnk_data_t* cnkData;
-
-	//if (m_dataSerNum >= 158209)
-extern int g_copyReadCount;
-	if (1250 == g_copyReadCount)
-	//if (m_dataSerNum != g_copyReadCount)
-	{
-		int j = 0;
-		j++;
-	}
 
 	// while there is data in any chunk, find the chunk with the next id
 	for (uint32_t id = 1; id < DID_COUNT; id++)
@@ -495,12 +480,6 @@ bool cDeviceLogSorted::ReadChunkFromFiles(cSortedDataChunk *chunk, uint32_t id)
 #if LOG_DEBUG_PRINT_CHUNK_READ
 	p_cnk_data_t* cnkData = (p_cnk_data_t*)(chunk->GetDataPtr());
 	printf("sorted chunk read:   DID:%3d  dCount: %5d  nBytes: %6d   dataSN: %2d\n", chunk->m_subHdr.dHdr.id, chunk->m_subHdr.dCount, nBytes-sizeof(sChunkHeader)-sizeof(sChunkSubHeader), cnkData->dataSerNum);
-
-	if (m_dataSerNum >= 2500)
-	{
-		int j = 0;
-		j++;
-	}
 #endif
 
 	// Validate chunk: non-zero size and is sorted type

--- a/src/DeviceLogSorted.h
+++ b/src/DeviceLogSorted.h
@@ -30,6 +30,7 @@ public:
 
 	void InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
 	void InitDeviceForReading() OVERRIDE;
+	bool OpenAllReadFiles();
 	bool CloseAllFiles() OVERRIDE;
     bool SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf) OVERRIDE;
 	p_data_t* ReadData() OVERRIDE;
@@ -39,13 +40,16 @@ public:
     cSortedDataChunk *m_chunks[DID_COUNT];
 
 	p_data_t* SerializeDataFromChunks();
-	bool ReadAllChunksFromFile();
-	bool ReadChunkFromFile(cSortedDataChunk *chunk);
+	bool ReadNextChunkFromFiles(uint32_t id);
+	bool ReadChunkFromFiles(cSortedDataChunk *chunk, uint32_t id);
 
 	uint32_t m_dataSerNum;
 	uint32_t m_lastSerNum;
 	p_data_t m_data;
 	cSortedDataChunk m_readChunk;
+
+	vector<cISLogFileBase*> m_pFiles;
+
 };
 
 #endif // DEVICE_LOG_SORTED_H

--- a/src/DeviceLogSorted.h
+++ b/src/DeviceLogSorted.h
@@ -38,10 +38,12 @@ public:
 	string LogFileExtention() OVERRIDE { return string(".sdat"); }
 
     cSortedDataChunk *m_chunks[DID_COUNT];
+	bool m_chunksAvailable[DID_COUNT];
 
 	p_data_t* SerializeDataFromChunks();
 	bool ReadNextChunkFromFiles(uint32_t id);
 	bool ReadChunkFromFiles(cSortedDataChunk *chunk, uint32_t id);
+	bool WriteChunkToFile(uint32_t id);
 
 	uint32_t m_dataSerNum;
 	uint32_t m_lastSerNum;

--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -427,6 +427,9 @@ extern void vPortFree(void* pv);
 
 #endif
 
+#ifndef UINT_MAX
+#define UINT_MAX      0xffffffff
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 // Time

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -104,12 +104,14 @@ static void PopulateSizeMappings(uint32_t sizeMap[DID_COUNT])
 	memset(sizeMap, 0, sizeof(uint32_t) * DID_COUNT);
 
 	sizeMap[DID_DEV_INFO] = sizeof(dev_info_t);
+	sizeMap[DID_SYS_FAULT] = sizeof(system_fault_t);
 	sizeMap[DID_MAGNETOMETER] = sizeof(magnetometer_t);
 	sizeMap[DID_BAROMETER] = sizeof(barometer_t);
 	sizeMap[DID_PREINTEGRATED_IMU] = sizeof(preintegrated_imu_t);
 	sizeMap[DID_WHEEL_ENCODER] = sizeof(wheel_encoder_t);
 	sizeMap[DID_GROUND_VEHICLE] = sizeof(ground_vehicle_t);
 	sizeMap[DID_SYS_CMD] = sizeof(system_command_t);
+	sizeMap[DID_RMC] = sizeof(rmc_t);
 	sizeMap[DID_INS_1] = sizeof(ins_1_t);
 	sizeMap[DID_INS_2] = sizeof(ins_2_t);
 	sizeMap[DID_INS_3] = sizeof(ins_3_t);
@@ -139,6 +141,7 @@ static void PopulateSizeMappings(uint32_t sizeMap[DID_COUNT])
 	sizeMap[DID_DUAL_IMU_RAW_MAG] = sizeof(imu_mag_t);
 	sizeMap[DID_CAN_CONFIG] = sizeof(can_config_t);
 	sizeMap[DID_DEBUG_ARRAY] = sizeof(debug_array_t);
+	sizeMap[DID_IO] = sizeof(io_t);
 
 	sizeMap[DID_EVB_STATUS] = sizeof(evb_status_t);
 	sizeMap[DID_EVB_FLASH_CFG] = sizeof(evb_flash_cfg_t);
@@ -239,6 +242,34 @@ static void PopulateDeviceInfoMappings(map_name_to_info_t mappings[DID_COUNT], u
     ASSERT_SIZE(totalSize);
 }
 
+static void PopulateIOMappings(map_name_to_info_t mappings[DID_COUNT])
+{
+	typedef io_t MAP_TYPE;
+	map_name_to_info_t& m = mappings[DID_IO];
+	uint32_t totalSize = 0;
+	ADD_MAP(m, totalSize, "timeOfWeekMs", timeOfWeekMs, 0, DataTypeUInt32, uint32_t, 0);
+	ADD_MAP(m, totalSize, "gpioStatus", gpioStatus, 0, DataTypeUInt32, uint32_t, 0);
+
+	ASSERT_SIZE(totalSize);
+}
+
+static void PopulateSysFaultMappings(map_name_to_info_t mappings[DID_COUNT])
+{
+	typedef system_fault_t MAP_TYPE;
+	map_name_to_info_t& m = mappings[DID_SYS_FAULT];
+	uint32_t totalSize = 0;
+	ADD_MAP(m, totalSize, "status", status, 0, DataTypeUInt32, uint32_t, 0);
+	ADD_MAP(m, totalSize, "g1Task", g1Task, 0, DataTypeUInt32, uint32_t, 0);
+	ADD_MAP(m, totalSize, "g2FileNum", g2FileNum, 0, DataTypeUInt32, uint32_t, 0);
+	ADD_MAP(m, totalSize, "g3LineNum", g3LineNum, 0, DataTypeUInt32, uint32_t, 0);
+	ADD_MAP(m, totalSize, "g4", g4, 0, DataTypeUInt32, uint32_t, 0);
+	ADD_MAP(m, totalSize, "g5Lr", g5Lr, 0, DataTypeUInt32, uint32_t, 0);
+	ADD_MAP(m, totalSize, "pc", pc, 0, DataTypeUInt32, uint32_t, 0);
+	ADD_MAP(m, totalSize, "psr", psr, 0, DataTypeUInt32, uint32_t, 0);
+
+	ASSERT_SIZE(totalSize);
+}
+
 static void PopulateIMUMappings(map_name_to_info_t mappings[DID_COUNT], uint32_t dataId)
 {
 	typedef dual_imu_t MAP_TYPE;
@@ -310,6 +341,17 @@ static void PopulateSysSensorsMappings(map_name_to_info_t mappings[DID_COUNT])
     ADD_MAP(m, totalSize, "ana4", ana1, 0, DataTypeFloat, float, 0);
 
     ASSERT_SIZE(totalSize);
+}
+
+static void PopulateRMCMappings(map_name_to_info_t mappings[DID_COUNT])
+{
+	typedef rmc_t MAP_TYPE;
+	map_name_to_info_t& m = mappings[DID_RMC];
+	uint32_t totalSize = 0;
+	ADD_MAP(m, totalSize, "bits", bits, 0, DataTypeUInt64, uint64_t, DataFlagsDisplayHex);
+	ADD_MAP(m, totalSize, "options", options, 0, DataTypeUInt32, uint32_t, DataFlagsDisplayHex);
+
+	ASSERT_SIZE(totalSize);
 }
 
 static void PopulateINS1Mappings(map_name_to_info_t mappings[DID_COUNT])
@@ -2105,10 +2147,12 @@ cISDataMappings::cISDataMappings()
 {
 	PopulateSizeMappings(m_lookupSize);
 	PopulateDeviceInfoMappings(m_lookupInfo, DID_DEV_INFO);
-    PopulateIMUMappings(m_lookupInfo, DID_DUAL_IMU);
+	PopulateSysFaultMappings(m_lookupInfo);
+	PopulateIMUMappings(m_lookupInfo, DID_DUAL_IMU);
     PopulateIMUMappings(m_lookupInfo, DID_DUAL_IMU_RAW);
 	PopulateSysParamsMappings(m_lookupInfo);
 	PopulateSysSensorsMappings(m_lookupInfo);
+	PopulateRMCMappings(m_lookupInfo);
 	PopulateINS1Mappings(m_lookupInfo);
 	PopulateINS2Mappings(m_lookupInfo);
 	PopulateINS3Mappings(m_lookupInfo);
@@ -2140,6 +2184,7 @@ cISDataMappings::cISDataMappings()
 	PopulateEvbFlashCfgMappings(m_lookupInfo);
 	PopulateDebugArrayMappings(m_lookupInfo, DID_EVB_DEBUG_ARRAY);
 	PopulateDeviceInfoMappings(m_lookupInfo, DID_EVB_DEV_INFO);
+	PopulateIOMappings(m_lookupInfo);
 
 #if defined(INCLUDE_LUNA_DATA_SETS)
     PopulateEvbLunaFlashCfgMappings(m_lookupInfo);

--- a/src/ISLogFile.cpp
+++ b/src/ISLogFile.cpp
@@ -161,3 +161,42 @@ std::size_t cISLogFile::read(void* bytes, std::size_t len)
         return 0;
     }
 }
+
+
+int cISLogFile::seek(long int offset, int origin)
+{
+    if (m_file)
+    {
+        return fseek(m_file, offset, origin);
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+
+int cISLogFile::getpos(fpos_t* pos)
+{
+    if (m_file)
+    {
+        return fgetpos(m_file, pos);
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+
+int cISLogFile::setpos(fpos_t* pos)
+{
+    if (m_file)
+    {
+        return fsetpos(m_file, pos);
+    }
+    else
+    {
+        return 0;
+    }
+}

--- a/src/ISLogFile.cpp
+++ b/src/ISLogFile.cpp
@@ -162,7 +162,8 @@ std::size_t cISLogFile::read(void* bytes, std::size_t len)
     }
 }
 
-
+// Sets the position indicator associated with the file stream to a new position. 
+// Values for origin: SEEK_SET = from beginning, SEEK_CUR = current position, SEEK_END = end of file
 int cISLogFile::seek(long int offset, int origin)
 {
     if (m_file)
@@ -175,7 +176,7 @@ int cISLogFile::seek(long int offset, int origin)
     }
 }
 
-
+// Retrieves the current position in the stream.
 int cISLogFile::getpos(fpos_t* pos)
 {
     if (m_file)
@@ -188,7 +189,7 @@ int cISLogFile::getpos(fpos_t* pos)
     }
 }
 
-
+// Restores the current position in the stream to pos
 int cISLogFile::setpos(fpos_t* pos)
 {
     if (m_file)
@@ -200,3 +201,16 @@ int cISLogFile::setpos(fpos_t* pos)
         return 0;
     }
 }
+
+int cISLogFile::isEmpty()
+{
+    if (m_file)
+    {
+        return feof(m_file);
+    }
+    else
+    {
+        return 0;
+    }
+}
+

--- a/src/ISLogFile.cpp
+++ b/src/ISLogFile.cpp
@@ -162,8 +162,8 @@ std::size_t cISLogFile::read(void* bytes, std::size_t len)
     }
 }
 
-// Sets the position indicator associated with the file stream to a new position. 
-// Values for origin: SEEK_SET = from beginning, SEEK_CUR = current position, SEEK_END = end of file
+// Sets the position indicator associated with the file stream to a new position relative to 
+// origin: SEEK_SET = beginning of file, SEEK_CUR = current position, SEEK_END = end of file
 int cISLogFile::seek(long int offset, int origin)
 {
     if (m_file)
@@ -176,12 +176,12 @@ int cISLogFile::seek(long int offset, int origin)
     }
 }
 
-// Retrieves the current position in the stream.
-int cISLogFile::getpos(fpos_t* pos)
+// Returns the byte offset from the start of the file.
+long int cISLogFile::tell()
 {
     if (m_file)
     {
-        return fgetpos(m_file, pos);
+        return ftell(m_file);
     }
     else
     {
@@ -189,20 +189,7 @@ int cISLogFile::getpos(fpos_t* pos)
     }
 }
 
-// Restores the current position in the stream to pos
-int cISLogFile::setpos(fpos_t* pos)
-{
-    if (m_file)
-    {
-        return fsetpos(m_file, pos);
-    }
-    else
-    {
-        return 0;
-    }
-}
-
-int cISLogFile::isEmpty()
+int cISLogFile::eof()
 {
     if (m_file)
     {

--- a/src/ISLogFile.h
+++ b/src/ISLogFile.h
@@ -32,9 +32,8 @@ public:
     int getch() OVERRIDE;
     std::size_t read(void* bytes, std::size_t len) OVERRIDE;
     int seek(long int offset, int origin = SEEK_CUR) OVERRIDE;
-    int getpos(fpos_t* pos) OVERRIDE;
-    int setpos(fpos_t* pos) OVERRIDE;
-    int isEmpty() OVERRIDE;
+    long int tell() OVERRIDE;
+    int eof() OVERRIDE;
 
 private:
     FILE *m_file;

--- a/src/ISLogFile.h
+++ b/src/ISLogFile.h
@@ -31,6 +31,9 @@ public:
 
     int getch() OVERRIDE;
     std::size_t read(void* bytes, std::size_t len) OVERRIDE;
+    int seek(long int offset, int origin = SEEK_CUR) OVERRIDE;
+    int getpos(fpos_t* pos) OVERRIDE;
+    int setpos(fpos_t* pos) OVERRIDE;
 
 private:
     FILE *m_file;

--- a/src/ISLogFile.h
+++ b/src/ISLogFile.h
@@ -34,6 +34,7 @@ public:
     int seek(long int offset, int origin = SEEK_CUR) OVERRIDE;
     int getpos(fpos_t* pos) OVERRIDE;
     int setpos(fpos_t* pos) OVERRIDE;
+    int isEmpty() OVERRIDE;
 
 private:
     FILE *m_file;

--- a/src/ISLogFileBase.h
+++ b/src/ISLogFileBase.h
@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #define LOG_DEBUG_GEN			(PLATFORM_IS_EMBEDDED==0)		
 #define LOG_DEBUG_FILE_WRITE	0		// Enable chunk debug printout
-#define LOG_DEBUG_FILE_READ		0		// 
+#define LOG_DEBUG_FILE_READ		1		// 
 #define LOG_DEBUG_CHUNK_WRITE	0		// Enable file debug printout
 #define LOG_DEBUG_CHUNK_READ	0
 #define LOG_CHUNK_STATS			0		// 0 = disabled, 1 = summary, 2 = detailed
@@ -45,6 +45,9 @@ public:
 
     virtual int getch() = 0;
     virtual std::size_t read(void* bytes, std::size_t len) = 0;
+    virtual int seek(long int offset, int origin = SEEK_CUR);
+    virtual int getpos(fpos_t* pos);
+    virtual int setpos(fpos_t* pos);
 };
 
 

--- a/src/ISLogFileBase.h
+++ b/src/ISLogFileBase.h
@@ -45,9 +45,11 @@ public:
 
     virtual int getch() = 0;
     virtual std::size_t read(void* bytes, std::size_t len) = 0;
-    virtual int seek(long int offset, int origin = SEEK_CUR);
-    virtual int getpos(fpos_t* pos);
-    virtual int setpos(fpos_t* pos);
+    virtual int seek(long int offset, int origin = SEEK_CUR) = 0;
+    virtual int getpos(fpos_t* pos) = 0;
+    virtual int setpos(fpos_t* pos) = 0;
+    virtual int isEmpty() = 0;
+
 };
 
 

--- a/src/ISLogFileBase.h
+++ b/src/ISLogFileBase.h
@@ -19,9 +19,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <string>
 
 #define LOG_DEBUG_GEN			(PLATFORM_IS_EMBEDDED==0)		
-#define LOG_DEBUG_FILE_WRITE	1		// Enable chunk debug printout
-#define LOG_DEBUG_FILE_READ		1		// 
-#define LOG_DEBUG_CHUNK_WRITE	0		// Enable file debug printout
+#define LOG_DEBUG_FILE_WRITE	0		// Enable file debug printout
+#define LOG_DEBUG_FILE_READ		0		// 
+#define LOG_DEBUG_CHUNK_WRITE	0		// Enable chunk debug printout
 #define LOG_DEBUG_CHUNK_READ	0
 #define LOG_CHUNK_STATS			0		// 0 = disabled, 1 = summary, 2 = detailed
 

--- a/src/ISLogFileBase.h
+++ b/src/ISLogFileBase.h
@@ -45,10 +45,9 @@ public:
 
     virtual int getch() = 0;
     virtual std::size_t read(void* bytes, std::size_t len) = 0;
-    virtual int seek(long int offset, int origin = SEEK_CUR) = 0;
-    virtual int getpos(fpos_t* pos) = 0;
-    virtual int setpos(fpos_t* pos) = 0;
-    virtual int isEmpty() = 0;
+    virtual int seek(long int offset, int origin = SEEK_SET) = 0;   // origin = SEEK_SET means offset is from start of file
+    virtual long int tell() = 0;
+    virtual int eof() = 0;		// returns non-zero at end of file
 
 };
 

--- a/src/ISLogFileBase.h
+++ b/src/ISLogFileBase.h
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <string>
 
 #define LOG_DEBUG_GEN			(PLATFORM_IS_EMBEDDED==0)		
-#define LOG_DEBUG_FILE_WRITE	0		// Enable chunk debug printout
+#define LOG_DEBUG_FILE_WRITE	1		// Enable chunk debug printout
 #define LOG_DEBUG_FILE_READ		1		// 
 #define LOG_DEBUG_CHUNK_WRITE	0		// Enable file debug printout
 #define LOG_DEBUG_CHUNK_READ	0

--- a/src/ISLogStats.cpp
+++ b/src/ISLogStats.cpp
@@ -1,0 +1,193 @@
+/*
+MIT LICENSE
+
+Copyright (c) 2014-2021 Inertial Sense, Inc. - http://inertialsense.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <string>
+
+#include "ISLogFile.h"
+#include "ISLogFileFactory.h"
+#include "ISDataMappings.h"
+#include "ISLogStats.h"
+
+using namespace std;
+
+
+cLogStatDataId::cLogStatDataId()
+{
+    count = 0;
+    errorCount = 0;
+    averageTimeDelta = 0.0;
+    totalTimeDelta = 0.0;
+    lastTimestamp = 0.0;
+    lastTimestampDelta = 0.0;
+    maxTimestampDelta = 0.0;
+    minTimestampDelta = 1.0E6;
+    timestampDeltaCount = 0;
+    timestampDropCount = 0;
+}
+
+void cLogStatDataId::LogTimestamp(double timestamp)
+{
+    // check for corrupt data
+    if (_ISNAN(timestamp) || timestamp < 0.0 || timestamp > 999999999999.0)
+    {
+        return;
+    }
+    else if (lastTimestamp > 0.0)
+    {
+        double delta = fabs(timestamp - lastTimestamp);
+        minTimestampDelta = _MIN(delta, minTimestampDelta);
+        maxTimestampDelta = _MAX(delta, maxTimestampDelta);
+        totalTimeDelta += delta;
+        averageTimeDelta = (totalTimeDelta / (double)++timestampDeltaCount);
+        if (lastTimestampDelta != 0.0 && (fabs(delta - lastTimestampDelta) > (lastTimestampDelta * 0.5)))
+        {
+            timestampDropCount++;
+        }
+        lastTimestampDelta = delta;
+    }
+    lastTimestamp = timestamp;
+}
+
+void cLogStatDataId::Printf()
+{
+
+#if !PLATFORM_IS_EMBEDDED
+
+    printf(" Count: %llu,   Errors: %llu\r\n", (unsigned long long)count, (unsigned long long)errorCount);
+    printf(" Time delta: (ave, min, max) %f, %f, %f\r\n", averageTimeDelta, minTimestampDelta, maxTimestampDelta);
+    printf(" Time delta drop: %llu\r\n", (unsigned long long)timestampDropCount);
+
+#endif
+
+}
+
+cLogStats::cLogStats()
+{
+    Clear();
+}
+
+void cLogStats::Clear()
+{
+    memset(dataIdStats, 0, sizeof(dataIdStats));
+    for (uint32_t id = 0; id < DID_COUNT; id++)
+    {
+        dataIdStats[id].minTimestampDelta = 1.0E6;
+    }
+    errorCount = 0;
+    count = 0;
+}
+
+void cLogStats::LogError(const p_data_hdr_t* hdr)
+{
+    errorCount++;
+    if (hdr != NULL && hdr->id < DID_COUNT)
+    {
+        cLogStatDataId& d = dataIdStats[hdr->id];
+        d.errorCount++;
+    }
+}
+
+void cLogStats::LogData(uint32_t dataId)
+{
+    if (dataId < DID_COUNT)
+    {
+        cLogStatDataId& d = dataIdStats[dataId];
+        d.count++;
+        count++;
+    }
+}
+
+void cLogStats::LogDataAndTimestamp(uint32_t dataId, double timestamp)
+{
+    if (dataId < DID_COUNT)
+    {
+        cLogStatDataId& d = dataIdStats[dataId];
+        d.count++;
+        count++;
+        if (timestamp != 0.0)
+        {
+            d.LogTimestamp(timestamp);
+        }
+    }
+}
+
+void cLogStats::Printf()
+{
+
+#if !PLATFORM_IS_EMBEDDED
+
+    printf("LOG STATS\r\n");
+    printf("----------");
+    printf("Count: %llu,   Errors: %llu\r\n", (unsigned long long)count, (unsigned long long)errorCount);
+    for (uint32_t id = 0; id < DID_COUNT; id++)
+    {
+        if (dataIdStats[id].count != 0)
+        {
+            printf(" DID: %d\r\n", id);
+            dataIdStats[id].Printf();
+            printf("\r\n");
+        }
+    }
+
+#endif
+
+}
+
+void cLogStats::WriteToFile(const string& file_name)
+{
+    if (count != 0)
+    {
+        // flush log stats to disk
+#if 1
+        cISLogFileBase* statsFile = CreateISLogFile(file_name, "wb");
+        statsFile->lprintf("Total count: %d,   Total errors: \r\n\r\n", count, errorCount);
+        for (uint32_t id = 0; id < DID_COUNT; id++)
+        {
+            cLogStatDataId& stat = dataIdStats[id];
+            if (stat.count == 0 && stat.errorCount == 0)
+            {   // Exclude zero count stats
+                continue;
+            }
+
+            statsFile->lprintf("Data Id: %d (%s)\r\n", id, cISDataMappings::GetDataSetName(id));
+            statsFile->lprintf("Count: %d,   Errors: %d\r\n", stat.count, stat.errorCount);
+            statsFile->lprintf("Timestamp Delta (ave, min, max): %.4f, %.4f, %.4f\r\n", stat.averageTimeDelta, stat.minTimestampDelta, stat.maxTimestampDelta);
+            statsFile->lprintf("Timestamp Drops: %d\r\n", stat.timestampDropCount);
+            statsFile->lprintf("\r\n");
+        }
+        CloseISLogFile(statsFile);
+#else
+        // The following code doesn't work on the EVB-2.  Converting stringstream to a string causes the system to hang.
+        CONST_EXPRESSION char CRLF[] = "\r\n";
+        stringstream stats;
+        stats << fixed << setprecision(6);
+        stats << "Total count: " << count << ",   Total errors: " << errorCount << CRLF << CRLF;
+        for (uint32_t id = 0; id < DID_COUNT; id++)
+        {
+            cLogStatDataId& stat = dataIdStats[id];
+            if (stat.count == 0 && stat.errorCount == 0)
+            {   // Exclude zero count stats
+                continue;
+            }
+
+            stats << "Data Id: " << id << " (" << cISDataMappings::GetDataSetName(id) << ")" << CRLF;
+            stats << "Count: " << stat.count << ",   Errors: " << stat.errorCount << CRLF;
+            stats << "Timestamp Delta (ave, min, max): " << stat.averageTimeDelta << ", " << stat.minTimestampDelta << ", " << stat.maxTimestampDelta << CRLF;
+            stats << "Timestamp Drops: " << stat.timestampDropCount << CRLF;
+            stats << CRLF;
+        }
+        cISLogFileBase* statsFile = CreateISLogFile(file_name, "wb");
+        statsFile->puts(stats.str().c_str());
+        CloseISLogFile(statsFile);
+#endif
+    }
+}

--- a/src/ISLogStats.h
+++ b/src/ISLogStats.h
@@ -1,0 +1,61 @@
+/*
+MIT LICENSE
+
+Copyright (c) 2014-2021 Inertial Sense, Inc. - http://inertialsense.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef IS_LOG_STATS_H
+#define IS_LOG_STATS_H
+
+#include <string>
+#include <cstdint>
+
+#include "data_sets.h"
+#include "ISComm.h"
+
+
+
+class cLogStatDataId
+{
+public:
+	uint64_t count; // count for this data id
+	uint64_t errorCount; // error count for this data id
+	double averageTimeDelta; // average time delta for the data id
+	double totalTimeDelta; // sum of all time deltas
+	double lastTimestamp;
+	double lastTimestampDelta;
+	double minTimestampDelta;
+	double maxTimestampDelta;
+	uint64_t timestampDeltaCount;
+	uint64_t timestampDropCount; // count of delta timestamps > 50% different from previous delta timestamp
+
+	cLogStatDataId();
+	void LogTimestamp(double timestamp);
+	void Printf();
+};
+
+class cLogStats
+{
+public:
+	cLogStatDataId dataIdStats[DID_COUNT];
+	uint64_t count; // count of all data ids
+	uint64_t errorCount; // total error count
+
+	cLogStats();
+	void Clear();
+	void LogError(const p_data_hdr_t* hdr);
+	void LogData(uint32_t dataId);
+	void LogDataAndTimestamp(uint32_t dataId, double timestamp);
+	void Printf();
+	void WriteToFile(const std::string& fileName);
+};
+
+
+
+#endif // IS_LOG_STATS_H

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -434,6 +434,10 @@ p_data_t* cISLogger::ReadNextData(unsigned int& device)
 		{
 			++device;
 		}
+		else
+		{
+			return data;
+		}
 	}
 	return NULL;
 }
@@ -541,6 +545,8 @@ const dev_info_t* cISLogger::GetDeviceInfo( unsigned int device )
 	return m_devices[device]->GetDeviceInfo();
 }
 
+int g_readCount = 0;
+
 bool cISLogger::CopyLog(cISLogger& log, const string& timestamp, const string &outputDir, eLogType logType, float maxLogSpacePercent, uint32_t maxFileSize, bool useSubFolderTimestamp)
 {
 	m_logStats->Clear();
@@ -585,8 +591,20 @@ bool cISLogger::CopyLog(cISLogger& log, const string& timestamp, const string &o
 				}
 			}
 
+			if (data->hdr.id == 5)
+			{
+				double timestamp1 = cISDataMappings::GetTimestamp(&(data->hdr), data->buf);
+				if (timestamp1 >= 933.8385)
+				{
+					int j=0;
+					j++;
+				}
+			}
+
 			// Save data
             LogData(dev, &data->hdr, data->buf);
+
+			g_readCount++;
 		}
 	}
 	CloseAllFiles();

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -43,8 +43,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #endif
 
-#define DEBUG_PRINT		0
-
 // #define DONT_CHECK_LOG_DATA_SET_SIZE		// uncomment to allow reading in of new data logs into older code sets
 
 const string cISLogger::g_emptyString;
@@ -548,7 +546,6 @@ const dev_info_t* cISLogger::GetDeviceInfo( unsigned int device )
 }
 
 int g_copyReadCount;
-int g_copyReadDid;
 
 bool cISLogger::CopyLog(cISLogger& log, const string& timestamp, const string &outputDir, eLogType logType, float maxLogSpacePercent, uint32_t maxFileSize, bool useSubFolderTimestamp)
 {
@@ -575,18 +572,6 @@ bool cISLogger::CopyLog(cISLogger& log, const string& timestamp, const string &o
 		// Copy data		
 		for (g_copyReadCount = 0; (data = log.ReadData(dev)); g_copyReadCount++)
 		{
-
-#if DEBUG_PRINT
-			double timestamp = cISDataMappings::GetTimestamp(&(data->hdr), data->buf);
-			printf("read: %d DID: %3d time: %.4lf\n", g_copyReadCount, data->hdr.id, timestamp);
-			if (data->hdr.id == 12)
-			{
-				int j = 0;
-				j++;
-			}
-			g_copyReadDid = data->hdr.id;
-#endif
-
 			// CSV special cases 
 			if (logType == eLogType::LOGTYPE_CSV)
 			{

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -89,7 +89,15 @@ public:
 	uint32_t GetDeviceCount() { return (uint32_t)m_devices.size(); }
 	bool SetDeviceInfo(const dev_info_t *info, unsigned int device = 0);
 	const dev_info_t* GetDeviceInfo(unsigned int device = 0);
-	bool CopyLog(cISLogger& log, const string& timestamp = g_emptyString, const string& outputDir = g_emptyString, eLogType logType = LOGTYPE_DAT, float maxDiskSpacePercent = 0.5f, uint32_t maxFileSize = 1024 * 1024 * 5, bool useSubFolderTimestamp = true);
+	bool CopyLog(
+		cISLogger& log, 
+		const string& timestamp = g_emptyString, 
+		const string& outputDir = g_emptyString, 
+		eLogType logType = LOGTYPE_DAT, 
+		float maxDiskSpacePercent = 0.5f, 
+		uint32_t maxFileSize = 1024 * 1024 * 5, 
+		bool useSubFolderTimestamp = true,
+		bool enableCsvIns2ToIns1Conversion = true);
 	const cLogStats& GetStats() { return m_logStats; }
 	eLogType GetType() { return m_logType; }
 

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -31,17 +31,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #if PLATFORM_IS_EVB_2
 #include "drivers/d_time.h"
+#include "ISLogFileFatFs.h"
+#else
+#include "ISLogFile.h"
 #endif
 
 #include "ISConstants.h"
-#include "ISLogFile.h"
+#include "ISLogStats.h"
 
 using namespace std;
 
 // default logging path if none specified
 #define DEFAULT_LOGS_DIRECTORY "IS_logs"
 
-class cLogStats;
 
 class cISLogger
 {
@@ -88,7 +90,7 @@ public:
 	bool SetDeviceInfo(const dev_info_t *info, unsigned int device = 0);
 	const dev_info_t* GetDeviceInfo(unsigned int device = 0);
 	bool CopyLog(cISLogger& log, const string& timestamp = g_emptyString, const string& outputDir = g_emptyString, eLogType logType = LOGTYPE_DAT, float maxDiskSpacePercent = 0.5f, uint32_t maxFileSize = 1024 * 1024 * 5, bool useSubFolderTimestamp = true);
-	const cLogStats& GetStats() { return *m_logStats; }
+	const cLogStats& GetStats() { return m_logStats; }
 	eLogType GetType() { return m_logType; }
 
 	/**
@@ -178,8 +180,12 @@ private:
 	vector<cDeviceLog*>		m_devices;
 	uint64_t				m_maxDiskSpace;
 	uint32_t				m_maxFileSize;
-	cLogStats*				m_logStats;
-	cISLogFileBase*         m_errorFile;
+	cLogStats				m_logStats;
+#if PLATFORM_IS_EVB_2
+	cISLogFileFatFs         m_errorFile;
+#else
+	cISLogFile				m_errorFile;
+#endif
 
 	bool					m_altClampToGround;
 	bool					m_showSample;
@@ -190,39 +196,5 @@ private:
 	time_t					m_timeoutFlushSeconds;
 };
 
-class cLogStatDataId
-{
-public:
-	uint64_t count; // count for this data id
-	uint64_t errorCount; // error count for this data id
-	double averageTimeDelta; // average time delta for the data id
-	double totalTimeDelta; // sum of all time deltas
-	double lastTimestamp;
-	double lastTimestampDelta;
-    double minTimestampDelta;
-    double maxTimestampDelta;
-	uint64_t timestampDeltaCount;
-	uint64_t timestampDropCount; // count of delta timestamps > 50% different from previous delta timestamp
-
-	cLogStatDataId();
-	void LogTimestamp(double timestamp);
-	void Printf();
-};
-
-class cLogStats
-{
-public:
-	cLogStatDataId dataIdStats[DID_COUNT];
-	uint64_t count; // count of all data ids
-	uint64_t errorCount; // total error count
-
-	cLogStats();
-	void Clear();
-	void LogError(const p_data_hdr_t* hdr);
-	void LogData(uint32_t dataId);
-	void LogDataAndTimestamp(uint32_t dataId, double timestamp);
-	void Printf();
-    void WriteToFile(const string& fileName);
-};
 
 #endif // IS_LOGGER_H

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1577,7 +1577,7 @@ enum eSysConfigBits
 	/*! Disable LEDs */
 	SYS_CFG_BITS_DISABLE_LEDS                           = (int)0x00000010,
 
-	/** Magnetometer recalibration.  0 = multi-axis, 1 = single-axis */
+	/** Magnetometer recalibration.  (see eMagRecalMode) 1 = multi-axis, 2 = single-axis */
 	SYS_CFG_BITS_MAG_RECAL_MODE_MASK					= (int)0x00000700,
 	SYS_CFG_BITS_MAG_RECAL_MODE_OFFSET					= 8,
 #define SYS_CFG_BITS_MAG_RECAL_MODE(sysCfgBits) ((sysCfgBits&SYS_CFG_BITS_MAG_RECAL_MODE_MASK)>>SYS_CFG_BITS_MAG_RECAL_MODE_OFFSET)

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1102,7 +1102,7 @@ enum eGenFaultCodes
 	GFC_UNHANDLED_INTERRUPT				= 0x00000010,
 	/*! Fault: sensor initialization  */
 	GFC_INIT_SENSORS					= 0x00000100,
-	/*! Fault: SPI initialization  */
+	/*! Fault: SPI bus initialization  */
 	GFC_INIT_SPI						= 0x00000200,
 	/*! Fault: SPI configuration  */
 	GFC_CONFIG_SPI						= 0x00000400,

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(SDK_test
 	../ISFileManager.cpp
 	../ISLogFile.cpp
 	../ISLogger.cpp
+	../ISLogStats.cpp
 	../ISMatrix.c
 	../ISPose.c
 	../ISUtilities.cpp


### PR DESCRIPTION
- Fixed significant issue with ISLogger and sdat data logging.
- Fixed ISLogger copy function so that .dat, .sdat, and .csv file formats can be interconverted without dropping data.
- Fixed the way data is serialized when read out of ISLogger .sdat data format.
- Fixed broken unit test for ISLogger and added more robust checks.
- Convert cLogStats objects from dynamic to static allocation inside cISLogger.
