### PR TITLE
SN-1313 bootloader update version detect bug

### DIFF
--- a/src/inertialSenseBootLoader.c
+++ b/src/inertialSenseBootLoader.c
@@ -1271,7 +1271,9 @@ static int bootloadFileInternal(FILE* file, bootload_params_t* p)
                 //printf("Bootloader file version: %d%c.\n", fileVerMajor, fileVerMinor);
 
                 //Check bootloader version against file
-                if (blVerMajor < fileVerMajor || blVerMinor < fileVerMinor || p->forceBootloaderUpdate > 0)
+                if (blVerMajor < fileVerMajor || 
+                    (blVerMajor == fileVerMajor && blVerMinor < fileVerMinor) || 
+                    p->forceBootloaderUpdate > 0)
                 {
                     if (sambaSupport)
                     {


### PR DESCRIPTION
This fixes an issue where the bootloader would update to older version of bootloader when it shouldn't.  It should downgrade if the FORCE option is used.