### PR TITLE
Renamed gps status flags to clafify GPS1 or GPS2 association

### DIFF
--- a/ExampleProjects/NTRIP_rover/ISNtripRoverExample.cpp
+++ b/ExampleProjects/NTRIP_rover/ISNtripRoverExample.cpp
@@ -91,7 +91,7 @@ void handle_uINS_data(is_comm_instance_t *comm, cISStream *clientStream)
 			s_rx.gps.hAcc,
 			s_rx.rel.differentialAge,	// time since last base message
 			fix.c_str(),
-			(s_rx.gps.status&GPS_STATUS_FLAGS_RTK_BASE_DATA_MISSING ? "BASE: No data" : (string("BASE: ")+to_string(s_rx.baseCount)).c_str())
+			(s_rx.gps.status&GPS_STATUS_FLAGS_GPS1_RTK_BASE_DATA_MISSING ? "BASE: No data" : (string("BASE: ")+to_string(s_rx.baseCount)).c_str())
 			 );
 
 		// Forward our position via GGA every 5 seconds to the RTK base.

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1151,18 +1151,21 @@ string cInertialSenseDisplay::DataToStringGpsPos(const gps_pos_t &gps, const p_d
 			gps.lla[0],					// GPS Latitude
 			gps.lla[1],					// GPS Longitude
 			gps.lla[2]);				// GPS Ellipsoid altitude (meters)
