### PR TITLE
Add separate color for ref INS dead reckoning mode in KML

### DIFF
--- a/src/DataKML.cpp
+++ b/src/DataKML.cpp
@@ -67,6 +67,7 @@ int cDataKML::WriteDataToFile(std::vector<sKmlLogData>& list, const p_data_hdr_t
 	uDatasets& d = (uDatasets&)(*dataBuf);
 	ixEuler theta;
     sKmlLogData data;
+	bool deadreckoning = false;
 
 #ifdef USE_IS_INTERNAL
 // 	uInternalDatasets &i = (uInternalDatasets&)(*dataBuf);
@@ -79,15 +80,18 @@ int cDataKML::WriteDataToFile(std::vector<sKmlLogData>& list, const p_data_hdr_t
         return 0;
 
 	case DID_INS_1:
-        data = sKmlLogData(d.ins1.timeOfWeek, d.ins1.lla, d.ins1.theta, !(d.ins1.insStatus & INS_STATUS_GPS_AIDING_POS));
+		deadreckoning = !(d.ins1.insStatus & INS_STATUS_GPS_AIDING_POS);
+        data = sKmlLogData(d.ins1.timeOfWeek, d.ins1.lla, d.ins1.theta, deadreckoning);
 		break;
 	case DID_INS_2:
 		quat2euler(d.ins2.qn2b, theta);
-        data = sKmlLogData(d.ins2.timeOfWeek, d.ins2.lla, theta, !(d.ins2.insStatus & INS_STATUS_GPS_AIDING_POS));
+		deadreckoning = !(d.ins2.insStatus & INS_STATUS_GPS_AIDING_POS);
+        data = sKmlLogData(d.ins2.timeOfWeek, d.ins2.lla, theta, deadreckoning);
 		break;
 	case DID_INS_3:
 		quat2euler(d.ins3.qn2b, theta);
-        data = sKmlLogData(d.ins3.timeOfWeek, d.ins3.lla, theta, !(d.ins3.insStatus & INS_STATUS_GPS_AIDING_POS));
+		deadreckoning = !(d.ins3.insStatus & INS_STATUS_GPS_AIDING_POS);
+        data = sKmlLogData(d.ins3.timeOfWeek, d.ins3.lla, theta, deadreckoning);
 		break;
 	case DID_GPS1_POS:
 	case DID_GPS1_UBX_POS:

--- a/src/DataKML.h
+++ b/src/DataKML.h
@@ -32,7 +32,7 @@ struct sKmlLogData
 	float                   theta[3];
 	bool                    deadReckoning;
     sKmlLogData() {}
-	sKmlLogData(double _time, double _lla[3], float _theta[3], bool _deadReckoning)
+	sKmlLogData(double _time, double _lla[3], float _theta[3], bool _deadReckoning=false)
 	{
 		time = _time;
         lla[0] = _lla[0];
@@ -51,7 +51,7 @@ struct sKmlLogData
         lla[1] = _lla[1];
         lla[2] = _lla[2];
         theta[0] = theta[1] = theta[2] = 0;
-		deadReckoning = 0;
+		deadReckoning = false;
 	}
 };
 
@@ -75,7 +75,8 @@ public:
 		switch (did)
 		{
 		default:					return -1; // Unused
-		case DID_INS_1:				return KID_INS;
+		case DID_INS_1:				
+		case DID_INS_2:				return KID_INS;
 		case DID_GPS1_POS:			return KID_GPS;
 		case DID_GPS1_UBX_POS:		return KID_GPS1;
 		case DID_GPS2_POS:			return KID_GPS2;
@@ -90,6 +91,7 @@ public:
         default:
             return -1; // Unused
         case KID_INS:
+        case KID_REF:
             return 130;
 		case KID_GPS:
 		case KID_GPS1:

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -39,6 +39,7 @@ cDeviceLog::cDeviceLog()
     m_fileCount = 0;
     memset(&m_devInfo, 0, sizeof(dev_info_t));
 	m_altClampToGround = true;
+	m_enableGpsLogging = true;
 	m_showTracks = true;
 	m_showPointTimestamps = true;
 	m_pointUpdatePeriodSec = 1.0f;

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -52,8 +52,9 @@ public:
 	uint64_t LogSize() { return m_logSize; }
 	uint32_t FileCount() { return m_fileCount; }
 	std::string GetNewFileName(uint32_t serialNumber, uint32_t fileCount, const char* suffix);
-	void SetKmlConfig(bool showTracks =true, bool showPoints =true, bool showPointTimestamps =true, double pointUpdatePeriodSec=1.0, bool altClampToGround=true)
+	void SetKmlConfig(bool gpsData =true, bool showTracks =true, bool showPoints =true, bool showPointTimestamps =true, double pointUpdatePeriodSec=1.0, bool altClampToGround=true)
 	{ 
+		m_enableGpsLogging = gpsData;
 		m_showTracks = showTracks;
 		m_showPoints = showPoints;
 		m_showPointTimestamps = showPointTimestamps;
@@ -80,6 +81,7 @@ protected:
 	uint64_t                m_maxDiskSpace;
 	uint32_t                m_maxFileSize;
 	bool                    m_altClampToGround;
+	bool                    m_enableGpsLogging;
 	bool                    m_showTracks;
 	bool                    m_showPoints;
 	bool                    m_showPointTimestamps;

--- a/src/DeviceLogKML.cpp
+++ b/src/DeviceLogKML.cpp
@@ -30,7 +30,15 @@ using namespace std;
 
 void cDeviceLogKML::InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize)
 {
-	memset(&m_Log, 0, sizeof(m_Log));
+	for (int kid=0; kid<cDataKML::MAX_NUM_KID; kid++ )
+	{
+		m_Log[kid].data.clear();
+		m_Log[kid].fileName.clear();
+		m_Log[kid].fileCount = 0;
+		m_Log[kid].fileDataSize = 0;
+		m_Log[kid].fileSize = 0;
+	}
+	m_isRefIns = false;
 
 	cDeviceLog::InitDeviceForWriting(pHandle, timestamp, directory, maxDiskSpace, maxFileSize);
 }
@@ -63,6 +71,12 @@ bool cDeviceLogKML::CloseWriteFile(int kid, sKmlLog &log)
 	if (m_directory.empty())
 	{
 		return false;
+	}
+
+	// Override KID as reference KID
+	if (kid==cDataKML::KID_INS && m_isRefIns) 
+	{
+		kid = cDataKML::KID_REF;
 	}
 
 	_MKDIR(m_directory.c_str());
@@ -107,7 +121,8 @@ bool cDeviceLogKML::CloseWriteFile(int kid, sKmlLog &log)
 	{
 	case cDataKML::KID_INS:
 		iconUrl = "http://earth.google.com/images/kml-icons/track-directional/track-0.png";
-		colorStr = "ff00ffff";  // yellow
+		colorStr = "ff00ffff";  	// yellow
+		colorDrStr = "ff00a5ff";	// orange
 		break;
 	case cDataKML::KID_GPS:
 		colorStr = "ff0000ff";  // red
@@ -120,7 +135,8 @@ bool cDeviceLogKML::CloseWriteFile(int kid, sKmlLog &log)
         break;
 	case cDataKML::KID_REF:
 		iconUrl = "http://earth.google.com/images/kml-icons/track-directional/track-0.png";
-		colorStr = "ffff00ff";  // magenta
+		colorStr = "ffff00ff";  	// magenta
+		colorDrStr = "ffcd00cd";	// tinted magenta
 		break;
 	}
 
@@ -434,6 +450,15 @@ bool cDeviceLogKML::SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf)
 	uDatasets& d = (uDatasets&)(*dataBuf);
 	switch (dataHdr->id)
 	{
+	case DID_DEV_INFO:
+		if (d.devInfo.serialNumber == 99999 ||
+			d.devInfo.serialNumber == 10101)
+		{
+			m_isRefIns = true;
+		}
+		break;
+
+#if 0	// This code is not needed as cDeviceLogKML::WriteDateToFile() saves both DID_INS_1 and DID_INS_2
 	case DID_INS_2:
 		ins_1_t ins1;
 		ins1.week = d.ins2.week;
@@ -450,6 +475,7 @@ bool cDeviceLogKML::SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf)
             return false;
         }
 		break;
