### PR TITLE
SN-2254 gps timepulse support

### DIFF
--- a/src/ISBootloaderISB.cpp
+++ b/src/ISBootloaderISB.cpp
@@ -405,7 +405,6 @@ int cISBootloaderISB::is_isb_read_line(FILE* file, char line[1024])
 is_operation_result cISBootloaderISB::upload_hex_page(unsigned char* hexData, int byteCount, int* currentOffset, int* totalBytes, int* verifyCheckSum)
 {
     serial_port_t* s = m_port;
-    int i;
 
     if (byteCount == 0)
     {
@@ -435,7 +434,7 @@ is_operation_result cISBootloaderISB::upload_hex_page(unsigned char* hexData, in
     int newVerifyChecksum = *verifyCheckSum;
 
     // calculate verification checksum for this data
-    for (i = 0; i < charsForThisPage; i++)
+    for (int i = 0; i < charsForThisPage; i++)
     {
         newVerifyChecksum = ((newVerifyChecksum << 5) + newVerifyChecksum) + hexData[i];
     }
@@ -750,7 +749,7 @@ is_operation_result cISBootloaderISB::process_hex_file(FILE* file)
     unsigned char* outputPtr = output;
     const unsigned char* outputPtrEnd = output + (HEX_BUFFER_SIZE * 2);
     int outputSize;
-    int page = 0;
+    //int page = 0;
     int pad;
     int fileSize;
     unsigned char tmp[5];

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -359,7 +359,7 @@ static void PopulateSysParamsMappings(map_name_to_info_t mappings[DID_COUNT])
     ADD_MAP(m, totalSize, "imuTemp", imuTemp, 0, DataTypeFloat, float, 0);
     ADD_MAP(m, totalSize, "baroTemp", baroTemp, 0, DataTypeFloat, float, 0);
     ADD_MAP(m, totalSize, "mcuTemp", mcuTemp, 0, DataTypeFloat, float, 0);
-    ADD_MAP(m, totalSize, "reserved1", reserved1, 0, DataTypeFloat, float, 0);
+    ADD_MAP(m, totalSize, "sysStatus", sysStatus, 0, DataTypeUInt32, uint32_t, 0);
 	ADD_MAP(m, totalSize, "imuPeriodMs", imuPeriodMs, 0, DataTypeUInt32, uint32_t, 0);
     ADD_MAP(m, totalSize, "navPeriodMs", navPeriodMs, 0, DataTypeUInt32, uint32_t, 0);
 	ADD_MAP(m, totalSize, "sensorTruePeriod", sensorTruePeriod, 0, DataTypeDouble, double, 0);

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -275,8 +275,8 @@ static void PopulateBitMappings(map_name_to_info_t mappings[DID_COUNT])
     ADD_MAP(m, totalSize, "tcPqrLinearity", tcPqrLinearity, 0, DataTypeFloat, float, 0);
     ADD_MAP(m, totalSize, "tcAccLinearity", tcAccLinearity, 0, DataTypeFloat, float, 0);
 
-    ADD_MAP(m, totalSize, "acc", pqr, 0, DataTypeFloat, float, 0);
-    ADD_MAP(m, totalSize, "pqr", acc, 0, DataTypeFloat, float, 0);
+    ADD_MAP(m, totalSize, "pqr", pqr, 0, DataTypeFloat, float, 0);
+    ADD_MAP(m, totalSize, "acc", acc, 0, DataTypeFloat, float, 0);
     ADD_MAP(m, totalSize, "pqrSigma", pqrSigma, 0, DataTypeFloat, float, 0);
     ADD_MAP(m, totalSize, "accSigma", accSigma, 0, DataTypeFloat, float, 0);
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -332,11 +332,10 @@ enum eHdwStatusFlags
 	/** Communications Rx buffer overrun */
 	HDW_STATUS_ERR_COM_RX_OVERRUN				= (int)0x00020000,
 
-	/** GPS PPS timepulse signal have not being recieved */
-	HDW_STATUS_ERR_GPS_PPS_MISSING				= (int)0x00040000,
-
-	/** Reserved */
-	HDW_STATUS_ERR_RESERVED						= (int)0x00080000,
+	/** GPS PPS timepulse signal has not been received or is in error */
+	HDW_STATUS_ERR_GPS_PPS_ERROR				= (int)0x00040000,
+	/** Time synchronized by GPS PPS */
+	HDW_STATUS_GPS_PPS_TIMESYNC					= (int)0x00080000,
 
 	/** Communications parse error count */
 	HDW_STATUS_COM_PARSE_ERR_COUNT_MASK			= (int)0x00F00000,
@@ -434,7 +433,9 @@ enum eGpsStatus
                                                     GPS_STATUS_FLAGS_RTK_COMPASSING_BASELINE_BAD|
                                                     GPS_STATUS_FLAGS_RTK_COMPASSING_BASELINE_UNSET),
 	GPS_STATUS_FLAGS_GPS_NMEA_DATA                  = (int)0x00008000,      // 1 = Data from NMEA message
-	GPS_STATUS_FLAGS_MASK                           = (int)0x0FFFE000,    
+	GPS_STATUS_FLAGS_GPS_PPS_TIMESYNC               = (int)0x10000000,      // Time is synchronized by GPS PPS. 
+
+	GPS_STATUS_FLAGS_MASK                           = (int)0xFFFFE000,    
 	GPS_STATUS_FLAGS_BIT_OFFSET                     = (int)16,
 	
 };
@@ -2215,8 +2216,8 @@ enum eIoConfig
 	IO_CFG_GPS_TIMEPUSE_SOURCE_OFFSET			= (int)13,
 	IO_CFG_GPS_TIMEPUSE_SOURCE_MASK				= (int)0x00000007,
 	IO_CFG_GPS_TIMEPUSE_SOURCE_DISABLED			= (int)0,
-	IO_CFG_GPS_TIMEPUSE_SOURCE_ONBOARD_1_PIN20	= (int)1,
-	IO_CFG_GPS_TIMEPUSE_SOURCE_ONBOARD_2		= (int)2,
+	IO_CFG_GPS_TIMEPUSE_SOURCE_GPS1_PPS_PIN20	= (int)1,
+	IO_CFG_GPS_TIMEPUSE_SOURCE_GPS2_PPS			= (int)2,
 	IO_CFG_GPS_TIMEPUSE_SOURCE_STROBE_G2_PIN6	= (int)3,
 	IO_CFG_GPS_TIMEPUSE_SOURCE_STROBE_G5_PIN9	= (int)4,
 	IO_CFG_GPS_TIMEPUSE_SOURCE_STROBE_G8_PIN12	= (int)5,

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -332,6 +332,12 @@ enum eHdwStatusFlags
 	/** Communications Rx buffer overrun */
 	HDW_STATUS_ERR_COM_RX_OVERRUN				= (int)0x00020000,
 
+	/** GPS PPS timepulse signal have not being recieved */
+	HDW_STATUS_ERR_GPS_PPS_MISSING				= (int)0x00040000,
+
+	/** Reserved */
+	HDW_STATUS_ERR_RESERVED						= (int)0x00080000,
+
 	/** Communications parse error count */
 	HDW_STATUS_COM_PARSE_ERR_COUNT_MASK			= (int)0x00F00000,
 	HDW_STATUS_COM_PARSE_ERR_COUNT_OFFSET		= 20,
@@ -365,6 +371,13 @@ enum eHdwStatusFlags
 
 	/** Critical System Fault - CPU error */
 	HDW_STATUS_FAULT_SYS_CRITICAL				= (int)0x80000000,
+};
+
+/** System status flags */
+enum eSysStatusFlags
+{
+	/**  */
+	SYS_STATUS_RESERVED							= (int)0x00000001,
 };
 
 // Used to validate GPS position (and velocity)