-		if (gps.status&GPS_STATUS_FLAGS_RTK_POSITION_ENABLED)
+		if (gps.status&GPS_STATUS_FLAGS_GPS1_RTK_POSITION_ENABLED)
 		{
-			if (gps.status&GPS_STATUS_FLAGS_RTK_COMPASSING_ENABLED) 
-			{ 
-				ptr += SNPRINTF(ptr, ptrEnd - ptr, "Compassing, "); 
-			}
-			if (gps.status&GPS_STATUS_FLAGS_RTK_RAW_GPS_DATA_ERROR)		{ ptr += SNPRINTF(ptr, ptrEnd - ptr, "Raw error, "); }
+			if (gps.status&GPS_STATUS_FLAGS_GPS1_RTK_RAW_GPS_DATA_ERROR)		{ ptr += SNPRINTF(ptr, ptrEnd - ptr, "Raw error, "); }
 			switch (gps.status&GPS_STATUS_FLAGS_ERROR_MASK)
 			{
-			case GPS_STATUS_FLAGS_RTK_BASE_DATA_MISSING:		ptr += SNPRINTF(ptr, ptrEnd - ptr, "Base missing, ");	break;
-			case GPS_STATUS_FLAGS_RTK_BASE_POSITION_MOVING:		ptr += SNPRINTF(ptr, ptrEnd - ptr, "Moving base, ");	break;
-			case GPS_STATUS_FLAGS_RTK_BASE_POSITION_INVALID:	ptr += SNPRINTF(ptr, ptrEnd - ptr, "Moving invalid, ");	break;
+			case GPS_STATUS_FLAGS_GPS1_RTK_BASE_DATA_MISSING:		ptr += SNPRINTF(ptr, ptrEnd - ptr, "Base missing, ");	break;
+			case GPS_STATUS_FLAGS_GPS1_RTK_BASE_POSITION_MOVING:		ptr += SNPRINTF(ptr, ptrEnd - ptr, "Moving base, ");	break;
+			case GPS_STATUS_FLAGS_GPS1_RTK_BASE_POSITION_INVALID:	ptr += SNPRINTF(ptr, ptrEnd - ptr, "Moving invalid, ");	break;
+			}
+		}
+		if (gps.status&GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_ENABLED)
+		{
+			if (gps.status&GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_ENABLED) 
+			{ 
+				ptr += SNPRINTF(ptr, ptrEnd - ptr, "Compassing, "); 
 			}
 		}
 		ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n"); 

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -172,7 +172,7 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
 // All DID messages are found in data_sets.h
 static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
 {
-	// inertialSenseInterface.StopBroadcasts();	// Stop streaming any prior messages
+	inertialSenseInterface.StopBroadcasts();	// Stop streaming any prior messages
 
 	if (g_commandLineOptions.asciiMessages.size() != 0)
 	{

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -172,7 +172,7 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
 // All DID messages are found in data_sets.h
 static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
 {
-	inertialSenseInterface.StopBroadcasts();	// Stop streaming any prior messages
+	// inertialSenseInterface.StopBroadcasts();	// Stop streaming any prior messages
 
 	if (g_commandLineOptions.asciiMessages.size() != 0)
 	{

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -414,24 +414,24 @@ enum eGpsStatus
  	GPS_STATUS_FLAGS_RTK_FIX_AND_HOLD               = (int)0x00040000,      // RTK feedback on the integer solutions to drive the float biases towards the resolved integers
 // 	GPS_STATUS_FLAGS_WEEK_VALID                     = (int)0x00040000,
 // 	GPS_STATUS_FLAGS_TOW_VALID                      = (int)0x00080000,
-	GPS_STATUS_FLAGS_RTK_POSITION_ENABLED           = (int)0x00100000,      // RTK precision positioning mode enabled
+	GPS_STATUS_FLAGS_GPS1_RTK_POSITION_ENABLED      = (int)0x00100000,      // GPS1 RTK precision positioning mode enabled
 	GPS_STATUS_FLAGS_STATIC_MODE                    = (int)0x00200000,      // Static mode
-	GPS_STATUS_FLAGS_RTK_COMPASSING_ENABLED         = (int)0x00400000,      // RTK moving base mode enabled
-    GPS_STATUS_FLAGS_RTK_RAW_GPS_DATA_ERROR         = (int)0x00800000,      // RTK error: observations or ephemeris are invalid or not received (i.e. RTK differential corrections)
-    GPS_STATUS_FLAGS_RTK_BASE_DATA_MISSING          = (int)0x01000000,      // RTK error: Either base observations or antenna position have not been received.
-    GPS_STATUS_FLAGS_RTK_BASE_POSITION_MOVING       = (int)0x02000000,      // RTK error: base position moved when it should be stationary
-    GPS_STATUS_FLAGS_RTK_BASE_POSITION_INVALID      = (int)0x03000000,      // RTK error: base position is invalid or not surveyed well
-    GPS_STATUS_FLAGS_RTK_BASE_POSITION_MASK         = (int)0x03000000,      // RTK error: base position error bitmask
-    GPS_STATUS_FLAGS_ERROR_MASK                     = (GPS_STATUS_FLAGS_RTK_RAW_GPS_DATA_ERROR|
-                                                    GPS_STATUS_FLAGS_RTK_BASE_POSITION_MASK),
-	GPS_STATUS_FLAGS_RTK_POSITION_VALID             = (int)0x04000000,      // GPS1 RTK precision position and carrier phase range solution with fixed ambiguities (i.e. < 6cm horizontal accuracy).  The carrier phase range solution with floating ambiguities occurs if GPS_STATUS_FIX_RTK_FIX is set and GPS_STATUS_FLAGS_RTK_POSITION_VALID is not set (i.e. > 6cm horizontal accuracy).
-	GPS_STATUS_FLAGS_RTK_COMPASSING_VALID           = (int)0x08000000,      // GPS2 RTK moving base heading.  Indicates RTK fix and hold with single band RTK compassing.
-    GPS_STATUS_FLAGS_RTK_COMPASSING_BASELINE_BAD    = (int)0x00002000,
-    GPS_STATUS_FLAGS_RTK_COMPASSING_BASELINE_UNSET  = (int)0x00004000,
-    GPS_STATUS_FLAGS_RTK_COMPASSING_MASK            = (GPS_STATUS_FLAGS_RTK_COMPASSING_ENABLED|
-                                                    GPS_STATUS_FLAGS_RTK_COMPASSING_VALID|
-                                                    GPS_STATUS_FLAGS_RTK_COMPASSING_BASELINE_BAD|
-                                                    GPS_STATUS_FLAGS_RTK_COMPASSING_BASELINE_UNSET),
+	GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_ENABLED       = (int)0x00400000,      // GPS2 RTK moving base mode enabled
+    GPS_STATUS_FLAGS_GPS1_RTK_RAW_GPS_DATA_ERROR    = (int)0x00800000,      // GPS1 RTK error: observations or ephemeris are invalid or not received (i.e. RTK differential corrections)
+    GPS_STATUS_FLAGS_GPS1_RTK_BASE_DATA_MISSING     = (int)0x01000000,      // GPS1 RTK error: Either base observations or antenna position have not been received.
+    GPS_STATUS_FLAGS_GPS1_RTK_BASE_POSITION_MOVING  = (int)0x02000000,      // GPS1 RTK error: base position moved when it should be stationary
+    GPS_STATUS_FLAGS_GPS1_RTK_BASE_POSITION_INVALID = (int)0x03000000,      // GPS1 RTK error: base position is invalid or not surveyed well
+    GPS_STATUS_FLAGS_GPS1_RTK_BASE_POSITION_MASK    = (int)0x03000000,      // GPS1 RTK error: base position error bitmask
+    GPS_STATUS_FLAGS_ERROR_MASK                     = (GPS_STATUS_FLAGS_GPS1_RTK_RAW_GPS_DATA_ERROR|
+                                                       GPS_STATUS_FLAGS_GPS1_RTK_BASE_POSITION_MASK),
+	GPS_STATUS_FLAGS_GPS1_RTK_POSITION_VALID        = (int)0x04000000,      // GPS1 RTK precision position and carrier phase range solution with fixed ambiguities (i.e. < 6cm horizontal accuracy).  The carrier phase range solution with floating ambiguities occurs if GPS_STATUS_FIX_RTK_FIX is set and GPS_STATUS_FLAGS_GPS1_RTK_POSITION_VALID is not set (i.e. > 6cm horizontal accuracy).
+	GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_VALID         = (int)0x08000000,      // GPS2 RTK moving base heading.  Indicates RTK fix and hold with single band RTK compassing.
+    GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_BASELINE_BAD  = (int)0x00002000,
+    GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_BASELINE_UNSET= (int)0x00004000,
+    GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_MASK          = (GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_ENABLED|
+                                                       GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_VALID|
+                                                       GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_BASELINE_BAD|
+                                                       GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_BASELINE_UNSET),
 	GPS_STATUS_FLAGS_GPS_NMEA_DATA                  = (int)0x00008000,      // 1 = Data from NMEA message
 	GPS_STATUS_FLAGS_GPS_PPS_TIMESYNC               = (int)0x10000000,      // Time is synchronized by GPS PPS. 
 

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -860,8 +860,8 @@ int parse_nmea_gns(const char msg[], int msgSize, gps_pos_t *gpsPos, double date
 		fixType = GPS_STATUS_FIX_RTK_FIX;
 		statusFlags |= 
 			GPS_STATUS_FLAGS_FIX_OK |
-			GPS_STATUS_FLAGS_RTK_POSITION_ENABLED |
-			GPS_STATUS_FLAGS_RTK_POSITION_VALID |
+			GPS_STATUS_FLAGS_GPS1_RTK_POSITION_ENABLED |
+			GPS_STATUS_FLAGS_GPS1_RTK_POSITION_VALID |
 			GPS_STATUS_FLAGS_RTK_FIX_AND_HOLD |
 			GPS_STATUS_FLAGS_DGPS_USED;
 		gpsPos->hAcc = 0.05f;
@@ -871,7 +871,7 @@ int parse_nmea_gns(const char msg[], int msgSize, gps_pos_t *gpsPos, double date
 		fixType = GPS_STATUS_FIX_RTK_FLOAT;
 		statusFlags |=
 			GPS_STATUS_FLAGS_FIX_OK |
-			GPS_STATUS_FLAGS_RTK_POSITION_ENABLED |
+			GPS_STATUS_FLAGS_GPS1_RTK_POSITION_ENABLED |
 			GPS_STATUS_FLAGS_DGPS_USED;
 		gpsPos->hAcc = 0.4f;
 	}
@@ -1000,7 +1000,7 @@ int parse_nmea_gga(const char msg[], int msgSize, gps_pos_t *gpsPos, double date
 		fixType = GPS_STATUS_FIX_RTK_FLOAT;
 		statusFlags |=
 			GPS_STATUS_FLAGS_FIX_OK |
-			GPS_STATUS_FLAGS_RTK_POSITION_ENABLED |
+			GPS_STATUS_FLAGS_GPS1_RTK_POSITION_ENABLED |
 			GPS_STATUS_FLAGS_DGPS_USED;
 		gpsPos->hAcc = 0.4f;
 		break;
@@ -1009,8 +1009,8 @@ int parse_nmea_gga(const char msg[], int msgSize, gps_pos_t *gpsPos, double date
 		fixType = GPS_STATUS_FIX_RTK_FIX;
 		statusFlags |= 
 			GPS_STATUS_FLAGS_FIX_OK |
-			GPS_STATUS_FLAGS_RTK_POSITION_ENABLED |
-			GPS_STATUS_FLAGS_RTK_POSITION_VALID |
+			GPS_STATUS_FLAGS_GPS1_RTK_POSITION_ENABLED |
+			GPS_STATUS_FLAGS_GPS1_RTK_POSITION_VALID |
 			GPS_STATUS_FLAGS_RTK_FIX_AND_HOLD |
 			GPS_STATUS_FLAGS_DGPS_USED;
 		gpsPos->hAcc = 0.05f;


### PR DESCRIPTION
Address confusing ambiguity of gps status flags that are found in both gps1pos.status and gps2pos.status.  These flags that were renamed are common in both locations but specific to GPS1 and GPS2 specific.  GPS status values defined in enum eGpsStatus were renamed to clarify GPS1 or GPS2 association.  