### PR TITLE
Fix compiler alignment warnings for FreeRTOS stream buffer

### DIFF
--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -50,6 +50,12 @@ is_comm_instance_t 			g_commTx = {};
 StreamBufferHandle_t        g_xStreamBufferUINS;
 StreamBufferHandle_t        g_xStreamBufferWiFiRx;
 StreamBufferHandle_t        g_xStreamBufferWiFiTx;
+static uint8_t s_xStreamBufferUINS_buf[ STREAM_BUFFER_SIZE ] __attribute__((aligned(4)));
+static uint8_t s_xStreamBufferWiFiRx_buf[ STREAM_BUFFER_SIZE ] __attribute__((aligned(4)));
+static uint8_t s_xStreamBufferWiFiTx_buf[ STREAM_BUFFER_SIZE ] __attribute__((aligned(4)));
+static StaticStreamBuffer_t s_xStreamBufferUINS_struct;
+static StaticStreamBuffer_t s_xStreamBufferWiFiRx_struct;
+static StaticStreamBuffer_t s_xStreamBufferWiFiTx_struct;
 
 static pfnHandleUinsData s_pfnHandleUinsData = NULLPTR;
 static pfnHandleHostData s_pfnHandleHostData = NULLPTR;
@@ -1072,9 +1078,19 @@ void comunications_set_host_data_callback( pfnHandleHostData pfn )
 void communications_init(pfnHandleBroadcst pfnBroadcst, pfnHandleDid2Ermc pfnDid2Ermc)
 {
     const size_t xTriggerLevel = 1;
-    g_xStreamBufferUINS = xStreamBufferCreate( STREAM_BUFFER_SIZE, xTriggerLevel );
-    g_xStreamBufferWiFiRx = xStreamBufferCreate( STREAM_BUFFER_SIZE, xTriggerLevel );
-    g_xStreamBufferWiFiTx = xStreamBufferCreate( STREAM_BUFFER_SIZE, xTriggerLevel );
+
+	g_xStreamBufferUINS = xStreamBufferCreateStatic(STREAM_BUFFER_SIZE,
+													xTriggerLevel,
+													s_xStreamBufferUINS_buf,
+													&s_xStreamBufferUINS_struct);
+	g_xStreamBufferWiFiRx = xStreamBufferCreateStatic(STREAM_BUFFER_SIZE,
+													xTriggerLevel,
+													s_xStreamBufferWiFiRx_buf,
+													&s_xStreamBufferWiFiRx_struct);
+	g_xStreamBufferWiFiTx = xStreamBufferCreateStatic(STREAM_BUFFER_SIZE,
+													xTriggerLevel,
+													s_xStreamBufferWiFiTx_buf,
+													&s_xStreamBufferWiFiTx_struct);
 
 	for(int i=0; i<COM_RX_PORT_COUNT; i++)
 	{

--- a/EVB-2/IS_EVB-2/src/config/FreeRTOSConfig.h
+++ b/EVB-2/IS_EVB-2/src/config/FreeRTOSConfig.h
@@ -59,7 +59,9 @@
 #define configMAX_PRIORITIES					( 10 )
 #define configMINIMAL_STACK_SIZE				( ( unsigned short ) 130 )
 
+#ifndef configTOTAL_HEAP_SIZE 
 #define configTOTAL_HEAP_SIZE					253000 
+#endif
 
 #define configMAX_TASK_NAME_LEN					( 10 )
 #define configUSE_TRACE_FACILITY				1

--- a/EVB-2/IS_EVB-2/src/config/FreeRTOSConfig.h
+++ b/EVB-2/IS_EVB-2/src/config/FreeRTOSConfig.h
@@ -59,7 +59,7 @@
 #define configMAX_PRIORITIES					( 10 )
 #define configMINIMAL_STACK_SIZE				( ( unsigned short ) 130 )
 
-#define configTOTAL_HEAP_SIZE					256000 
+#define configTOTAL_HEAP_SIZE					253000 
 
 #define configMAX_TASK_NAME_LEN					( 10 )
 #define configUSE_TRACE_FACILITY				1
@@ -73,6 +73,7 @@
 #define configUSE_APPLICATION_TASK_TAG			0
 #define configUSE_COUNTING_SEMAPHORES			1
 #define configUSE_DAEMON_TASK_STARTUP_HOOK 		1
+#define configSUPPORT_STATIC_ALLOCATION			1
 
 /* The full demo always has tasks to run so the tick will never be turned off.
 The blinky demo will use the default tickless idle implementation to turn the

--- a/hw-libs/boards/EVB-2.h
+++ b/hw-libs/boards/EVB-2.h
@@ -1,6 +1,10 @@
 #ifndef __EVB_2_H
 #define __EVB_2_H
 
+#ifdef LUNA_VEHICLE
+#include "config/conf_luna.h"
+#endif
+
 #define USE_FREERTOS                    1
 #define USE_TIMER_DRIVER				0
 

--- a/hw-libs/freertos/stream_buffer.c
+++ b/hw-libs/freertos/stream_buffer.c
@@ -231,6 +231,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 /*-----------------------------------------------------------*/
 
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+#if 0   /* Inertial Sense - use static allocation for stream buffers, this 
+            throws a compiler warning because of an unaligned cast */
 
     StreamBufferHandle_t xStreamBufferGenericCreate( size_t xBufferSizeBytes,
                                                      size_t xTriggerLevelBytes,
@@ -301,6 +303,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         return ( StreamBufferHandle_t ) pucAllocatedMemory; /*lint !e9087 !e826 Safe cast as allocated memory is aligned. */
     }
 
+#endif /* Inertial Sense */
 #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
 /*-----------------------------------------------------------*/
 

--- a/hw-libs/misc/rtos.c
+++ b/hw-libs/misc/rtos.c
@@ -248,6 +248,56 @@ void vApplicationDaemonTaskStartupHook(void)
 	g_rtos.task[TASK_TIMER].handle = (uint32_t)xTaskGetCurrentTaskHandle();
 }
 
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                    StackType_t **ppxIdleTaskStackBuffer,
+                                    uint32_t *pulIdleTaskStackSize )
+{
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the Idle task's
+    state will be stored. */
+    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+
+    /* Pass out the array that will be used as the Idle task's stack. */
+    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+
+    /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
+    Note that, as the array is necessarily of type StackType_t,
+    configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+
+#if (configUSE_TIMERS == 1)
+/* configSUPPORT_STATIC_ALLOCATION and configUSE_TIMERS are both set to 1, so the
+application must provide an implementation of vApplicationGetTimerTaskMemory()
+to provide the memory that is used by the Timer service task. */
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                     StackType_t **ppxTimerTaskStackBuffer,
+                                     uint32_t *pulTimerTaskStackSize )
+{
+	/* If the buffers to be provided to the Timer task are declared inside this
+	function then they must be declared static - otherwise they will be allocated on
+	the stack and so not exists after this function exits. */
+	static StaticTask_t xTimerTaskTCB;
+	static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the Timer
+    task's state will be stored. */
+    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+
+    /* Pass out the array that will be used as the Timer task's stack. */
+    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
+
+    /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+    Note that, as the array is necessarily of type StackType_t,
+    configTIMER_TASK_STACK_DEPTH is specified in words, not bytes. */
+    *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}
+#endif
+#endif
+
 #if 1
 void MemManage_Handler(void) 
 {	

--- a/hw-libs/misc/rtos.c
+++ b/hw-libs/misc/rtos.c
@@ -12,6 +12,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "FreeRTOS.h"
 #include "task.h"
+#if ((configUSE_TIMERS == 1) && (configSUPPORT_STATIC_ALLOCATION == 1))
+#include "timers.h"
+#endif
 #include "rtos.h"
 
 #if !defined(PLATFORM_IS_EVB_2) && !defined(TESTBED)


### PR DESCRIPTION
All of our projects with FreeRTOS were throwing this warning. Only the EVB-2 uses stream buffers, so the fix was two-fold:

1. On the EVB-2, switch to statically allocated stream buffers. This completely avoids the issue with alignment. If you read the FreeRTOS source code, they assume that malloc is aligned, which I'm not a fan of. I put an `#if 0` ... `#endif` around dynamically allocated stream buffers. I had to decrease the heap size to account for the buffers being allocated statically.
1. On our internal projects, don't compile the `stream_buffers.c` file (see PR in internal repo) and disable stream buffers in the `FreeRTOSConfig.h` file.

```
../hw-libs/freertos/stream_buffer.c: In function 'xStreamBufferGenericCreate':
../hw-libs/freertos/stream_buffer.c:288:43: warning: cast increases required alignment of target type [-Wcast-align]
             prvInitialiseNewStreamBuffer( ( StreamBuffer_t * ) pucAllocatedMemory,       /* Structure at the start of the allocated memory. */ /*lint !e9087 Safe cast as allocated memory is aligned. */ /*lint !e826 Area is not too small and alignment is guaranteed provided malloc() behaves as expected and returns aligned buffer. */
                                           ^
../hw-libs/freertos/stream_buffer.c:301:16: warning: cast increases required alignment of target type [-Wcast-align]
         return ( StreamBufferHandle_t ) pucAllocatedMemory; /*lint !e9087 !e826 Safe cast as allocated memory is aligned. */
                ^
```