### PR TITLE
SN-2757 evb2 startup flash write

### DIFF
--- a/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
+++ b/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
@@ -30,482 +30,482 @@
     <EraseKey />
     <AsfFrameworkConfig>
       <framework-data>
-  <options>
-    <option id="common.boards" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="common.components.memory.sd_mmc" value="Add" config="mci" content-id="Atmel.ASF" />
-    <option id="common.components.wifi.winc3400" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="common.services.basic.clock" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="common.services.basic.gpio" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="common.services.ioport" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="common.services.basic.spi_master" value="Add" config="usart_and_standard_spi" content-id="Atmel.ASF" />
-    <option id="common.services.usb.class.device" value="Add" config="cdc" content-id="Atmel.ASF" />
-    <option id="common.utils.stdio.stdio_serial" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.mcan" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.mpu" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.pio" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.rtc" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.rtt" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.tc.appnote" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.twihs" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.wdt" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.drivers.xdmac" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.services.flash" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="common.services.fs.fatfs" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="thirdparty.os.freertos.version" value="Add" config="7.3.0" content-id="Atmel.ASF" />
-    <option id="sam.drivers.afec" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="common.services.freertos.sam_example" value="Add" config="" content-id="Atmel.ASF" />
-    <option id="sam.utils.cmsis.same70.source.template" value="Add" config="" content-id="Atmel.ASF" />
-  </options>
-  <configurations>
-    <configuration key="config.thirdparty.os.freertos-10_0_0.memory_manager" value="3_use_libc_malloc_free" default="3_use_libc_malloc_free" content-id="Atmel.ASF" />
-    <configuration key="config.board.same70_xplained.led" value="yes" default="yes" content-id="Atmel.ASF" />
-    <configuration key="config.compiler.armgcc.create_aux" value="no" default="no" content-id="Atmel.ASF" />
-    <configuration key="config.compiler.armgcc.optimization" value="high" default="high" content-id="Atmel.ASF" />
-    <configuration key="config.compiler.iarewarm.debugger.driver" value="cmsisdap" default="cmsisdap" content-id="Atmel.ASF" />
-    <configuration key="config.compiler.iarewarm.heap_size" value="0x1800" default="0x1800" content-id="Atmel.ASF" />
-    <configuration key="config.thirdparty.os.freertos.version" value="7.3.0" default="10.0.0" content-id="Atmel.ASF" />
-    <configuration key="config.compiler.armgcc.fpu_used" value="yes" default="yes" content-id="Atmel.ASF" />
-    <configuration key="config.compiler.armgcc.printf" value="iprintf" default="iprintf" content-id="Atmel.ASF" />
-    <configuration key="config.compiler.armgcc.scanf" value="iscanf" default="iscanf" content-id="Atmel.ASF" />
-    <configuration key="config.sam.pio.pio_handler" value="yes" default="yes" content-id="Atmel.ASF" />
-    <configuration key="config.common.components.memory.sd_mmc.ctrl_access" value="enable" default="disable" content-id="Atmel.ASF" />
-    <configuration key="config.sam.drivers.usbhs.device.sleepmgr" value="with_sleepmgr" default="with_sleepmgr" content-id="Atmel.ASF" />
-    <configuration key="config.common.services.fs.fatfs.codepage" value="sbcs" default="sbcs" content-id="Atmel.ASF" />
-  </configurations>
-  <files>
-    <file path="src/ASF/common/services/serial/sam_uart/uart_serial.h" framework="" version="" source="common/services/serial/sam_uart/uart_serial.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/serial/serial.h" framework="" version="" source="common/services/serial/serial.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/serial/usart_serial.c" framework="" version="" source="common/services/serial/usart_serial.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/utils/stdio/read.c" framework="" version="" source="common/utils/stdio/read.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/utils/stdio/stdio_serial/stdio_serial.h" framework="" version="" source="common/utils/stdio/stdio_serial/stdio_serial.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/utils/stdio/write.c" framework="" version="" source="common/utils/stdio/write.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/boards/user_board/init.c" framework="" version="" source="sam/boards/user_board/init.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/boards/user_board/led.h" framework="" version="" source="sam/boards/user_board/led.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/boards/same70_xplained/same70_xplained.h" framework="" version="3.44.1" source="sam\boards\same70_xplained\same70_xplained.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/uart/uart.c" framework="" version="" source="sam/drivers/uart/uart.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/uart/uart.h" framework="" version="" source="sam/drivers/uart/uart.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/usart/usart.c" framework="" version="" source="sam/drivers/usart/usart.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/usart/usart.h" framework="" version="" source="sam/drivers/usart/usart.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70j19b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70j20b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70j21b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70n19b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70n20b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70n21b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70q19b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70q20b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70q21b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70j19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70j19b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70j20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70j20b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70j21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70j21b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70n19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70n19b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70n20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70n20b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70n21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70n21b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70q19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70q19b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70q20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70q20b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70q21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70q21b.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/linker_scripts/same70/same70q21/gcc/flash.ld" framework="" version="" source="sam/utils/linker_scripts/same70/same70q21/gcc/flash.ld" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/license.txt" framework="" version="" source="thirdparty/CMSIS/license.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/main.c" framework="" version="" source="thirdparty/freertos/demo/sam_example/main.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/FreeRTOSConfig.h" framework="" version="3.44.1" source="thirdparty\freertos\freertos-10.0.0\module_config\FreeRTOSConfig.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_board.h" framework="" version="3.44.1" source="sam\drivers\tc\tc_capture_waveform_example\sam4e16e_sam4e_ek\conf_board.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_clock.h" framework="" version="3.44.1" source="common\services\clock\same70\module_config\conf_clock.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_uart_serial.h" framework="" version="3.44.1" source="common\services\serial\sam_uart\module_config\conf_uart_serial.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/License/license.txt" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/License/license.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/croutine.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/croutine.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/event_groups.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/event_groups.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/FreeRTOS.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/FreeRTOS.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/StackMacros.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/StackMacros.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/croutine.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/croutine.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/deprecated_definitions.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/deprecated_definitions.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/event_groups.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/event_groups.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/list.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/list.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/message_buffer.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/message_buffer.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/mpu_wrappers.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/mpu_wrappers.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/portable.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/portable.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/projdefs.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/projdefs.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/queue.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/queue.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/semphr.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/semphr.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/stack_macros.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/stack_macros.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/stream_buffer.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/stream_buffer.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/task.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/task.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/timers.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/timers.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/list.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/list.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/portable/GCC/ARM_CM7/r0p1/port.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/portable/GCC/ARM_CM7/r0p1/port.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/portable/GCC/ARM_CM7/r0p1/portmacro.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/portable/GCC/ARM_CM7/r0p1/portmacro.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/portable/MemMang/heap_4.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/portable/MemMang/heap_4.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/portable/readme.txt" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/portable/readme.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/queue.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/queue.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/readme.txt" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/readme.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/stream_buffer.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/stream_buffer.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/tasks.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/tasks.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/timers.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/timers.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/readme.txt" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/readme.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/storage/ctrl_access/ctrl_access.c" framework="" version="3.44.1" source="common\services\storage\ctrl_access\ctrl_access.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/storage/ctrl_access/ctrl_access.h" framework="" version="3.44.1" source="common\services\storage\ctrl_access\ctrl_access.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_access.h" framework="" version="3.44.1" source="common\services\storage\ctrl_access\module_config\conf_access.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/mcan/mcan.c" framework="" version="3.44.1" source="sam\drivers\mcan\mcan.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/mcan/mcan.h" framework="" version="3.44.1" source="sam\drivers\mcan\mcan.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_mcan.h" framework="" version="3.44.1" source="sam\drivers\mcan\module_config\conf_mcan.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/rtc/rtc.c" framework="" version="3.44.1" source="sam\drivers\rtc\rtc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/rtc/rtc.h" framework="" version="3.44.1" source="sam\drivers\rtc\rtc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/tc/tc.c" framework="" version="3.44.1" source="sam\drivers\tc\tc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/tc/tc.h" framework="" version="3.44.1" source="sam\drivers\tc\tc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/tc/tc_capture_waveform_example/tc_capture_waveform_example.h" framework="" version="3.44.1" source="sam\drivers\tc\tc_capture_waveform_example\tc_capture_waveform_example.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/twihs/twihs.c" framework="" version="3.44.1" source="sam\drivers\twihs\twihs.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/twihs/twihs.h" framework="" version="3.44.1" source="sam\drivers\twihs\twihs.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/xdmac/xdmac.c" framework="" version="3.44.1" source="sam\drivers\xdmac\xdmac.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/xdmac/xdmac.h" framework="" version="3.44.1" source="sam\drivers\xdmac\xdmac.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/ff.c" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\ff.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/00index_e.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\00index_e.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/00index_j.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\00index_j.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dwrite.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dwrite.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/close.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\close.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/unlink.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\unlink.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f3.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f3.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f2.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f2.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f1.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f1.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/mount.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\mount.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/appnote.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\appnote.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/ATMEL-disclaimer.txt" framework="" version="3.44.1" source="thirdparty\fatfs\ATMEL-disclaimer.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/chdrive.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\chdrive.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/error.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\error.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/getcwd.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\getcwd.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/open.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\open.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dstat.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dstat.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/rename.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\rename.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/rwtest2.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\rwtest2.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/rwtest3.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\rwtest3.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/00readme.txt" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\00readme.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dioctl.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dioctl.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/eof.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\eof.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/read.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\read.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/chdir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\chdir.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/fattime.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\fattime.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/utime.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\utime.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/write.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\write.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sfile.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sfile.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sdir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sdir.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/putc.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\putc.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/forward.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\forward.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/puts.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\puts.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/readdir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\readdir.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/size.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\size.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f6.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f6.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/filename.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\filename.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/updates.txt" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\updates.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f5.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f5.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/lseek.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\lseek.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/rwtest.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\rwtest.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sfileinfo.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sfileinfo.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f4.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f4.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/getfree.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\getfree.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/opendir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\opendir.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/layers3.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\layers3.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dread.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dread.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/mkfs.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\mkfs.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sync.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sync.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/css_j.css" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\css_j.css" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/css_e.css" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\css_e.css" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sfatfs.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sfatfs.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/tell.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\tell.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/chmod.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\chmod.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/stat.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\stat.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/truncate.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\truncate.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/printf.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\printf.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/gets.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\gets.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/mkdir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\mkdir.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/rc.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\rc.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/layers.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\layers.png" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dinit.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dinit.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/fdisk.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\fdisk.html" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/ffconf.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\ffconf.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/diskio.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\diskio.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/ff.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\ff.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/integer.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\integer.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc.c" framework="" version="3.44.1" source="common\components\memory\sd_mmc\sd_mmc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc.h" framework="" version="3.44.1" source="common\components\memory\sd_mmc\sd_mmc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_sd_mmc.h" framework="" version="3.44.1" source="common\components\memory\sd_mmc\module_config_spi\conf_sd_mmc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc_protocol.h" framework="" version="3.44.1" source="common\components\memory\sd_mmc\sd_mmc_protocol.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/delay/sam/cycle_counter.c" framework="" version="3.44.1" source="common\services\delay\sam\cycle_counter.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/delay/sam/cycle_counter.h" framework="" version="3.44.1" source="common\services\delay\sam\cycle_counter.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/delay/delay.h" framework="" version="3.44.1" source="common\services\delay\delay.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/sleepmgr/sam/sleepmgr.c" framework="" version="3.44.1" source="common\services\sleepmgr\sam\sleepmgr.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/sleepmgr/sleepmgr.h" framework="" version="3.44.1" source="common\services\sleepmgr\sleepmgr.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/sleepmgr/sam/sleepmgr.h" framework="" version="3.44.1" source="common\services\sleepmgr\sam\sleepmgr.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/spi/sam_spi/spi_master.c" framework="" version="3.44.1" source="common\services\spi\sam_spi\spi_master.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/spi/sam_spi/spi_master.h" framework="" version="3.44.1" source="common\services\spi\sam_spi\spi_master.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/spi/spi_master.h" framework="" version="3.44.1" source="common\services\spi\spi_master.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_spi_master.h" framework="" version="3.44.1" source="common\services\spi\sam_spi\module_config\conf_spi_master.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/spi/sam_usart_spi/usart_spi.c" framework="" version="3.42.0" source="common\services\spi\sam_usart_spi\usart_spi.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/spi/sam_usart_spi/usart_spi.h" framework="" version="3.42.0" source="common\services\spi\sam_usart_spi\usart_spi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/spi/usart_spi.h" framework="" version="3.42.0" source="common\services\spi\usart_spi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_usart_spi.h" framework="" version="3.42.0" source="common\services\spi\sam_usart_spi\module_config\conf_usart_spi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/usb_atmel.h" framework="" version="3.44.1" source="common\services\usb\usb_atmel.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/usb_protocol.h" framework="" version="3.44.1" source="common\services\usb\usb_protocol.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/class/cdc/usb_protocol_cdc.h" framework="" version="3.44.1" source="common\services\usb\class\cdc\usb_protocol_cdc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/class/cdc/device/udi_cdc.c" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\udi_cdc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/class/cdc/device/udi_cdc_desc.c" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\udi_cdc_desc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="atmel_devices_cdc.cat" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\atmel_devices_cdc.cat" changed="False" content-id="Atmel.ASF" />
-    <file path="atmel_devices_cdc.inf" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\atmel_devices_cdc.inf" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/class/cdc/device/udi_cdc.h" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\udi_cdc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/class/cdc/device/udi_cdc_conf.h" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\udi_cdc_conf.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_usb.h" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\module_config\conf_usb.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/udc/udc.c" framework="" version="3.44.1" source="common\services\usb\udc\udc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/udc/udc.h" framework="" version="3.44.1" source="common\services\usb\udc\udc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/udc/udd.h" framework="" version="3.44.1" source="common\services\usb\udc\udd.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/udc/udc_desc.h" framework="" version="3.44.1" source="common\services\usb\udc\udc_desc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/usb/udc/udi.h" framework="" version="3.44.1" source="common\services\usb\udc\udi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/hsmci/hsmci.c" framework="" version="3.42.0" source="sam\drivers\hsmci\hsmci.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/hsmci/hsmci.h" framework="" version="3.42.0" source="sam\drivers\hsmci\hsmci.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/spi/spi.c" framework="" version="3.44.1" source="sam\drivers\spi\spi.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/spi/spi.h" framework="" version="3.44.1" source="sam\drivers\spi\spi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/usbhs/usbhs_device.c" framework="" version="3.44.1" source="sam\drivers\usbhs\usbhs_device.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/usbhs/usbhs_otg.h" framework="" version="3.44.1" source="sam\drivers\usbhs\usbhs_otg.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/usbhs/usbhs_device.h" framework="" version="3.44.1" source="sam\drivers\usbhs\usbhs_device.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-port-r0.09/diskio.c" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-port-r0.09\diskio.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-port-r0.09/sam/fattime_rtc.c" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-port-r0.09\sam\fattime_rtc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/option/ccsbcs.c" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\option\ccsbcs.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_fatfs.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\module_config_sbcs\conf_fatfs.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc_mem.c" framework="" version="3.42.0" source="common\components\memory\sd_mmc\sd_mmc_mem.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc_mem.h" framework="" version="3.42.0" source="common\components\memory\sd_mmc\sd_mmc_mem.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/rtt/rtt.c" framework="" version="3.44.1" source="sam\drivers\rtt\rtt.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/rtt/rtt.h" framework="" version="3.44.1" source="sam\drivers\rtt\rtt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/source/templates/system_same70.c" framework="" version="3.44.1" source="sam\utils\cmsis\same70\source\templates\system_same70.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/source/templates/gcc/startup_same70.c" framework="" version="3.44.1" source="sam\utils\cmsis\same70\source\templates\gcc\startup_same70.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/source/templates/system_same70.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\source\templates\system_same70.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/boards/board.h" framework="" version="3.44.1" source="common\boards\board.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/status_codes.h" framework="" version="3.44.1" source="sam\utils\status_codes.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/compiler.h" framework="" version="3.44.1" source="sam\utils\compiler.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/header_files/io.h" framework="" version="3.44.1" source="sam\utils\header_files\io.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/preprocessor/mrepeat.h" framework="" version="3.44.1" source="sam\utils\preprocessor\mrepeat.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/preprocessor/preprocessor.h" framework="" version="3.44.1" source="sam\utils\preprocessor\preprocessor.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/preprocessor/tpaste.h" framework="" version="3.44.1" source="sam\utils\preprocessor\tpaste.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/preprocessor/stringz.h" framework="" version="3.44.1" source="sam\utils\preprocessor\stringz.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/make/Makefile.sam.in" framework="" version="3.44.1" source="sam\utils\make\Makefile.sam.in" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Include/core_cmFunc.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\core_cmFunc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Include/core_cmInstr.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\core_cmInstr.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Include/core_cm7.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\core_cm7.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Include/arm_const_structs.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\arm_const_structs.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Include/core_cmSimd.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\core_cmSimd.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Include/arm_math.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\arm_math.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Include/arm_common_tables.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\arm_common_tables.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Lib/GCC/libarm_cortexM7lfsp_math.a" framework="" version="3.44.1" source="thirdparty\CMSIS\Lib\GCC\libarm_cortexM7lfsp_math.a" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Lib/GCC/libarm_cortexM7lfsp_math_softfp.a" framework="" version="3.44.1" source="thirdparty\CMSIS\Lib\GCC\libarm_cortexM7lfsp_math_softfp.a" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/CMSIS_END_USER_LICENCE_AGREEMENT.pdf" framework="" version="3.44.1" source="thirdparty\CMSIS\CMSIS_END_USER_LICENCE_AGREEMENT.pdf" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/README.txt" framework="" version="3.44.1" source="thirdparty\CMSIS\README.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/ATMEL-disclaimer.txt" framework="" version="3.44.1" source="thirdparty\CMSIS\ATMEL-disclaimer.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/thirdparty/CMSIS/Lib/license.txt" framework="" version="3.44.1" source="thirdparty\CMSIS\Lib\license.txt" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/syscalls/gcc/syscalls.c" framework="" version="3.44.1" source="sam\utils\syscalls\gcc\syscalls.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/fpu/fpu.h" framework="" version="3.44.1" source="sam\utils\fpu\fpu.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/utils/interrupt/interrupt_sam_nvic.c" framework="" version="3.44.1" source="common\utils\interrupt\interrupt_sam_nvic.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/utils/interrupt.h" framework="" version="3.44.1" source="common\utils\interrupt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/utils/interrupt/interrupt_sam_nvic.h" framework="" version="3.44.1" source="common\utils\interrupt\interrupt_sam_nvic.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/utils/parts.h" framework="" version="3.44.1" source="common\utils\parts.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70j20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70j20.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70j21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70j21.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70n20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70n20.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70n21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70n21.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70q20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70q20.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70q21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70q21.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70j19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70j19.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70n19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70n19.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/same70q19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70q19.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/wdt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\wdt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/chipid.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\chipid.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/spi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\spi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/gmac.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\gmac.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/pio.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\pio.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/usbhs.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\usbhs.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/rswdt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\rswdt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/efc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\efc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/utmi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\utmi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/hsmci.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\hsmci.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/supc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\supc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/pwm.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\pwm.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/twihs.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\twihs.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/aes.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\aes.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/usart.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\usart.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/sdramc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\sdramc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/qspi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\qspi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/isi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\isi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/ssc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\ssc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/rstc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\rstc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/afec.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\afec.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/trng.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\trng.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/rtc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\rtc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/i2sc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\i2sc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/dacc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\dacc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/mcan.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\mcan.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/pmc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\pmc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/matrix.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\matrix.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/rtt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\rtt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/smc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\smc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/gpbr.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\gpbr.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/acc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\acc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/icm.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\icm.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/tc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\tc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/uart.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\uart.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/component/xdmac.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\xdmac.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/gpbr.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\gpbr.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/matrix.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\matrix.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/usart0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\usart0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/usart1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\usart1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/usart2.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\usart2.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/utmi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\utmi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/tc3.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\tc3.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/trng.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\trng.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/hsmci.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\hsmci.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/gmac.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\gmac.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/smc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\smc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/ssc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\ssc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/i2sc0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\i2sc0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/i2sc1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\i2sc1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/twihs0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\twihs0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/twihs1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\twihs1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/twihs2.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\twihs2.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/tc2.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\tc2.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/isi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\isi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pwm0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pwm0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pwm1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pwm1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/rstc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\rstc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/spi1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\spi1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/spi0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\spi0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/aes.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\aes.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/rtc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\rtc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/qspi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\qspi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/afec0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\afec0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/afec1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\afec1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/tc1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\tc1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/icm.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\icm.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/usbhs.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\usbhs.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/wdt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\wdt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/mcan0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\mcan0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/chipid.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\chipid.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/dacc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\dacc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/mcan1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\mcan1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/xdmac.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\xdmac.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart4.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart4.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/sdramc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\sdramc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart2.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart2.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart3.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart3.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart1.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/tc0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\tc0.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/rswdt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\rswdt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/acc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\acc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/efc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\efc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/rtt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\rtt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pmc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pmc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/supc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\supc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/piod.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\piod.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pioe.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pioe.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pioa.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pioa.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/piob.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\piob.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pioc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pioc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70n20.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70n21.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70j20.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70n19.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70q19.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70j19.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70j21.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70q20.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70q21.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/ioport/sam/ioport_pio.h" framework="" version="3.44.1" source="common\services\ioport\sam\ioport_pio.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/ioport/ioport.h" framework="" version="3.44.1" source="common\services\ioport\ioport.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/same70/sysclk.c" framework="" version="3.44.1" source="common\services\clock\same70\sysclk.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/same70/genclk.h" framework="" version="3.44.1" source="common\services\clock\same70\genclk.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/same70/pll.h" framework="" version="3.44.1" source="common\services\clock\same70\pll.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/genclk.h" framework="" version="3.44.1" source="common\services\clock\genclk.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/osc.h" framework="" version="3.44.1" source="common\services\clock\osc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/same70/osc.h" framework="" version="3.44.1" source="common\services\clock\same70\osc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/same70/sysclk.h" framework="" version="3.44.1" source="common\services\clock\same70\sysclk.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/sysclk.h" framework="" version="3.44.1" source="common\services\clock\sysclk.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/clock/pll.h" framework="" version="3.44.1" source="common\services\clock\pll.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/pmc/pmc.c" framework="" version="3.44.1" source="sam\drivers\pmc\pmc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/pmc/sleep.c" framework="" version="3.44.1" source="sam\drivers\pmc\sleep.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/pmc/pmc.h" framework="" version="3.44.1" source="sam\drivers\pmc\pmc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/pmc/sleep.h" framework="" version="3.44.1" source="sam\drivers\pmc\sleep.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/gpio/sam_gpio/sam_gpio.h" framework="" version="3.44.1" source="common\services\gpio\sam_gpio\sam_gpio.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/services/gpio/gpio.h" framework="" version="3.44.1" source="common\services\gpio\gpio.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/pio/pio.c" framework="" version="3.44.1" source="sam\drivers\pio\pio.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/pio/pio.h" framework="" version="3.44.1" source="sam\drivers\pio\pio.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/pio/pio_handler.c" framework="" version="3.44.1" source="sam\drivers\pio\pio_handler.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/pio/pio_handler.h" framework="" version="3.44.1" source="sam\drivers\pio\pio_handler.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/mpu/mpu.c" framework="" version="3.44.1" source="sam\drivers\mpu\mpu.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/mpu/mpu.h" framework="" version="3.44.1" source="sam\drivers\mpu\mpu.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/common/source/nm_common.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\common\source\nm_common.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/spi_flash/source/spi_flash.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\spi_flash\source\spi_flash.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_flash.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_flash.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/source/nm_bsp_same70_app.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\source\nm_bsp_same70_app.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/source/nm_bsp_same70.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\source\nm_bsp_same70.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bus_wrapper/source/nm_bus_wrapper_same70.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bus_wrapper\source\nm_bus_wrapper_same70.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmbus.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmbus.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_hif.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_hif.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/socket/source/socket.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\socket\source\socket.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_periph.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_periph.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmuart.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmuart.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmspi.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmspi.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmasic.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmasic.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_crypto.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_crypto.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_wifi.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_wifi.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_ota.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_ota.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_ate_mode.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_ate_mode.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmflash.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmflash.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmdrv.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmdrv.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmi2c.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmi2c.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/WINC3400_IoT_SW_APIs.chm" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\WINC3400_IoT_SW_APIs.chm" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/common/include/nm_debug.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\common\include\nm_debug.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/socket/include/m2m_socket_host_if.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\socket\include\m2m_socket_host_if.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/include/nm_bsp.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\include\nm_bsp.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/common/include/nm_common.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\common\include\nm_common.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/spi_flash/include/spi_flash.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\spi_flash\include\spi_flash.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmbus.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmbus.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/socket/include/socket.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\socket\include\socket.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_wifi.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_wifi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_ota.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_ota.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmspi.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmspi.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/socket/source/socket_internal.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\socket\source\socket_internal.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmdrv.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmdrv.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/include/nm_bsp_internal.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\include\nm_bsp_internal.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmuart.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmuart.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmasic.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmasic.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmi2c.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmi2c.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/include/nm_bsp_same70.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\include\nm_bsp_same70.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bus_wrapper/include/nm_bus_wrapper.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bus_wrapper\include\nm_bus_wrapper.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_ate_mode.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_ate_mode.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/programmer/programmer.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\programmer\programmer.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_crypto.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_crypto.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_hif.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_hif.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_flash.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_flash.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/include/nm_bsp_same70_app.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\include\nm_bsp_same70_app.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_types.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_types.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/spi_flash/include/spi_flash_map.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\spi_flash\include\spi_flash_map.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmflash.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmflash.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_periph.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_periph.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/Config/conf_winc.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\module_config\same70\conf_winc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/efc/efc.h" framework="" version="3.44.1" source="sam\drivers\efc\efc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/services/flash_efc/flash_efc.c" framework="" version="3.44.1" source="sam\services\flash_efc\flash_efc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/services/flash_efc/flash_efc.h" framework="" version="3.44.1" source="sam\services\flash_efc\flash_efc.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/efc/efc.c" framework="" version="3.44.1" source="sam\drivers\efc\efc.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/wdt/wdt.c" framework="" version="3.44.1" source="sam\drivers\wdt\wdt.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/wdt/wdt.h" framework="" version="3.44.1" source="sam\drivers\wdt\wdt.h" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/afec/afec.c" framework="" version="3.44.1" source="sam\drivers\afec\afec.c" changed="False" content-id="Atmel.ASF" />
-    <file path="src/ASF/sam/drivers/afec/afec.h" framework="" version="3.44.1" source="sam\drivers\afec\afec.h" changed="False" content-id="Atmel.ASF" />
-  </files>
-  <documentation help="http://asf.atmel.com/docs/3.44.1/common.services.freertos.sam_example.same70_xplained/html/index.html" />
-  <offline-documentation help="" />
-  <dependencies>
-    <content-extension eid="atmel.asf" uuidref="Atmel.ASF" version="3.42.0" />
-  </dependencies>
-  <project id="common.services.freertos.sam_example.same70_xplained" value="Add" config="" content-id="Atmel.ASF" />
-  <board id="board.same70_xplained" value="Add" config="" content-id="Atmel.ASF" />
-</framework-data>
+        <options>
+          <option id="common.boards" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="common.components.memory.sd_mmc" value="Add" config="mci" content-id="Atmel.ASF" />
+          <option id="common.components.wifi.winc3400" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="common.services.basic.clock" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="common.services.basic.gpio" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="common.services.ioport" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="common.services.basic.spi_master" value="Add" config="usart_and_standard_spi" content-id="Atmel.ASF" />
+          <option id="common.services.usb.class.device" value="Add" config="cdc" content-id="Atmel.ASF" />
+          <option id="common.utils.stdio.stdio_serial" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.mcan" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.mpu" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.pio" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.rtc" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.rtt" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.tc.appnote" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.twihs" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.wdt" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.drivers.xdmac" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.services.flash" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="common.services.fs.fatfs" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="thirdparty.os.freertos.version" value="Add" config="7.3.0" content-id="Atmel.ASF" />
+          <option id="sam.drivers.afec" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="common.services.freertos.sam_example" value="Add" config="" content-id="Atmel.ASF" />
+          <option id="sam.utils.cmsis.same70.source.template" value="Add" config="" content-id="Atmel.ASF" />
+        </options>
+        <configurations>
+          <configuration key="config.thirdparty.os.freertos-10_0_0.memory_manager" value="3_use_libc_malloc_free" default="3_use_libc_malloc_free" content-id="Atmel.ASF" />
+          <configuration key="config.board.same70_xplained.led" value="yes" default="yes" content-id="Atmel.ASF" />
+          <configuration key="config.compiler.armgcc.create_aux" value="no" default="no" content-id="Atmel.ASF" />
+          <configuration key="config.compiler.armgcc.optimization" value="high" default="high" content-id="Atmel.ASF" />
+          <configuration key="config.compiler.iarewarm.debugger.driver" value="cmsisdap" default="cmsisdap" content-id="Atmel.ASF" />
+          <configuration key="config.compiler.iarewarm.heap_size" value="0x1800" default="0x1800" content-id="Atmel.ASF" />
+          <configuration key="config.thirdparty.os.freertos.version" value="7.3.0" default="10.0.0" content-id="Atmel.ASF" />
+          <configuration key="config.compiler.armgcc.fpu_used" value="yes" default="yes" content-id="Atmel.ASF" />
+          <configuration key="config.compiler.armgcc.printf" value="iprintf" default="iprintf" content-id="Atmel.ASF" />
+          <configuration key="config.compiler.armgcc.scanf" value="iscanf" default="iscanf" content-id="Atmel.ASF" />
+          <configuration key="config.sam.pio.pio_handler" value="yes" default="yes" content-id="Atmel.ASF" />
+          <configuration key="config.common.components.memory.sd_mmc.ctrl_access" value="enable" default="disable" content-id="Atmel.ASF" />
+          <configuration key="config.sam.drivers.usbhs.device.sleepmgr" value="with_sleepmgr" default="with_sleepmgr" content-id="Atmel.ASF" />
+          <configuration key="config.common.services.fs.fatfs.codepage" value="sbcs" default="sbcs" content-id="Atmel.ASF" />
+        </configurations>
+        <files>
+          <file path="src/ASF/common/services/serial/sam_uart/uart_serial.h" framework="" version="" source="common/services/serial/sam_uart/uart_serial.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/serial/serial.h" framework="" version="" source="common/services/serial/serial.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/serial/usart_serial.c" framework="" version="" source="common/services/serial/usart_serial.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/utils/stdio/read.c" framework="" version="" source="common/utils/stdio/read.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/utils/stdio/stdio_serial/stdio_serial.h" framework="" version="" source="common/utils/stdio/stdio_serial/stdio_serial.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/utils/stdio/write.c" framework="" version="" source="common/utils/stdio/write.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/boards/user_board/init.c" framework="" version="" source="sam/boards/user_board/init.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/boards/user_board/led.h" framework="" version="" source="sam/boards/user_board/led.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/boards/same70_xplained/same70_xplained.h" framework="" version="3.44.1" source="sam\boards\same70_xplained\same70_xplained.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/uart/uart.c" framework="" version="" source="sam/drivers/uart/uart.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/uart/uart.h" framework="" version="" source="sam/drivers/uart/uart.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/usart/usart.c" framework="" version="" source="sam/drivers/usart/usart.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/usart/usart.h" framework="" version="" source="sam/drivers/usart/usart.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70j19b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70j20b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70j21b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70n19b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70n20b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70n21b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70q19b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70q20b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/pio/same70q21b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70j19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70j19b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70j20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70j20b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70j21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70j21b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70n19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70n19b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70n20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70n20b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70n21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70n21b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70q19b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70q19b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70q20b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70q20b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70q21b.h" framework="" version="" source="sam/utils/cmsis/same70/include/same70q21b.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/linker_scripts/same70/same70q21/gcc/flash.ld" framework="" version="" source="sam/utils/linker_scripts/same70/same70q21/gcc/flash.ld" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/license.txt" framework="" version="" source="thirdparty/CMSIS/license.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/main.c" framework="" version="" source="thirdparty/freertos/demo/sam_example/main.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/FreeRTOSConfig.h" framework="" version="3.44.1" source="thirdparty\freertos\freertos-10.0.0\module_config\FreeRTOSConfig.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_board.h" framework="" version="3.44.1" source="sam\drivers\tc\tc_capture_waveform_example\sam4e16e_sam4e_ek\conf_board.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_clock.h" framework="" version="3.44.1" source="common\services\clock\same70\module_config\conf_clock.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_uart_serial.h" framework="" version="3.44.1" source="common\services\serial\sam_uart\module_config\conf_uart_serial.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/License/license.txt" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/License/license.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/croutine.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/croutine.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/event_groups.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/event_groups.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/FreeRTOS.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/FreeRTOS.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/StackMacros.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/StackMacros.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/croutine.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/croutine.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/deprecated_definitions.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/deprecated_definitions.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/event_groups.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/event_groups.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/list.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/list.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/message_buffer.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/message_buffer.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/mpu_wrappers.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/mpu_wrappers.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/portable.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/portable.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/projdefs.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/projdefs.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/queue.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/queue.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/semphr.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/semphr.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/stack_macros.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/stack_macros.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/stream_buffer.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/stream_buffer.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/task.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/task.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/include/timers.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/include/timers.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/list.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/list.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/portable/GCC/ARM_CM7/r0p1/port.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/portable/GCC/ARM_CM7/r0p1/port.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/portable/GCC/ARM_CM7/r0p1/portmacro.h" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/portable/GCC/ARM_CM7/r0p1/portmacro.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/portable/MemMang/heap_4.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/portable/MemMang/heap_4.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/portable/readme.txt" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/portable/readme.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/queue.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/queue.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/readme.txt" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/readme.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/stream_buffer.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/stream_buffer.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/tasks.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/tasks.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/Source/timers.c" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/Source/timers.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/freertos/freertos-10.0.0/readme.txt" framework="" version="" source="thirdparty/freertos/freertos-10.0.0/readme.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/storage/ctrl_access/ctrl_access.c" framework="" version="3.44.1" source="common\services\storage\ctrl_access\ctrl_access.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/storage/ctrl_access/ctrl_access.h" framework="" version="3.44.1" source="common\services\storage\ctrl_access\ctrl_access.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_access.h" framework="" version="3.44.1" source="common\services\storage\ctrl_access\module_config\conf_access.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/mcan/mcan.c" framework="" version="3.44.1" source="sam\drivers\mcan\mcan.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/mcan/mcan.h" framework="" version="3.44.1" source="sam\drivers\mcan\mcan.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_mcan.h" framework="" version="3.44.1" source="sam\drivers\mcan\module_config\conf_mcan.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/rtc/rtc.c" framework="" version="3.44.1" source="sam\drivers\rtc\rtc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/rtc/rtc.h" framework="" version="3.44.1" source="sam\drivers\rtc\rtc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/tc/tc.c" framework="" version="3.44.1" source="sam\drivers\tc\tc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/tc/tc.h" framework="" version="3.44.1" source="sam\drivers\tc\tc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/tc/tc_capture_waveform_example/tc_capture_waveform_example.h" framework="" version="3.44.1" source="sam\drivers\tc\tc_capture_waveform_example\tc_capture_waveform_example.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/twihs/twihs.c" framework="" version="3.44.1" source="sam\drivers\twihs\twihs.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/twihs/twihs.h" framework="" version="3.44.1" source="sam\drivers\twihs\twihs.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/xdmac/xdmac.c" framework="" version="3.44.1" source="sam\drivers\xdmac\xdmac.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/xdmac/xdmac.h" framework="" version="3.44.1" source="sam\drivers\xdmac\xdmac.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/ff.c" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\ff.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/00index_e.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\00index_e.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/00index_j.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\00index_j.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dwrite.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dwrite.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/close.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\close.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/unlink.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\unlink.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f3.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f3.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f2.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f2.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f1.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f1.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/mount.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\mount.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/appnote.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\appnote.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/ATMEL-disclaimer.txt" framework="" version="3.44.1" source="thirdparty\fatfs\ATMEL-disclaimer.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/chdrive.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\chdrive.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/error.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\error.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/getcwd.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\getcwd.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/open.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\open.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dstat.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dstat.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/rename.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\rename.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/rwtest2.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\rwtest2.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/rwtest3.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\rwtest3.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/00readme.txt" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\00readme.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dioctl.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dioctl.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/eof.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\eof.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/read.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\read.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/chdir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\chdir.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/fattime.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\fattime.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/utime.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\utime.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/write.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\write.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sfile.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sfile.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sdir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sdir.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/putc.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\putc.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/forward.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\forward.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/puts.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\puts.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/readdir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\readdir.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/size.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\size.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f6.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f6.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/filename.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\filename.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/updates.txt" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\updates.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f5.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f5.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/lseek.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\lseek.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/rwtest.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\rwtest.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sfileinfo.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sfileinfo.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/f4.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\f4.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/getfree.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\getfree.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/opendir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\opendir.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/layers3.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\layers3.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dread.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dread.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/mkfs.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\mkfs.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sync.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sync.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/css_j.css" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\css_j.css" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/css_e.css" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\css_e.css" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/sfatfs.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\sfatfs.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/tell.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\tell.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/chmod.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\chmod.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/stat.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\stat.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/truncate.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\truncate.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/printf.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\printf.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/gets.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\gets.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/mkdir.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\mkdir.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/rc.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\rc.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/img/layers.png" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\img\layers.png" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/dinit.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\dinit.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/doc/en/fdisk.html" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\doc\en\fdisk.html" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/ffconf.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\ffconf.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/diskio.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\diskio.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/ff.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\ff.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/integer.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\integer.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc.c" framework="" version="3.44.1" source="common\components\memory\sd_mmc\sd_mmc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc.h" framework="" version="3.44.1" source="common\components\memory\sd_mmc\sd_mmc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_sd_mmc.h" framework="" version="3.44.1" source="common\components\memory\sd_mmc\module_config_spi\conf_sd_mmc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc_protocol.h" framework="" version="3.44.1" source="common\components\memory\sd_mmc\sd_mmc_protocol.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/delay/sam/cycle_counter.c" framework="" version="3.44.1" source="common\services\delay\sam\cycle_counter.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/delay/sam/cycle_counter.h" framework="" version="3.44.1" source="common\services\delay\sam\cycle_counter.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/delay/delay.h" framework="" version="3.44.1" source="common\services\delay\delay.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/sleepmgr/sam/sleepmgr.c" framework="" version="3.44.1" source="common\services\sleepmgr\sam\sleepmgr.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/sleepmgr/sleepmgr.h" framework="" version="3.44.1" source="common\services\sleepmgr\sleepmgr.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/sleepmgr/sam/sleepmgr.h" framework="" version="3.44.1" source="common\services\sleepmgr\sam\sleepmgr.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/spi/sam_spi/spi_master.c" framework="" version="3.44.1" source="common\services\spi\sam_spi\spi_master.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/spi/sam_spi/spi_master.h" framework="" version="3.44.1" source="common\services\spi\sam_spi\spi_master.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/spi/spi_master.h" framework="" version="3.44.1" source="common\services\spi\spi_master.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_spi_master.h" framework="" version="3.44.1" source="common\services\spi\sam_spi\module_config\conf_spi_master.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/spi/sam_usart_spi/usart_spi.c" framework="" version="3.42.0" source="common\services\spi\sam_usart_spi\usart_spi.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/spi/sam_usart_spi/usart_spi.h" framework="" version="3.42.0" source="common\services\spi\sam_usart_spi\usart_spi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/spi/usart_spi.h" framework="" version="3.42.0" source="common\services\spi\usart_spi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_usart_spi.h" framework="" version="3.42.0" source="common\services\spi\sam_usart_spi\module_config\conf_usart_spi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/usb_atmel.h" framework="" version="3.44.1" source="common\services\usb\usb_atmel.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/usb_protocol.h" framework="" version="3.44.1" source="common\services\usb\usb_protocol.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/class/cdc/usb_protocol_cdc.h" framework="" version="3.44.1" source="common\services\usb\class\cdc\usb_protocol_cdc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/class/cdc/device/udi_cdc.c" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\udi_cdc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/class/cdc/device/udi_cdc_desc.c" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\udi_cdc_desc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="atmel_devices_cdc.cat" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\atmel_devices_cdc.cat" changed="False" content-id="Atmel.ASF" />
+          <file path="atmel_devices_cdc.inf" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\atmel_devices_cdc.inf" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/class/cdc/device/udi_cdc.h" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\udi_cdc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/class/cdc/device/udi_cdc_conf.h" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\udi_cdc_conf.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_usb.h" framework="" version="3.44.1" source="common\services\usb\class\cdc\device\module_config\conf_usb.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/udc/udc.c" framework="" version="3.44.1" source="common\services\usb\udc\udc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/udc/udc.h" framework="" version="3.44.1" source="common\services\usb\udc\udc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/udc/udd.h" framework="" version="3.44.1" source="common\services\usb\udc\udd.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/udc/udc_desc.h" framework="" version="3.44.1" source="common\services\usb\udc\udc_desc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/usb/udc/udi.h" framework="" version="3.44.1" source="common\services\usb\udc\udi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/hsmci/hsmci.c" framework="" version="3.42.0" source="sam\drivers\hsmci\hsmci.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/hsmci/hsmci.h" framework="" version="3.42.0" source="sam\drivers\hsmci\hsmci.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/spi/spi.c" framework="" version="3.44.1" source="sam\drivers\spi\spi.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/spi/spi.h" framework="" version="3.44.1" source="sam\drivers\spi\spi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/usbhs/usbhs_device.c" framework="" version="3.44.1" source="sam\drivers\usbhs\usbhs_device.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/usbhs/usbhs_otg.h" framework="" version="3.44.1" source="sam\drivers\usbhs\usbhs_otg.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/usbhs/usbhs_device.h" framework="" version="3.44.1" source="sam\drivers\usbhs\usbhs_device.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-port-r0.09/diskio.c" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-port-r0.09\diskio.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-port-r0.09/sam/fattime_rtc.c" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-port-r0.09\sam\fattime_rtc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/fatfs/fatfs-r0.09/src/option/ccsbcs.c" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\option\ccsbcs.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_fatfs.h" framework="" version="3.44.1" source="thirdparty\fatfs\fatfs-r0.09\src\module_config_sbcs\conf_fatfs.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc_mem.c" framework="" version="3.42.0" source="common\components\memory\sd_mmc\sd_mmc_mem.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/memory/sd_mmc/sd_mmc_mem.h" framework="" version="3.42.0" source="common\components\memory\sd_mmc\sd_mmc_mem.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/rtt/rtt.c" framework="" version="3.44.1" source="sam\drivers\rtt\rtt.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/rtt/rtt.h" framework="" version="3.44.1" source="sam\drivers\rtt\rtt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/source/templates/system_same70.c" framework="" version="3.44.1" source="sam\utils\cmsis\same70\source\templates\system_same70.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/source/templates/gcc/startup_same70.c" framework="" version="3.44.1" source="sam\utils\cmsis\same70\source\templates\gcc\startup_same70.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/source/templates/system_same70.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\source\templates\system_same70.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/boards/board.h" framework="" version="3.44.1" source="common\boards\board.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/status_codes.h" framework="" version="3.44.1" source="sam\utils\status_codes.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/compiler.h" framework="" version="3.44.1" source="sam\utils\compiler.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/header_files/io.h" framework="" version="3.44.1" source="sam\utils\header_files\io.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/preprocessor/mrepeat.h" framework="" version="3.44.1" source="sam\utils\preprocessor\mrepeat.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/preprocessor/preprocessor.h" framework="" version="3.44.1" source="sam\utils\preprocessor\preprocessor.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/preprocessor/tpaste.h" framework="" version="3.44.1" source="sam\utils\preprocessor\tpaste.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/preprocessor/stringz.h" framework="" version="3.44.1" source="sam\utils\preprocessor\stringz.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/make/Makefile.sam.in" framework="" version="3.44.1" source="sam\utils\make\Makefile.sam.in" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Include/core_cmFunc.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\core_cmFunc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Include/core_cmInstr.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\core_cmInstr.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Include/core_cm7.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\core_cm7.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Include/arm_const_structs.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\arm_const_structs.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Include/core_cmSimd.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\core_cmSimd.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Include/arm_math.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\arm_math.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Include/arm_common_tables.h" framework="" version="3.44.1" source="thirdparty\CMSIS\Include\arm_common_tables.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Lib/GCC/libarm_cortexM7lfsp_math.a" framework="" version="3.44.1" source="thirdparty\CMSIS\Lib\GCC\libarm_cortexM7lfsp_math.a" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Lib/GCC/libarm_cortexM7lfsp_math_softfp.a" framework="" version="3.44.1" source="thirdparty\CMSIS\Lib\GCC\libarm_cortexM7lfsp_math_softfp.a" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/CMSIS_END_USER_LICENCE_AGREEMENT.pdf" framework="" version="3.44.1" source="thirdparty\CMSIS\CMSIS_END_USER_LICENCE_AGREEMENT.pdf" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/README.txt" framework="" version="3.44.1" source="thirdparty\CMSIS\README.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/ATMEL-disclaimer.txt" framework="" version="3.44.1" source="thirdparty\CMSIS\ATMEL-disclaimer.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/thirdparty/CMSIS/Lib/license.txt" framework="" version="3.44.1" source="thirdparty\CMSIS\Lib\license.txt" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/syscalls/gcc/syscalls.c" framework="" version="3.44.1" source="sam\utils\syscalls\gcc\syscalls.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/fpu/fpu.h" framework="" version="3.44.1" source="sam\utils\fpu\fpu.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/utils/interrupt/interrupt_sam_nvic.c" framework="" version="3.44.1" source="common\utils\interrupt\interrupt_sam_nvic.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/utils/interrupt.h" framework="" version="3.44.1" source="common\utils\interrupt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/utils/interrupt/interrupt_sam_nvic.h" framework="" version="3.44.1" source="common\utils\interrupt\interrupt_sam_nvic.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/utils/parts.h" framework="" version="3.44.1" source="common\utils\parts.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70j20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70j20.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70j21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70j21.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70n20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70n20.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70n21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70n21.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70q20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70q20.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70q21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70q21.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70j19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70j19.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70n19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70n19.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/same70q19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\same70q19.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/wdt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\wdt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/chipid.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\chipid.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/spi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\spi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/gmac.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\gmac.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/pio.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\pio.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/usbhs.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\usbhs.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/rswdt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\rswdt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/efc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\efc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/utmi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\utmi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/hsmci.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\hsmci.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/supc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\supc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/pwm.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\pwm.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/twihs.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\twihs.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/aes.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\aes.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/usart.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\usart.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/sdramc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\sdramc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/qspi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\qspi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/isi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\isi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/ssc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\ssc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/rstc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\rstc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/afec.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\afec.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/trng.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\trng.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/rtc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\rtc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/i2sc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\i2sc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/dacc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\dacc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/mcan.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\mcan.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/pmc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\pmc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/matrix.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\matrix.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/rtt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\rtt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/smc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\smc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/gpbr.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\gpbr.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/acc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\acc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/icm.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\icm.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/tc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\tc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/uart.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\uart.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/component/xdmac.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\component\xdmac.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/gpbr.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\gpbr.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/matrix.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\matrix.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/usart0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\usart0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/usart1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\usart1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/usart2.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\usart2.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/utmi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\utmi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/tc3.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\tc3.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/trng.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\trng.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/hsmci.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\hsmci.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/gmac.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\gmac.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/smc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\smc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/ssc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\ssc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/i2sc0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\i2sc0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/i2sc1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\i2sc1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/twihs0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\twihs0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/twihs1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\twihs1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/twihs2.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\twihs2.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/tc2.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\tc2.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/isi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\isi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pwm0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pwm0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pwm1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pwm1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/rstc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\rstc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/spi1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\spi1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/spi0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\spi0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/aes.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\aes.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/rtc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\rtc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/qspi.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\qspi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/afec0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\afec0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/afec1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\afec1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/tc1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\tc1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/icm.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\icm.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/usbhs.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\usbhs.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/wdt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\wdt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/mcan0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\mcan0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/chipid.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\chipid.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/dacc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\dacc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/mcan1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\mcan1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/xdmac.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\xdmac.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart4.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart4.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/sdramc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\sdramc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart2.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart2.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart3.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart3.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/uart1.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\uart1.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/tc0.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\tc0.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/rswdt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\rswdt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/acc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\acc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/efc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\efc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/rtt.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\rtt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pmc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pmc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/supc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\supc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/piod.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\piod.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pioe.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pioe.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pioa.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pioa.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/piob.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\piob.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/instance/pioc.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\instance\pioc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70n20.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70n21.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70j20.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70n19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70n19.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70q19.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j19.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70j19.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70j21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70j21.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q20.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70q20.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/utils/cmsis/same70/include/pio/same70q21.h" framework="" version="3.44.1" source="sam\utils\cmsis\same70\include\pio\same70q21.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/ioport/sam/ioport_pio.h" framework="" version="3.44.1" source="common\services\ioport\sam\ioport_pio.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/ioport/ioport.h" framework="" version="3.44.1" source="common\services\ioport\ioport.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/same70/sysclk.c" framework="" version="3.44.1" source="common\services\clock\same70\sysclk.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/same70/genclk.h" framework="" version="3.44.1" source="common\services\clock\same70\genclk.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/same70/pll.h" framework="" version="3.44.1" source="common\services\clock\same70\pll.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/genclk.h" framework="" version="3.44.1" source="common\services\clock\genclk.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/osc.h" framework="" version="3.44.1" source="common\services\clock\osc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/same70/osc.h" framework="" version="3.44.1" source="common\services\clock\same70\osc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/same70/sysclk.h" framework="" version="3.44.1" source="common\services\clock\same70\sysclk.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/sysclk.h" framework="" version="3.44.1" source="common\services\clock\sysclk.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/clock/pll.h" framework="" version="3.44.1" source="common\services\clock\pll.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/pmc/pmc.c" framework="" version="3.44.1" source="sam\drivers\pmc\pmc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/pmc/sleep.c" framework="" version="3.44.1" source="sam\drivers\pmc\sleep.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/pmc/pmc.h" framework="" version="3.44.1" source="sam\drivers\pmc\pmc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/pmc/sleep.h" framework="" version="3.44.1" source="sam\drivers\pmc\sleep.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/gpio/sam_gpio/sam_gpio.h" framework="" version="3.44.1" source="common\services\gpio\sam_gpio\sam_gpio.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/services/gpio/gpio.h" framework="" version="3.44.1" source="common\services\gpio\gpio.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/pio/pio.c" framework="" version="3.44.1" source="sam\drivers\pio\pio.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/pio/pio.h" framework="" version="3.44.1" source="sam\drivers\pio\pio.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/pio/pio_handler.c" framework="" version="3.44.1" source="sam\drivers\pio\pio_handler.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/pio/pio_handler.h" framework="" version="3.44.1" source="sam\drivers\pio\pio_handler.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/mpu/mpu.c" framework="" version="3.44.1" source="sam\drivers\mpu\mpu.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/mpu/mpu.h" framework="" version="3.44.1" source="sam\drivers\mpu\mpu.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/common/source/nm_common.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\common\source\nm_common.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/spi_flash/source/spi_flash.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\spi_flash\source\spi_flash.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_flash.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_flash.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/source/nm_bsp_same70_app.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\source\nm_bsp_same70_app.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/source/nm_bsp_same70.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\source\nm_bsp_same70.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bus_wrapper/source/nm_bus_wrapper_same70.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bus_wrapper\source\nm_bus_wrapper_same70.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmbus.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmbus.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_hif.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_hif.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/socket/source/socket.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\socket\source\socket.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_periph.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_periph.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmuart.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmuart.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmspi.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmspi.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmasic.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmasic.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_crypto.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_crypto.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_wifi.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_wifi.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_ota.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_ota.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_ate_mode.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_ate_mode.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmflash.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmflash.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmdrv.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmdrv.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmi2c.c" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmi2c.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/WINC3400_IoT_SW_APIs.chm" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\WINC3400_IoT_SW_APIs.chm" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/common/include/nm_debug.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\common\include\nm_debug.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/socket/include/m2m_socket_host_if.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\socket\include\m2m_socket_host_if.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/include/nm_bsp.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\include\nm_bsp.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/common/include/nm_common.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\common\include\nm_common.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/spi_flash/include/spi_flash.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\spi_flash\include\spi_flash.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmbus.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmbus.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/socket/include/socket.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\socket\include\socket.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_wifi.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_wifi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_ota.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_ota.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmspi.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmspi.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/socket/source/socket_internal.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\socket\source\socket_internal.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmdrv.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmdrv.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/include/nm_bsp_internal.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\include\nm_bsp_internal.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmuart.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmuart.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmasic.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmasic.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmi2c.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmi2c.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/include/nm_bsp_same70.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\include\nm_bsp_same70.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bus_wrapper/include/nm_bus_wrapper.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bus_wrapper\include\nm_bus_wrapper.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_ate_mode.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_ate_mode.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/programmer/programmer.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\programmer\programmer.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_crypto.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_crypto.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/m2m_hif.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\m2m_hif.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_flash.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_flash.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/bsp/include/nm_bsp_same70_app.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\bsp\include\nm_bsp_same70_app.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_types.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_types.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/spi_flash/include/spi_flash_map.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\spi_flash\include\spi_flash_map.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/source/nmflash.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\source\nmflash.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/common/components/wifi/winc3400/wifi_drv/driver/include/m2m_periph.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\driver\include\m2m_periph.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/Config/conf_winc.h" framework="" version="3.44.1" source="common\components\wifi\winc3400\wifi_drv\module_config\same70\conf_winc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/efc/efc.h" framework="" version="3.44.1" source="sam\drivers\efc\efc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/services/flash_efc/flash_efc.c" framework="" version="3.44.1" source="sam\services\flash_efc\flash_efc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/services/flash_efc/flash_efc.h" framework="" version="3.44.1" source="sam\services\flash_efc\flash_efc.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/efc/efc.c" framework="" version="3.44.1" source="sam\drivers\efc\efc.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/wdt/wdt.c" framework="" version="3.44.1" source="sam\drivers\wdt\wdt.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/wdt/wdt.h" framework="" version="3.44.1" source="sam\drivers\wdt\wdt.h" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/afec/afec.c" framework="" version="3.44.1" source="sam\drivers\afec\afec.c" changed="False" content-id="Atmel.ASF" />
+          <file path="src/ASF/sam/drivers/afec/afec.h" framework="" version="3.44.1" source="sam\drivers\afec\afec.h" changed="False" content-id="Atmel.ASF" />
+        </files>
+        <documentation help="http://asf.atmel.com/docs/3.44.1/common.services.freertos.sam_example.same70_xplained/html/index.html" />
+        <offline-documentation help="" />
+        <dependencies>
+          <content-extension eid="atmel.asf" uuidref="Atmel.ASF" version="3.44.1" />
+        </dependencies>
+        <project id="common.services.freertos.sam_example.same70_xplained" value="Add" config="" content-id="Atmel.ASF" />
+        <board id="board.same70_xplained" value="Add" config="" content-id="Atmel.ASF" />
+      </framework-data>
     </AsfFrameworkConfig>
     <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
