### PR TITLE
Change status indicator to flash write pending

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -325,7 +325,7 @@ enum eHdwStatusFlags
 	/** Magnetometer recalibration has finished (when INS_STATUS_MAG_RECALIBRATING is unset).  */
 	HDW_STATUS_MAG_RECAL_COMPLETE	            = (int)0x00004000,
 	/** System flash write staging or occuring now.  Processor will pause and not respond during a flash write, typicaly 150-250 ms. */
-	HDW_STATUS_FLASH_WRITE_IN_PROGRESS          = (int)0x00008000,
+	HDW_STATUS_FLASH_WRITE_PENDING              = (int)0x00008000,
 
 	/** Communications Tx buffer limited */
 	HDW_STATUS_ERR_COM_TX_LIMITED				= (int)0x00010000,


### PR DESCRIPTION
This changes the `flash write` indicator to `flash write pending` to indicate that the flash write will occur at the when the indicator turns off.