### PR TITLE
SN-2861 Linux SAM-BA Fixes

### DIFF
--- a/src/ISBootloaderBase.cpp
+++ b/src/ISBootloaderBase.cpp
@@ -236,13 +236,9 @@ is_operation_result cISBootloaderBase::mode_device_app
         }
     }
 
-    char msg[120] = { 0 };
-    SNPRINTF(msg, sizeof(msg), "    | (%s) Incompatible device.", handle->port);
-    statusfn(NULL, msg, IS_LOG_LEVEL_ERROR);
-
     delete obj;
     SLEEP_MS(3000);
-    return IS_OP_OK;
+    return IS_OP_CLOSED;    // Assume we found something besides app mode
 }
 
 is_operation_result cISBootloaderBase::get_device_isb_version(

--- a/src/ISBootloaderSAMBA.cpp
+++ b/src/ISBootloaderSAMBA.cpp
@@ -415,7 +415,7 @@ is_operation_result cISBootloaderSAMBA::verify_image(std::string filename)
 
     serialPortFlush(m_port);
 
-    SAMBA_STATUS("(SAM-BA) Verifying ISB bootloader...", IS_LOG_LEVEL_INFO);
+    SAMBA_STATUS("(SAM-BA) Verifying ISB bootloader (may take some time)...", IS_LOG_LEVEL_INFO);
 
     while (serialPortRead(m_port, buf, 1));
 


### PR DESCRIPTION
Fixes an issue where the serial port comes back as a different /dev/ and gets re-interrogated when it is in bootloader mode already.