-    <avrtoolserialnumber>J42700051025</avrtoolserialnumber>
+    <avrtoolserialnumber>J41800054309</avrtoolserialnumber>
     <avrdeviceexpectedsignature>0xA1020C01</avrdeviceexpectedsignature>
     <avrtoolinterface>SWD</avrtoolinterface>
     <com_atmel_avrdbg_tool_edbg>
@@ -540,7 +540,7 @@
         <InterfaceName>SWD</InterfaceName>
       </ToolOptions>
       <ToolType>com.atmel.avrdbg.tool.atmelice</ToolType>
-      <ToolNumber>J42700051025</ToolNumber>
+      <ToolNumber>J41800054309</ToolNumber>
       <ToolName>Atmel-ICE</ToolName>
     </com_atmel_avrdbg_tool_atmelice>
     <com_atmel_avrdbg_tool_samice>

--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -599,7 +599,7 @@ void update_flash_cfg(evb_flash_cfg_t &newCfg)
     
 	// Enable flash write
 	nvr_flash_config_write_needed();
-	nvr_flash_config_write_enable(true);
+	nvr_flash_config_write_enable();
 }
 
 
@@ -624,6 +624,7 @@ void handle_data_from_host(is_comm_instance_t *comm, protocol_type_t ptype, uint
 
 			case SYS_CMD_MANF_UNLOCK:				// Unlock process for chip erase
 				manfUnlock = true;
+				g_status.evbStatus |= EVB_STATUS_MANF_UNLOCKED;
 				break;
 
 			case SYS_CMD_MANF_CHIP_ERASE:			// chip erase and reboot - do NOT reset calibration!

--- a/EVB-2/IS_EVB-2/src/globals.c
+++ b/EVB-2/IS_EVB-2/src/globals.c
@@ -342,7 +342,7 @@ bool nvr_validate_config_integrity(evb_flash_cfg_t* cfg)
     {   // Reset to defaults
         *cfg = defaults;
         nvr_flash_config_write_needed();
-        nvr_flash_config_write_enable(true);
+        nvr_flash_config_write_enable();
     }   
     
     // Disable cbPresets is necessary
@@ -482,18 +482,10 @@ void nvr_flash_config_write_needed(void)
 
 // Used to enabled flash writes at controlled times.  The system may identify when a flash write is needed. 
 // However, this will not occur until flash is enabled (at time EKF can tolerate stutters in RTOS update).
-void nvr_flash_config_write_enable(bool enable)
+void nvr_flash_config_write_enable(void)
 {
-    if (enable)
-    {
-        g_nvr_manage_config.flash_write_enable_timeMs = time_msec();
-        g_status.evbStatus |= EVB_STATUS_FLASH_WRITE_IN_PROGRESS;
-    }
-    else
-    {
-        g_nvr_manage_config.flash_write_enable_timeMs = 0;
-        g_status.evbStatus &= ~EVB_STATUS_FLASH_WRITE_IN_PROGRESS;
-    }
+    g_nvr_manage_config.flash_write_enable_timeMs = time_msec();
+    g_status.evbStatus |= EVB_STATUS_FLASH_WRITE_IN_PROGRESS;
 }
 
 

--- a/EVB-2/IS_EVB-2/src/globals.h
+++ b/EVB-2/IS_EVB-2/src/globals.h
@@ -141,7 +141,7 @@ bool nvr_validate_config_integrity(evb_flash_cfg_t* cfg);
 void nvr_init(void);
 bool nvr_slow_maintenance(void);
 void nvr_flash_config_write_needed(void);
-void nvr_flash_config_write_enable(bool enable);
+void nvr_flash_config_write_enable(void);
 
 int error_check_config(evb_flash_cfg_t *cfg);
 

--- a/EVB-2/IS_EVB-2/src/misc/init.c
+++ b/EVB-2/IS_EVB-2/src/misc/init.c
@@ -653,6 +653,7 @@ void board_init()
 
 	// Real-time timer
 	time_init();
+	time_delay(1);	// Delay to ensure time_msec() returns non-zero.	
 
 	/* Initialize IOPORTs */
 	ioport_init();

--- a/EVB-2/IS_EVB-2/src/user_interface.cpp
+++ b/EVB-2/IS_EVB-2/src/user_interface.cpp
@@ -64,7 +64,7 @@ static void on_cfg_button_release()
     com_bridge_apply_preset(g_flashCfg);
     board_IO_config();
     nvr_flash_config_write_needed();
-    nvr_flash_config_write_enable(true);
+    nvr_flash_config_write_enable();
 	evbUiRefreshLedCfg();
 }
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3588,6 +3588,9 @@ typedef enum
 	/** System flash write staging or occuring now.  Processor will pause and not respond during a flash write, typicaly 150-250 ms. */
     EVB_STATUS_FLASH_WRITE_IN_PROGRESS      = 0x01000000,
 
+	/** Manufacturing unlocked */
+    EVB_STATUS_MANF_UNLOCKED                = 0x02000000,
+
 } eEvbStatus;
 
 /** EVB-2 communications ports. */


### PR DESCRIPTION
Fixes an issue where the flash write needed on startup does not happen because time_msec() returns zero from booting too quickly.  