+#endif
 	}
 
 	return true;

--- a/src/DeviceLogKML.cpp
+++ b/src/DeviceLogKML.cpp
@@ -74,9 +74,24 @@ bool cDeviceLogKML::CloseWriteFile(int kid, sKmlLog &log)
 	}
 
 	// Override KID as reference KID
-	if (kid==cDataKML::KID_INS && m_isRefIns) 
+	switch (kid)
 	{
-		kid = cDataKML::KID_REF;
+	case cDataKML::KID_INS:
+		if (m_isRefIns) 
+		{
+			kid = cDataKML::KID_REF;
+		}
+		break;
+
+	case cDataKML::KID_GPS:
+	case cDataKML::KID_GPS1:
+	case cDataKML::KID_GPS2:
+	case cDataKML::KID_RTK:
+		if (!m_enableGpsLogging)
+		{	
+			return false;
+		}
+		break;
 	}
 
 	_MKDIR(m_directory.c_str());
@@ -490,6 +505,19 @@ bool cDeviceLogKML::WriteDateToFile(const p_data_hdr_t *dataHdr, const uint8_t* 
 	if (kid < 0)
 	{
 		return true;
+	}
+
+	switch (kid)
+	{
+	case cDataKML::KID_GPS:
+	case cDataKML::KID_GPS1:
+	case cDataKML::KID_GPS2:
+	case cDataKML::KID_RTK:
+		if (!m_enableGpsLogging)
+		{
+			return true;
+		}
+		break;
 	}
 
 	// Reference current log

--- a/src/DeviceLogKML.h
+++ b/src/DeviceLogKML.h
@@ -58,6 +58,7 @@ private:
 
 	cDataKML                m_kml;
 	sKmlLog                 m_Log[cDataKML::MAX_NUM_KID];
+	bool                    m_isRefIns;
 };
 
 #endif // DEVICE_LOG_KML_H

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -597,7 +597,7 @@ bool cISLogger::CopyLog(cISLogger& log, const string& timestamp, const string &o
 #endif
 
 		// Set KML configuration
-		m_devices[dev]->SetKmlConfig(m_showPath, m_showSample, m_showTimeStamp, m_iconUpdatePeriodSec, m_altClampToGround);
+		m_devices[dev]->SetKmlConfig(m_gpsData, m_showPath, m_showSample, m_showTimeStamp, m_iconUpdatePeriodSec, m_altClampToGround);
 
 		// Copy data		
 		for (g_copyReadCount = 0; (data = log.ReadData(dev)); g_copyReadCount++)

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -128,8 +128,9 @@ public:
     // the map contains device id (serial number) key and a vector containing log data for each data id, which will be an empty vector if no log data for that id
     static bool ReadAllLogDataIntoMemory(const std::string& directory, std::map<uint32_t, std::vector<std::vector<uint8_t>>>& data);
 
-	void SetKmlConfig(bool showPath = true, bool showSample = false, bool showTimeStamp = true, double updatePeriodSec = 1.0, bool altClampToGround = true)
+	void SetKmlConfig(bool gpsData = true, bool showPath = true, bool showSample = false, bool showTimeStamp = true, double updatePeriodSec = 1.0, bool altClampToGround = true)
 	{
+		m_gpsData = gpsData;
 		m_showPath = showPath;
 		m_showSample = showSample;
 		m_showTimeStamp = showTimeStamp;
@@ -199,6 +200,7 @@ private:
 #endif
 
 	bool					m_altClampToGround;
+	bool					m_gpsData;
 	bool					m_showSample;
 	bool					m_showPath;
 	bool					m_showTimeStamp;


### PR DESCRIPTION
This changes the color of the reference INS line in the KML data (Google Earth) image so we can tell when the SPAN is in dead reckoning mode.