### PR TITLE
SN-3019 sdk tcp corrections bug

### DIFF
--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -126,6 +126,7 @@ InertialSense::InertialSense(pfnHandleBinaryData callback) : m_tcpServer(this)
 InertialSense::~InertialSense()
 {
 	Close();
+	CloseServerConnection();	
 }
 
 bool InertialSense::EnableLogging(const string& path, cISLogger::eLogType logType, float maxDiskSpacePercent, uint32_t maxFileSize, const string& subFolder)
@@ -595,7 +596,6 @@ void InertialSense::Close()
 		serialPortClose(&m_comManagerState.devices[i].serialPort);
 	}
 	m_comManagerState.devices.clear();
-	CloseServerConnection();
 }
 
 vector<string> InertialSense::GetPorts()

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -132,7 +132,7 @@ public:
 	bool IsOpen();
 
 	/**
-	* Close the connection, logger and free all resources
+	* Close the device connection, stop logger if running, and free resources.
 	*/
 	void Close();
 

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -514,6 +514,7 @@ static int cltool_createHost()
 
 	// close the interface cleanly, this ensures serial port and any logging are shutdown properly
 	inertialSenseInterface.Close();
+	inertialSenseInterface.CloseServerConnection();
 	
 	return 0;
 }
@@ -595,6 +596,7 @@ static int inertialSenseMain()
 			{
 				cout << "Failed to setup logger!" << endl;
 				inertialSenseInterface.Close();
+				inertialSenseInterface.CloseServerConnection();
 				return -1;
 			}
 			try
@@ -634,6 +636,7 @@ static int inertialSenseMain()
 		// [C++ COMM INSTRUCTION] STEP 6: Close interface
 		// Close cleanly to ensure serial port and logging are shutdown properly.  (optional)
 		inertialSenseInterface.Close();
+		inertialSenseInterface.CloseServerConnection();
 	}
 
 	return 0;


### PR DESCRIPTION
Decouple SDK tcp connection close from device close in InertialSense class.  We shouldn't be closing the TCP connecting if the device serial port closes.