### PR TITLE
Optimize ecef2lla

### DIFF
--- a/ros/src/inertial_sense_ros.cpp
+++ b/ros/src/inertial_sense_ros.cpp
@@ -1035,7 +1035,7 @@ void InertialSenseROS::INS4_callback(eDataIDs DID, const ins_4_t *const msg)
         Pe[0] = msg->ecef[0];
         Pe[1] = msg->ecef[1];
         Pe[2] = msg->ecef[2];
-        ecef2lla(Pe, lla, 5);
+        ecef2lla(Pe, lla);
         quat_ecef2ned(lla[0], lla[1], qe2n);
 
         if (odom_ins_ecef_.enabled)
@@ -1132,7 +1132,7 @@ void InertialSenseROS::INS4_callback(eDataIDs DID, const ins_4_t *const msg)
             // Position
             ixVector3d llaPosRadians;
                 //ecef to lla (rad,rad,m)
-            ecef2lla(msg->ecef, llaPosRadians, 5);
+            ecef2lla(msg->ecef, llaPosRadians);
             ixVector3 ned;
             ixVector3d refLlaRadians;
                 //convert refLla_ to radians
@@ -1222,7 +1222,7 @@ void InertialSenseROS::INS4_callback(eDataIDs DID, const ins_4_t *const msg)
                 //Calculate in NED then convert
             ixVector3d llaPosRadians;
                 //ecef to lla (rad,rad,m)
-            ecef2lla(msg->ecef, llaPosRadians, 5);
+            ecef2lla(msg->ecef, llaPosRadians);
             ixVector3 ned;
             ixVector3d refLlaRadians;
                 //convert refLla_ to radians

--- a/src/ISEarth.h
+++ b/src/ISEarth.h
@@ -59,7 +59,7 @@ typedef ixMatrix4     ixMatrix4;
 /* 
  * Coordinate transformation from ECEF coordinates to latitude/longitude/altitude (rad,rad,m)
  */
-void ecef2lla(const double *Pe, double *LLA, const int method);
+void ecef2lla(const double *Pe, double *LLA);
 
 /*
  * Coordinate transformation from latitude/longitude/altitude (rad,rad,m) to ECEF coordinates
@@ -195,6 +195,25 @@ double meridonalRadius(const double lat);
  * @param rb                            array of the resulting range (m) and bearing (rad)
  */
 void rangeBearing_from_lla(const ixVector3d lla1, const ixVector3d lla2, ixVector2d rb);
+
+/**
+ * @brief Compute rotation matrix from NED to ECEF
+ *
+ * @param latlon                        latitute/longitude (rad) (2x1)
+ * @param R                             rotation matrix (3x3)
+ */
+void rotMat_ned2ecef(const double *latlon, float *R);
+
+/**
+ * @brief Convert ground speed and heading to ECEF velocity
+ *
+ * @param gndSpeed                      m/s
+ * @param hdg                           rad
+ * @param vertVel                       m/s
+ * @param lla                           rad (can just pass lat/lon, alt not required)
+ * @param velEcef                       m/s
+ */
+void gndSpeedToVelEcef(const float gndSpeed, const float hdg, const float vertVel, const ixVector3d lla, ixVector3 velEcef);
 
 #ifdef __cplusplus
 }

--- a/src/convert_ins.cpp
+++ b/src/convert_ins.cpp
@@ -74,7 +74,7 @@ void convertIns4ToIns1(ins_4_t *ins4, ins_1_t *result, double *refLla)
     result->hdwStatus	= ins4->hdwStatus;
 
     quatConjRot(result->uvw, ins4->qe2b, ins4->ve);
-    ecef2lla(ins4->ecef, llaRad, ECEF2LLA_METHOD);
+    ecef2lla(ins4->ecef, llaRad);
     qe2b2EulerNedLLA(result->theta, ins4->qe2b, llaRad);
     lla_Rad2Deg_d(result->lla, llaRad);
     if (refLla)


### PR DESCRIPTION
Including all version of ecef2lla takes allot of instruction space memory.  This reduced the selected version to compile time and still allows the application to select which version to use. 