### PR TITLE
Add build type and call out build date and time

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -244,14 +244,14 @@ static void PopulateDeviceInfoMappings(map_name_to_info_t mappings[DID_COUNT], u
     ADD_MAP(m, totalSize, "protocolVer[3]", protocolVer[3], 0, DataTypeUInt8, uint8_t&, 0);
     ADD_MAP(m, totalSize, "repoRevision", repoRevision, 0, DataTypeUInt32, uint32_t, 0);
     ADD_MAP(m, totalSize, "manufacturer", manufacturer, DEVINFO_MANUFACTURER_STRLEN, DataTypeString, char[DEVINFO_MANUFACTURER_STRLEN], 0);
-    ADD_MAP(m, totalSize, "buildDate[0]", buildDate[0], 0, DataTypeUInt8, uint8_t&, 0);
-    ADD_MAP(m, totalSize, "buildDate[1]", buildDate[1], 0, DataTypeUInt8, uint8_t&, 0);
-    ADD_MAP(m, totalSize, "buildDate[2]", buildDate[2], 0, DataTypeUInt8, uint8_t&, 0);
-    ADD_MAP(m, totalSize, "buildDate[3]", buildDate[3], 0, DataTypeUInt8, uint8_t&, 0);
-    ADD_MAP(m, totalSize, "buildTime[0]", buildTime[0], 0, DataTypeUInt8, uint8_t&, 0);
-    ADD_MAP(m, totalSize, "buildTime[1]", buildTime[1], 0, DataTypeUInt8, uint8_t&, 0);
-    ADD_MAP(m, totalSize, "buildTime[2]", buildTime[2], 0, DataTypeUInt8, uint8_t&, 0);
-    ADD_MAP(m, totalSize, "buildTime[3]", buildTime[3], 0, DataTypeUInt8, uint8_t&, 0);
+    ADD_MAP(m, totalSize, "buildType", buildType, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "buildYear", buildYear, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "buildMonth", buildMonth, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "buildDay", buildDay, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "buildHour", buildHour, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "buildMinute", buildMinute, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "buildSecond", buildSecond, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "buildMillisecond", buildMillisecond, 0, DataTypeUInt8, uint8_t, 0);
     ADD_MAP(m, totalSize, "addInfo", addInfo, DEVINFO_ADDINFO_STRLEN, DataTypeString, char[DEVINFO_ADDINFO_STRLEN], 0);
 
     ASSERT_SIZE(totalSize);

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1417,19 +1417,19 @@ string cInertialSenseDisplay::DataToStringDevInfo(const dev_info_t &info, bool f
 		info.firmwareVer[1],
 		info.firmwareVer[2],
 		info.firmwareVer[3],
-		info.buildDate[0],
+		info.buildType,
 		info.buildNumber,
-		info.buildDate[1] + 2000,
-		info.buildDate[2],
-		info.buildDate[3]
+		info.buildYear + 2000,
+		info.buildMonth,
+		info.buildDay
 	);
 
 	if (full)
 	{	// Spacious format
 		ptr += SNPRINTF(ptr, ptrEnd - ptr, " %02d:%02d:%02d, Proto %d.%d.%d.%d",
-			info.buildTime[0],
-			info.buildTime[1],
-			info.buildTime[2],
+			info.buildHour,
+			info.buildMinute,
+			info.buildSecond,
 			info.protocolVer[0],
 			info.protocolVer[1],
 			info.protocolVer[2],

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -474,7 +474,6 @@ typedef struct PACKED
 
 }pos_measurement_t;
 
-
 /** (DID_DEV_INFO) Device information */
 typedef struct PACKED
 {
@@ -502,11 +501,24 @@ typedef struct PACKED
     /** Manufacturer name */
     char            manufacturer[DEVINFO_MANUFACTURER_STRLEN];
 
-    /** Build date, little endian order: [0] = status ('r'=release, 'd'=debug), [1] = year-2000, [2] = month, [3] = day.  Reversed byte order for big endian systems */
-    uint8_t         buildDate[4];
+	/** Build type (Release: 'a'=ALPHA, 'b'=BETA, 'c'=RELEASE CANDIDATE, 'r'=PRODUCTION RELEASE, 'd'=debug) */
+	uint8_t         buildType;
+    
+    /** Build date year - 2000 */
+	uint8_t         buildYear;
+    /** Build date month */
+	uint8_t         buildMonth;
+    /** Build date day */
+	uint8_t         buildDay;
 
-    /** Build date, little endian order: [0] = hour, [1] = minute, [2] = second, [3] = millisecond.  Reversed byte order for big endian systems */
-    uint8_t         buildTime[4];
+    /** Build time hour */
+    uint8_t         buildHour;
+    /** Build time minute */
+    uint8_t         buildMinute;
+    /** Build time second */
+    uint8_t         buildSecond;
+    /** Build time millisecond */
+    uint8_t         buildMillisecond;
 
     /** Additional info */
     char            addInfo[DEVINFO_ADDINFO_STRLEN];

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -419,8 +419,8 @@ int nmea_dev_info(char a[], const int aSize, dev_info_t &info)
 		info.protocolVer[0], info.protocolVer[1], info.protocolVer[2], info.protocolVer[3], // 5
 		(int)info.repoRevision,	// 6
 		info.manufacturer,		// 7
-		info.buildDate[1]+2000, info.buildDate[2], info.buildDate[3], // 8
-		info.buildTime[0], info.buildTime[1], info.buildTime[2], info.buildTime[3], // 9
+		info.buildYear+2000, info.buildMonth, info.buildDay, // 8
+		info.buildHour, info.buildMinute, info.buildSecond, info.buildMillisecond, // 9
 		info.addInfo);			// 10
 		
 	return nmea_sprint_footer(a, aSize, n);
@@ -1372,18 +1372,18 @@ int nmea_parse_info(dev_info_t &info, const char a[], const int aSize)
 	// uint8_t         buildDate[4];	YYYY-MM-DD
 	unsigned int year, month, day;
 	SSCANF(ptr, "%04d-%02u-%02u", &year, &month, &day);
-	info.buildDate[1] = (uint8_t)(year - 2000);
-	info.buildDate[2] = (uint8_t)(month);
-	info.buildDate[3] = (uint8_t)(day);
+	info.buildYear = (uint8_t)(year - 2000);
+	info.buildMonth = (uint8_t)(month);
+	info.buildDay = (uint8_t)(day);
 	ptr = ASCII_find_next_field(ptr);
 	
 	// uint8_t         buildTime[4];	hh:mm:ss.ms
 	unsigned int hour, minute, second, ms;
 	SSCANF(ptr, "%02u:%02u:%03u.%02u", &hour, &minute, &second, &ms);
-	info.buildTime[0] = (uint8_t)hour;
-	info.buildTime[1] = (uint8_t)minute;
-	info.buildTime[2] = (uint8_t)second;
-	info.buildTime[3] = (uint8_t)ms;
+	info.buildHour = (uint8_t)hour;
+	info.buildMinute = (uint8_t)minute;
+	info.buildSecond = (uint8_t)second;
+	info.buildMillisecond = (uint8_t)ms;
 	ptr = ASCII_find_next_field(ptr);
 	
 	// char            addInfo[DEVINFO_ADDINFO_STRLEN];

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -20,7 +20,7 @@ PYBIND11_NUMPY_DTYPE(evb_luna_velocity_control_wheel_t, velCmd, velCmdSlew, vel,
 PYBIND11_NUMPY_DTYPE(evb_luna_velocity_control_t, timeMs, dt, current_mode, status, vehicle, wheel_l, wheel_r, potV_l, potV_r);
 
 // Public Types
-PYBIND11_NUMPY_DTYPE(dev_info_t, reserved, serialNumber, hardwareVer, firmwareVer, buildNumber, protocolVer, repoRevision, manufacturer, buildDate, buildTime, addInfo);
+PYBIND11_NUMPY_DTYPE(dev_info_t, reserved, serialNumber, hardwareVer, firmwareVer, buildNumber, protocolVer, repoRevision, manufacturer, buildType, buildYear, buildMonth, buildDay, buildHour, buildMinute, buildSecond, buildMillisecond, addInfo);
 PYBIND11_NUMPY_DTYPE(system_fault_t, status, g1Task, g2FileNum, g3LineNum, g4, g5Lr, pc, psr);
 PYBIND11_NUMPY_DTYPE(pimu_t, time, dt, status, theta, vel);
 PYBIND11_NUMPY_DTYPE(ins_1_t, week, timeOfWeek, insStatus, hdwStatus, theta, uvw, lla, ned);

--- a/src/test/test_protocol_nmea.cpp
+++ b/src/test/test_protocol_nmea.cpp
@@ -118,7 +118,7 @@ TEST(protocol_nmea, INFO)
         info.buildDate[i] = i;
         info.buildTime[i] = i+4;
     }
-    info.buildDate[0] = 0;
+    info.buildType = 0;
     snprintf(info.addInfo, DEVINFO_ADDINFO_STRLEN, "additional string   123");
 
     char abuf[ASCII_BUF_LEN] = { 0 };


### PR DESCRIPTION
Add build type (alpha, beta, release candidate, release, debug) to dev_info_t.  Convert buildDate and buildTime to specific names (year, month, day, hour, minute, second, etc.).  