@@ -1095,10 +1108,10 @@ typedef struct PACKED
 	/** GPS time of week (since Sunday morning) in milliseconds */
 	uint32_t                timeOfWeekMs;
 
-	/** System status 1 flags (eInsStatusFlags) */
+	/** INS status flags (eInsStatusFlags) */
 	uint32_t                insStatus;
 
-	/** System status 2 flags (eHdwStatusFlags) */
+	/** Hardware status flags (eHdwStatusFlags) */
 	uint32_t                hdwStatus;
 
 	/** IMU temperature */
@@ -1110,8 +1123,8 @@ typedef struct PACKED
 	/** MCU temperature (not available yet) */
 	float					mcuTemp;
 
-	/** Reserved */
-	float					reserved1;
+	/** System status flags (eSysStatusFlags) */
+	uint32_t				sysStatus;
 
 	/** IMU sample period in milliseconds. Zero disables sampling. */
 	uint32_t				imuPeriodMs;

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -28,7 +28,7 @@ PYBIND11_NUMPY_DTYPE(ins_4_t, week, timeOfWeek, insStatus, hdwStatus, qe2b, ve, 
 PYBIND11_NUMPY_DTYPE(system_command_t, command, invCommand);
 PYBIND11_NUMPY_DTYPE(ascii_msgs_t, options, pimu, ppimu, pins1, pins2, pgpsp, reserved, gpgga, gpgll, gpgsa, gprmc, gpzda, pashr);
 PYBIND11_NUMPY_DTYPE(rmc_t, bits, options);
-PYBIND11_NUMPY_DTYPE(sys_params_t, timeOfWeekMs, insStatus, hdwStatus, imuTemp, baroTemp, mcuTemp, reserved1, imuPeriodMs, navPeriodMs, sensorTruePeriod, reserved2, reserved3, genFaultCode);
+PYBIND11_NUMPY_DTYPE(sys_params_t, timeOfWeekMs, insStatus, hdwStatus, imuTemp, baroTemp, mcuTemp, sysStatus, imuPeriodMs, navPeriodMs, sensorTruePeriod, reserved2, reserved3, genFaultCode);
 PYBIND11_NUMPY_DTYPE(sys_sensors_t, time, temp, pqr, acc, mag, bar, barTemp, mslBar, humidity, vin, ana1, ana3, ana4);
 PYBIND11_NUMPY_DTYPE(nvm_flash_cfg_t, size, checksum, key, startupImuDtMs, startupNavDtMs, ser0BaudRate, ser1BaudRate, insRotation, insOffset, gps1AntOffset, insDynModel, debug, gnssSatSigConst, sysCfgBits, refLla, lastLla, lastLlaTimeOfWeekMs, lastLlaWeek, lastLlaUpdateDistance, ioConfig, cBrdConfig, gps2AntOffset, zeroVelRotation, zeroVelOffset, magInclination, magDeclination, gpsTimeSyncPeriodMs, startupGPSDtMs, RTKCfgBits, sensorConfig, gpsMinimumElevation, ser2BaudRate, wheelConfig);
 PYBIND11_NUMPY_DTYPE(gps_pos_t, week, timeOfWeekMs, status, ecef, lla, hMSL, hAcc, vAcc, pDop, cnoMean, towOffset, leapS, reserved);

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -380,8 +380,8 @@ static int serialPortClosePlatform(serial_port_t* serialPort)
 
 #if PLATFORM_IS_WINDOWS
 
-    DWORD dwRead = 0;
-    DWORD error = 0;
+    //DWORD dwRead = 0;
+    //DWORD error = 0;
 
     CancelIo(handle->platformHandle);
     //GetOverlappedResult(handle->platformHandle, &handle->ovRead, &dwRead, 1);


### PR DESCRIPTION
Allow GPS PPS input on IMX-5 PPS TIMEPULSE (pin 20).  
Add status indicators to identify if PPS is valid or if there is an error. 

![image](https://user-images.githubusercontent.com/15111560/186857300-dd9e5f79-d9ed-42ca-975f-e152fb8106aa.png)

![image](https://user-images.githubusercontent.com/15111560/186857558-5f58ba4a-528a-4c74-8c2c-95ff7cd3f737.png)
