### PR TITLE
SN-1534 Add support for v5a bootloader

### DIFF
--- a/src/inertialSenseBootLoader.c
+++ b/src/inertialSenseBootLoader.c
@@ -1107,7 +1107,7 @@ static int bootloaderSync(serial_port_t* s)
         }
     }
 
-#if defined(SUPPORT_BOOTLOADER_V5A)     // ONLY NEEDED TO SUPPORT BOOTLOADER v5a.  Delete this and assocated code in (2022 Q4) after bootloader v5a is out of circulation. WHJ
+#if defined(SUPPORT_BOOTLOADER_V5A)     // ONLY NEEDED TO SUPPORT BOOTLOADER v5a.  Delete this and assocated code in 2022 Q4 after bootloader v5a is out of circulation. WHJ
 
     static const unsigned char handshaker[] = "INERTIAL_SENSE_SYNC_DFU";
 

--- a/src/inertialSenseBootLoader.c
+++ b/src/inertialSenseBootLoader.c
@@ -1090,7 +1090,6 @@ static void bootloaderRestart(serial_port_t* s)
 static int bootloaderSync(serial_port_t* s)
 {
     static const unsigned char handshakerChar = 'U';
-    static const unsigned char handshaker[] = "INERTIAL_SENSE_SYNC_DFU";
 
     //Most usages of this function we do not know if we can communicate (still doing auto-baud or checking to see if the bootloader or application is running) so trying to reset unit here does not make sense.
     //This was probably added because the PC bootloader was doing multiple syncs in a row but the hardware bootloader only allowed one.
@@ -1109,6 +1108,8 @@ static int bootloaderSync(serial_port_t* s)
     }
 
 #if defined(SUPPORT_BOOTLOADER_V5A)     // ONLY NEEDED TO SUPPORT BOOTLOADER v5a.  Delete this and assocated code in (2022 Q4) after bootloader v5a is out of circulation. WHJ
+
+    static const unsigned char handshaker[] = "INERTIAL_SENSE_SYNC_DFU";
 
     // Attempt handshake using extended string for bootloader v5a
     for (int i = 0; i < BOOTLOADER_RETRIES; i++)

--- a/src/inertialSenseBootLoader.c
+++ b/src/inertialSenseBootLoader.c
@@ -24,7 +24,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define SAM_BA_FLASH_START_ADDRESS 0x00400000
 #define SAM_BA_BOOTLOADER_SIZE 16384
 
-#define SUPPORT_BOOTLOADER_V5A      // ONLY NEEDED TO SUPPORT BOOTLOADER v5a.  Delete this and assocated code in (2022 Q4) after bootloader v5a is out of circulation. WHJ
+#define SUPPORT_BOOTLOADER_V5A      // ONLY NEEDED TO SUPPORT BOOTLOADER v5a.  Delete this and assocated code in Q4 2022 after bootloader v5a is out of circulation. WHJ
 
 #define X_SOH 0x01
 #define X_EOT 0x04
@@ -1107,7 +1107,7 @@ static int bootloaderSync(serial_port_t* s)
         }
     }
 
-#if defined(SUPPORT_BOOTLOADER_V5A)     // ONLY NEEDED TO SUPPORT BOOTLOADER v5a.  Delete this and assocated code in 2022 Q4 after bootloader v5a is out of circulation. WHJ
+#if defined(SUPPORT_BOOTLOADER_V5A)     // ONLY NEEDED TO SUPPORT BOOTLOADER v5a.  Delete this and assocated code in Q4 2022 after bootloader v5a is out of circulation. WHJ
 
     static const unsigned char handshaker[] = "INERTIAL_SENSE_SYNC_DFU";
 


### PR DESCRIPTION
This adds support for the v5a bootloader to our SDK, preventing bootloader incompatibility for customers that have v5a. 