### PR TITLE
Fix logInspector for PyQt5 5.15.7

### DIFF
--- a/python/logInspector/logInspector.py
+++ b/python/logInspector/logInspector.py
@@ -5,8 +5,8 @@ from PyQt5 import QtCore
 from PyQt5.QtWidgets import QWidget, QDialog, QApplication, QPushButton, QVBoxLayout, QLineEdit, QTreeView, QFileSystemModel,\
     QHBoxLayout, QGridLayout, QMainWindow, QSizePolicy, QSpacerItem, QFileDialog, QMessageBox, QLabel, QRadioButton,\
     QAbstractItemView, QMenu, QTableWidget,QTableWidgetItem, QSpinBox, QSpacerItem, QCheckBox
-from PyQt5.QtGui import QMovie, QPicture, QIcon, QDropEvent, QPixmap, QImage
-from PyQt5.Qt import QApplication, QClipboard, QStyle
+from PyQt5.QtGui import QMovie, QPicture, QIcon, QDropEvent, QPixmap, QImage, QClipboard
+from PyQt5.QtWidgets import QApplication, QStyle
 import json
 import io
 


### PR DESCRIPTION
Since the python dependency version is not locked in `setup.py`,  the `pip install logInspector/` will always install the latest version python dependency . This commit will fix logInspector for the current latest PyQt5 5.15.7.

I suggest we lock the python dependency version.