### PR TITLE
SN-1872 Add 1s delay following last flash write to reduce likelihood of data drop

### DIFF
--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -602,7 +602,8 @@ void update_flash_cfg(evb_flash_cfg_t &newCfg)
     
 	// Enable flash write
 	g_nvr_manage_config.flash_write_needed = true;
-	g_nvr_manage_config.flash_write_enable = true;
+	g_nvr_manage_config.flash_write_enable_timeMs = time_msec();
+	g_status.evbStatus |= EVB_STATUS_FLASH_WRITE_IN_PROGRESS;
 }
 
 

--- a/EVB-2/IS_EVB-2/src/globals.c
+++ b/EVB-2/IS_EVB-2/src/globals.c
@@ -342,7 +342,8 @@ bool nvr_validate_config_integrity(evb_flash_cfg_t* cfg)
     {   // Reset to defaults
         *cfg = defaults;
         g_nvr_manage_config.flash_write_needed = true;
-		g_nvr_manage_config.flash_write_enable = true;
+		g_nvr_manage_config.flash_write_enable_timeMs = time_msec();
+        g_status.evbStatus |= EVB_STATUS_FLASH_WRITE_IN_PROGRESS;
     }   
     
     // Disable cbPresets is necessary
@@ -369,7 +370,8 @@ void nvr_init(void)
     memcpy(&g_userPage, (void*)BOOTLOADER_FLASH_CONFIG_BASE_ADDRESS, sizeof(g_userPage));
 
     // Disable flash writes.  We require the user to initiate each write with this option.
-    g_nvr_manage_config.flash_write_enable = 0;
+    g_nvr_manage_config.flash_write_enable_timeMs = 0;
+    g_status.evbStatus &= ~EVB_STATUS_FLASH_WRITE_IN_PROGRESS;
 
     // Reset to defaults if checksum or keys don't match
     nvr_validate_config_integrity(g_flashCfg);    
@@ -378,10 +380,16 @@ void nvr_init(void)
 
 void nvr_slow_maintenance(void)
 {
-    if(g_nvr_manage_config.flash_write_enable==0)
+    if (g_nvr_manage_config.flash_write_enable_timeMs==0)
     {
         return;
     }
+
+	uint32_t dtMs = time_msec() - g_nvr_manage_config.flash_write_enable_timeMs;
+	if (dtMs < 1000)
+	{	// Wait 1 second following flash_write_enable_timeMs
+		return;
+	}
     
     if (g_nvr_manage_config.flash_write_needed)
     {
@@ -455,7 +463,8 @@ void nvr_slow_maintenance(void)
 
         g_nvr_manage_config.flash_write_needed = 0;
         // Disable following each flash write.  We require users to re-enable for each write.
-        g_nvr_manage_config.flash_write_enable = 0;
+        g_nvr_manage_config.flash_write_enable_timeMs = 0;
+        g_status.evbStatus &= ~EVB_STATUS_FLASH_WRITE_IN_PROGRESS;
     }    
 }
 

--- a/EVB-2/IS_EVB-2/src/globals.h
+++ b/EVB-2/IS_EVB-2/src/globals.h
@@ -63,9 +63,9 @@ typedef struct
 
 typedef struct PACKED      // Non-volatile memory state
 {
-    uint32_t                flash_write_needed;					// 0=No write; 1=config write needed; 2=config write needed without backup 0xFFFFFFFF=reset defaults
+    uint32_t                flash_write_needed;                 // 0=No write; 1=config write needed; 2=config write needed without backup 0xFFFFFFFF=reset defaults
     uint32_t                flash_write_count;                  // Number of times flash is written to since reset
-    uint32_t                flash_write_enable;				    // 1 = enables flash writes.  This is used to prevent stutters in RTOS caused by flash writes until controlled times.
+    uint32_t                flash_write_enable_timeMs;          // Local time when enabled.  Flash will happen 1-2 seconds after this enable time.  Reset to zero following flash write.
 } nvr_manage_t;
 
 typedef struct PACKED      // 

--- a/EVB-2/IS_EVB-2/src/user_interface.cpp
+++ b/EVB-2/IS_EVB-2/src/user_interface.cpp
@@ -65,6 +65,7 @@ static void on_cfg_button_release()
     board_IO_config();
     g_nvr_manage_config.flash_write_needed = true;
 	g_nvr_manage_config.flash_write_enable_timeMs = time_msec();
+    g_status.evbStatus |= EVB_STATUS_FLASH_WRITE_IN_PROGRESS;
 	evbUiRefreshLedCfg();
 }
 

--- a/EVB-2/IS_EVB-2/src/user_interface.cpp
+++ b/EVB-2/IS_EVB-2/src/user_interface.cpp
@@ -64,7 +64,7 @@ static void on_cfg_button_release()
     com_bridge_apply_preset(g_flashCfg);
     board_IO_config();
     g_nvr_manage_config.flash_write_needed = true;
-	g_nvr_manage_config.flash_write_enable = true;
+	g_nvr_manage_config.flash_write_enable_timeMs = time_msec();
 	evbUiRefreshLedCfg();
 }
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1667,7 +1667,7 @@ enum eInfieldCalState
     INFIELD_CAL_STATE_CMD_SAVE_AND_FINISH               = 9,    // Run this command to compute and save results.  Must be run following INFIELD_CAL_STATE_CMD_START_SAMPLE.
     
     /** Status: (read only) */
-    INFIELD_CAL_STATE_INITIALIZED_READY_FOR_SAMPLING    = 50,   // Initialized and waiting for user to intiate.  User must send a command to exit this state.
+    INFIELD_CAL_STATE_READY_FOR_SAMPLING                = 50,   // System has been initialized and is waiting for user to intiate sampling.  User must send a command to exit this state.
     INFIELD_CAL_STATE_SAMPLING                          = 51,   // System is averaging the IMU data.  Minimize all motion and vibration.
     INFIELD_CAL_STATE_RUN_BIT_AND_FINISH                = 52,   // Follow up calibration zero with BIT and copy out IMU biases.
     INFIELD_CAL_STATE_SAVED_AND_FINISHED                = 53,   // Calculations are complete and DID_INFIELD_CAL.imu holds the update IMU biases.  Updates are saved to flash. 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -318,7 +318,9 @@ enum eHdwStatusFlags
 	/** System Reset is Required for proper function */
 	HDW_STATUS_SYSTEM_RESET_REQUIRED			= (int)0x00001000,
 
-	HDW_STATUS_UNUSED_3				            = (int)0x00002000,
+	/** System flash write staging or occuring now.  Processor will pause and not respond during a flash write, typicaly 150-250 ms. */
+	HDW_STATUS_FLASH_WRITE_IN_PROGRESS          = (int)0x00002000,
+
 	HDW_STATUS_UNUSED_4				            = (int)0x00004000,
 	HDW_STATUS_UNUSED_5				            = (int)0x00008000,
 
@@ -3364,6 +3366,9 @@ typedef enum
 
     /** XBee: failed to configure */
     EVB_STATUS_XBEE_CONFIG_FAILURE          = 0x00800000,
+
+	/** System flash write staging or occuring now.  Processor will pause and not respond during a flash write, typicaly 150-250 ms. */
+    EVB_STATUS_FLASH_WRITE_IN_PROGRESS      = 0x01000000,
 
 } eEvbStatus;
 


### PR DESCRIPTION
Currently flash writes happen every second on the second if enabled and needed.  

This adds 1 second delay to all flash writes to allow grace time and reduce likelihood that a sequence of flash config changes will cause a flash write and data drop in middle of the sequence of flash writes.