### PR TITLE
SN-3703 standard NMEA use gn

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -891,7 +891,7 @@ typedef struct PACKED
 /** Sat SV - GNSS System ID */
 enum eSatSvGnssId
 {
-    SAT_SV_GNSS_ID_UNKNOWN	= 0, 
+    SAT_SV_GNSS_ID_UNKNOWN	= 0, 	// Unknown or GNSS (multi-constellation)
     SAT_SV_GNSS_ID_GPS		= 1,	// GPS (USA)
     SAT_SV_GNSS_ID_SBS		= 2,	// SBAS (multiple regional systems, see flash config for selection)
     SAT_SV_GNSS_ID_GAL		= 3,	// Galileo (European Union)	

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -891,15 +891,16 @@ typedef struct PACKED
 /** Sat SV - GNSS System ID */
 enum eSatSvGnssId
 {
-    SAT_SV_GNSS_ID_UNKNOWN	= 0, 	// Unknown or GNSS (multi-constellation)
-    SAT_SV_GNSS_ID_GPS		= 1,	// GPS (USA)
-    SAT_SV_GNSS_ID_SBS		= 2,	// SBAS (multiple regional systems, see flash config for selection)
-    SAT_SV_GNSS_ID_GAL		= 3,	// Galileo (European Union)	
-    SAT_SV_GNSS_ID_BEI		= 4,	// BeiDou (China)
-    SAT_SV_GNSS_ID_QZS		= 5,	// QZSS (Japan)
-    SAT_SV_GNSS_ID_GLO		= 6,	// GLONASS (Russia)	
-    SAT_SV_GNSS_ID_IRN		= 7,	// IRNSS / NavIC (India)	
-    SAT_SV_GNSS_ID_IME		= 8,	// IMES (Japan's Indoor Messaging System)
+    SAT_SV_GNSS_ID_UNKNOWN  = 0,
+    SAT_SV_GNSS_ID_GNSS     = 0, 	// (multi-constellation)
+    SAT_SV_GNSS_ID_GPS      = 1,	// GPS (USA)
+    SAT_SV_GNSS_ID_SBS      = 2,	// SBAS (multiple regional systems, see flash config for selection)
+    SAT_SV_GNSS_ID_GAL      = 3,	// Galileo (European Union)	
+    SAT_SV_GNSS_ID_BEI      = 4,	// BeiDou (China)
+    SAT_SV_GNSS_ID_QZS      = 5,	// QZSS (Japan)
+    SAT_SV_GNSS_ID_GLO      = 6,	// GLONASS (Russia)	
+    SAT_SV_GNSS_ID_IRN      = 7,	// IRNSS / NavIC (India)	
+    SAT_SV_GNSS_ID_IME      = 8,	// IMES (Japan's Indoor Messaging System)
 };
 
 /** GPS Sat Status */
@@ -2050,7 +2051,7 @@ enum eGnssSatSigConst
 	/*! GPS  */
 	GNSS_SAT_SIG_CONST_GPS                              = (uint16_t)0x0003,
 	/*! QZSS  */
-	GNSS_SAT_SIG_CONST_QZSS                             = (uint16_t)0x000C,
+	GNSS_SAT_SIG_CONST_QZS                              = (uint16_t)0x000C,
 	/*! Galileo  */
 	GNSS_SAT_SIG_CONST_GAL                              = (uint16_t)0x0030,
 	/*! BeiDou  */
@@ -2058,13 +2059,17 @@ enum eGnssSatSigConst
 	/*! GLONASS  */
 	GNSS_SAT_SIG_CONST_GLO                              = (uint16_t)0x0300,
 	/*! SBAS  */
-	GNSS_SAT_SIG_CONST_SBAS                             = (uint16_t)0x1000,
-	
+	GNSS_SAT_SIG_CONST_SBS                              = (uint16_t)0x1000,
+	/*! IRNSS / NavIC  */
+	GNSS_SAT_SIG_CONST_IRN                              = (uint16_t)0x2000,
+	/*! IMES  */
+	GNSS_SAT_SIG_CONST_IME                              = (uint16_t)0x4000,
+
 	/*! GNSS default */
 	GNSS_SAT_SIG_CONST_DEFAULT = \
 		GNSS_SAT_SIG_CONST_GPS | \
-		GNSS_SAT_SIG_CONST_SBAS | \
-		GNSS_SAT_SIG_CONST_QZSS | \
+		GNSS_SAT_SIG_CONST_SBS | \
+		GNSS_SAT_SIG_CONST_QZS | \
 		GNSS_SAT_SIG_CONST_GAL | \
 		GNSS_SAT_SIG_CONST_GLO | \
 		GNSS_SAT_SIG_CONST_BDS

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -7,7 +7,7 @@
 
 
 static int s_protocol_version = 0;
-static uint8_t s_gnssId = 0;	// GNSS multi-constellation (see eSatSvGnssId)
+static uint8_t s_gnssId = 0;	// 0 = GNSS multi-constellation, $GNxxx NMEA (see eSatSvGnssId)
 
 
 uint8_t nmea2p3_svid_to_sigId(uint8_t gnssId, uint16_t svId);

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -7,10 +7,10 @@
 
 
 static int s_protocol_version = 0;
+static uint8_t s_gnssId = 0;	// GNSS multi-constellation (see eSatSvGnssId)
 
 
 uint8_t nmea2p3_svid_to_sigId(uint8_t gnssId, uint16_t svId);
-
 
 //////////////////////////////////////////////////////////////////////////
 // Utility functions
@@ -19,6 +19,11 @@ uint8_t nmea2p3_svid_to_sigId(uint8_t gnssId, uint16_t svId);
 void nema_set_protocol_version(int protocol_version)
 { 
 	s_protocol_version = protocol_version; 
+}
+
+void nmea_set_gnss_id(int gnssId)
+{
+	s_gnssId = gnssId;
 }
 
 // Safe snprintf that prevents use of invalid size.
@@ -152,7 +157,7 @@ void talkerId_to_gnssId(const char a[], uint8_t &gnssId, uint16_t &svId, uint8_t
 	sigId = nmea2p3_svid_to_sigId(gnssId, svIdLast);
 }
 
-static int nmea_talker(char* a, int aSize, uint8_t gnssId=0)
+static int nmea_talker(char* a, int aSize, uint8_t gnssId=s_gnssId)
 {
 	a[0] = '$';
 	return gnssId_to_talkerId(a+1, gnssId) + 1;
@@ -694,7 +699,8 @@ int nmea_gll(char a[], const int aSize, gps_pos_t &pos)
 	     *iD          checksum data
 	*/
 
-	int n = ssnprintf(a, aSize, "$GPGLL");
+	int n = nmea_talker(a, aSize);
+	nmea_sprint(a, aSize, n, "GLL");
 	nmea_latToDegMin(a, aSize, n, pos.lla[0]);			// 1,2
 	nmea_lonToDegMin(a, aSize, n, pos.lla[1]);			// 3,4
 	nmea_GPSTimeOfLastFixMilliseconds(a, aSize, n, pos.timeOfWeekMs - pos.leapS*1000);	// 5
@@ -739,12 +745,11 @@ int nmea_gsa(char a[], const int aSize, gps_pos_t &pos, gps_sat_t &sat)
 		17   = VDOP
 	*/
 
-	int n = ssnprintf(a, aSize, "$GPGSA"
-		",A"		// 1
-		",%02u",	// 2
-		(unsigned int)fixQuality);	// 1,2
+	int n = nmea_talker(a, aSize);
+	nmea_sprint(a, aSize, n, "GSA");
+	nmea_sprint(a, aSize, n, ",A,%02u",	(unsigned int)fixQuality);		// 1,2
 		
-	for (uint32_t i = 0; i < 12; i++)												// 3-14
+	for (uint32_t i = 0; i < 12; i++)									// 3-14
 	{
 		if(sat.sat[i].svId)
 		{
@@ -774,7 +779,8 @@ int nmea_rmc(char a[], const int aSize, gps_pos_t &pos, gps_vel_t &vel, float ma
 	quat_ecef2ned((float)pos.lla[0], (float)pos.lla[1], qe2n);
 	quatConjRot(vel_ned_, qe2n, vel.vel);
 
-	int n = ssnprintf(a, aSize, "$GPRMC");
+	int n = nmea_talker(a, aSize);
+	nmea_sprint(a, aSize, n, "RMC");
 	nmea_GPSTimeOfLastFix(a, aSize, n, pos.timeOfWeekMs - (pos.leapS*1000));		// 1 - UTC time of last fix
 	if((pos.status&GPS_STATUS_FIX_MASK)!=GPS_STATUS_FIX_NONE)
 	{
@@ -822,7 +828,8 @@ int nmea_zda(char a[], const int aSize, gps_pos_t &pos)
 		*CC       checksum
 	*/
 
-	int n = ssnprintf(a, aSize, "$GPZDA");
+	int n = nmea_talker(a, aSize);
+	nmea_sprint(a, aSize, n, "ZDA");
 	nmea_GPSTimeOfLastFix(a, aSize, n, pos.timeOfWeekMs - pos.leapS*1000);			// 1 
 	nmea_GPSDateOfLastFixCSV(a, aSize, n, pos);										// 2,3,4
 	nmea_sprint(a, aSize, n, ",00,00");												// 5,6

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -7,7 +7,7 @@
 
 
 static int s_protocol_version = 0;
-static uint8_t s_gnssId = 0;	// 0 = GNSS multi-constellation, $GNxxx NMEA (see eSatSvGnssId)
+static uint8_t s_gnssId = SAT_SV_GNSS_ID_GNSS;
 
 
 uint8_t nmea2p3_svid_to_sigId(uint8_t gnssId, uint16_t svId);

--- a/src/protocol_nmea.h
+++ b/src/protocol_nmea.h
@@ -42,6 +42,7 @@ enum eNmeaProtocolVersion
 // Utility functions
 //////////////////////////////////////////////////////////////////////////
 void nema_set_protocol_version(int protocol_version);
+void nmea_set_gnss_id(int gnssId);
 void nmea_sprint(char buf[], int bufSize, int &offset, const char *fmt, ...);
 int nmea_sprint_footer(char* a, int aSize, int &n);
 char *ASCII_find_next_field(char *str);


### PR DESCRIPTION
Allow standard NMEA messages to have configurable talker ID.  GNSS ID "$GNxxx" is used if multiple constellations are selected, or the constellation specific talker ID is used if a single GNSS constellation is selected (i.e. $GPGGA for GPS).