### PR TITLE
[ISClient] Fail even if getaddrinfo fails

### DIFF
--- a/src/ISClient.cpp
+++ b/src/ISClient.cpp
@@ -56,7 +56,7 @@ cISStream* cISClient::OpenConnectionToServer(const string& connectionString, boo
 		string username = (pieces.size() > 5 ? pieces[5] : "");
 		string password = (pieces.size() > 6 ? pieces[6] : "");
 
-		if (clientStream->Open(host, atoi(port.c_str()), 100) == -1)
+		if (clientStream->Open(host, atoi(port.c_str()), 100) != 0)
 		{
 			return NULLPTR;
 		}


### PR DESCRIPTION
When `getaddrinfo` fails, the `cISTcpClient` returns `getaddrinfo` error code (see [here](https://github.com/inertialsense/inertial-sense-sdk/blob/a04077f075d432dec6dbccfabefdddf68ace2030/src/ISTcpClient.cpp#L258)), which can potentially be different from `-1`. In such a case, it should not report a successful connection.