### PR TITLE
SN-4050 fix ros flash config sync

### DIFF
--- a/ros/include/inertial_sense_ros.h
+++ b/ros/include/inertial_sense_ros.h
@@ -121,6 +121,7 @@ public:
     void get_flash_config();
     void reset_device();
     void flash_config_callback(eDataIDs DID, const nvm_flash_cfg_t *const msg);
+    void setRefLla(const double refLla[3]);
 
     bool flashConfigStreaming_ = false;
     bool factory_reset_ = false;        // Apply factory reset on startup

--- a/ros/include/inertial_sense_ros.h
+++ b/ros/include/inertial_sense_ros.h
@@ -121,12 +121,14 @@ public:
     void get_flash_config();
     void reset_device();
     void flash_config_callback(eDataIDs DID, const nvm_flash_cfg_t *const msg);
+
     bool flashConfigStreaming_ = false;
+    bool factory_reset_ = false;        // Apply factory reset on startup
 
     // Serial Port Configuration
-    std::vector<std::string> ports_; // a collection of ports which will be attempted, in order until a connection is made
-    std::string port_; // the actual port we connected with
-    int baudrate_;  // the baudrate to connect with
+    std::vector<std::string> ports_;    // a collection of ports which will be attempted, in order until a connection is made
+    std::string port_;                  // the actual port we connected with
+    int baudrate_;                      // the baudrate to connect with
 
     bool sdk_connected_ = false;
     bool log_enabled_ = false;

--- a/ros/include/inertial_sense_ros.h
+++ b/ros/include/inertial_sense_ros.h
@@ -407,9 +407,9 @@ public:
     float insRotation_[3] = {0, 0, 0};
     float insOffset_[3] = {0, 0, 0};
     double refLla_[3] = {0, 0, 0};      // Upload disabled if all zero
+    bool refLLA_valid = false;
     float magDeclination_;
     int insDynModel_;
-    bool refLLA_known = false;
 
     uint32_t ioConfigBits_ = 0;                 // this is read directly from the config,
     bool setIoConfigBits_ = false;

--- a/ros/include/inertial_sense_ros.h
+++ b/ros/include/inertial_sense_ros.h
@@ -67,9 +67,9 @@
 #define GPS_UNIX_OFFSET 315964800 // GPS time started on 6/1/1980 while UNIX time started 1/1/1970 this is the difference between those in seconds
 #define LEAP_SECONDS 18           // GPS time does not have leap seconds, UNIX does (as of 1/1/2017 - next one is probably in 2020 sometime unless there is some crazy earthquake or nuclear blast)
 #define UNIX_TO_GPS_OFFSET (GPS_UNIX_OFFSET - LEAP_SECONDS)
-#define FIRMWARE_VERSION_CHAR0 1
-#define FIRMWARE_VERSION_CHAR1 9
-#define FIRMWARE_VERSION_CHAR2 0
+#define REPO_VERSION_MAJOR 1
+#define REPO_VERSION_MINOR 10   // The repo/firmware version should originate from git tag (like repositoryInfo.h used in EvalTool).  For now we set these manually.
+#define REPO_VERSION_REVIS 0
 
 #define SET_CALLBACK(DID, __type, __cb_fun, __periodmultiple)                               \
     IS_.BroadcastBinaryData((DID), (__periodmultiple),                                      \
@@ -132,6 +132,7 @@ public:
     bool log_enabled_ = false;
     bool covariance_enabled_;
     int platformConfig_ = 0;
+    bool setPlatformConfig_ = false;
 
     std::string frame_id_;
 
@@ -409,13 +410,9 @@ public:
     bool refLLA_known = false;
 
     uint32_t ioConfigBits_ = 0;                 // this is read directly from the config,
-    uint32_t working_ioConfigBits_ = 0;         // this is the calculated/derived value from other parameters
-
+    bool setIoConfigBits_ = false;
     uint32_t rtkConfigBits_ = 0;                // this is read directly from the config
-    uint32_t working_rtkConfigBits_ = 0;        // this is the calculated/derived value from other parameters
-
     uint32_t wheelConfigBits_ = 0;              // this is read directly from the config
-    uint32_t working_wheelConfigBits_ = 0;      // this is the calculated/derived value from other parameters
 
     float gpsTimeUserDelay_ = 0;
 

--- a/ros/launch/example_params.yaml
+++ b/ros/launch/example_params.yaml
@@ -28,22 +28,23 @@
 
 
 topic: "inertialsense"
-port: [/dev/ttyACM0, /dev/ttyACM1]
+port: [/dev/ttyACM0, /dev/ttyACM1, /dev/ttyACM2]
 baudrate: 921600
 enable_log: false
 publishTf: true                                 # Publish Transform Frame (TR)
 frame_id: ""                                    # FIXME: What is this?  is it just the FrameID to use in the ROS messages?
 mag_declination: 0.0
 ref_lla: [0.0, 0.0, 0.0]
+# factory_reset: true                             # Reset flash config to factory defaults on startup.
 
 # Hardware platform specifying the IMX carrier board type (i.e. EVB-2) and configuration bits (see ePlatformConfig).  The platform type is used to simplify the GPS and I/O configuration process.
-platformConfig: 1                                 # PLATFORM_CFG_TYPE_NONE_ONBOARD_M8
+# platformConfig: 1                               # PLATFORM_CFG_TYPE_NONE_ONBOARD_M8
 # platform: 10                                    # PLATFORM_CFG_TYPE_RUG3_G2
 # platformConfig: 11                              # PLATFORM_CFG_TYPE_EVB2_G2
 # platform: 15                                    # PLATFORM_CFG_TYPE_IG1_G2
 
-# IMX ioConfig (see eIoConfig)
-ioConfig:  0x00112044
+# Overwrite IMX ioConfig (see eIoConfig)
+# ioConfig: 0x00112044
 # ioConfig: 0x26CA060       # EVB2: GPS1 Ser1 F9P, GPS2 Ser2 F9P, PPS G8
 # ioConfig: 0x025CA060      # EVB2: GPS1 Ser1 F9P, GPS2 Ser0 F9P, PPS G8
 # ioConfig: 0x0244a060      # EVB2: GPS1 Ser1 F9P, GPS2 disabled F9P, PPS G8

--- a/ros/launch/test_config.yaml
+++ b/ros/launch/test_config.yaml
@@ -28,7 +28,7 @@
 
 
 topic: "inertialsense"
-port: [/dev/ttyACM0, /dev/ttyACM1]
+port: [/dev/ttyACM0, /dev/ttyACM1, /dev/ttyACM2]
 baudrate: 921600
 enable_log: false
 publishTf: true                                 # Publish Transform Frame (TR)

--- a/ros/launch/test_config.yaml
+++ b/ros/launch/test_config.yaml
@@ -35,13 +35,14 @@ publishTf: true                                 # Publish Transform Frame (TR)
 frame_id: ""                                    # FIXME: What is this?  is it just the FrameID to use in the ROS messages?
 mag_declination: 0.0
 ref_lla: [0.0, 0.0, 0.0]
+# factory_reset: true                             # Reset flash config to factory defaults on startup.
 
 # Hardware platform specifying the IMX carrier board type (i.e. EVB-2) and configuration bits (see ePlatformConfig).  The platform type is used to simplify the GPS and I/O configuration process.
 # platform: 10                                    # PLATFORM_CFG_TYPE_RUG3_G2
-platform: 11                                    # PLATFORM_CFG_TYPE_EVB2_G2
+# platform: 11                                    # PLATFORM_CFG_TYPE_EVB2_G2
 # platform: 15                                    # PLATFORM_CFG_TYPE_IG1_G2
 
-# IMX ioConfig (see eIoConfig)
+# Overwrite IMX ioConfig (see eIoConfig)
 # Set DID_FLASH_CONFIG.ioConfig: 0x025c2060
 # Set DID_FLASH_CONFIG.platformConfig: 0x0000000c
 # Set DID_FLASH_CONFIG.RTKCfgBits: 0x00000400

--- a/ros/launch/test_config.yaml
+++ b/ros/launch/test_config.yaml
@@ -138,7 +138,7 @@ gps1:
       period: 5                                 # Publish every 1 second (200ms x 5)
     raw:
       topic: "gps1/raw"                         # Observation "/obs", ephemeris "/eph", and GLONASS ephemeris "/gep" are appended to the end of the topic name.  (i.e. topic="gps1_raw" results is "gps1_raw_obs" published as actual topic)
-      enable: true
+      enable: false
       period: 5                                 # Publish every 1 second (200ms x 5)
     rtk_pos_rel:
       topic: "gps1/pos_vel"

--- a/ros/launch/test_ros_bridge.launch
+++ b/ros/launch/test_ros_bridge.launch
@@ -1,6 +1,5 @@
 <launch>
     <rosparam file="$(find inertial_sense_ros)/launch/test_config.yaml" />
     <node pkg="rosservice" type="rosservice" name="set_move_base_log_level" args="call --wait /move_base/set_logger_level 'ros.move_base' 'debug'" />
-    <node name="inertial_sense_node" pkg="inertial_sense_ros" type="inertial_sense_node" output="screen" />
     <test test-name="test_ros_bridge" pkg="inertial_sense_ros" type="test_ros_bridge" />
 </launch>

--- a/ros/launch/test_ros_bridge.launch
+++ b/ros/launch/test_ros_bridge.launch
@@ -1,5 +1,6 @@
 <launch>
     <rosparam file="$(find inertial_sense_ros)/launch/test_config.yaml" />
     <node pkg="rosservice" type="rosservice" name="set_move_base_log_level" args="call --wait /move_base/set_logger_level 'ros.move_base' 'debug'" />
+    <node name="inertial_sense_node" pkg="inertial_sense_ros" type="inertial_sense_node" output="screen" />
     <test test-name="test_ros_bridge" pkg="inertial_sense_ros" type="test_ros_bridge" />
 </launch>

--- a/ros/src/inertial_sense_ros.cpp
+++ b/ros/src/inertial_sense_ros.cpp
@@ -863,7 +863,6 @@ void InertialSenseROS::configure_rtk()
     }
     else
     {
-
         ROS_ERROR_COND(RTK_rover_ && RTK_rover_->enable && RTK_base_ && RTK_base_->enable, "unable to configure onboard receiver to be both RTK rover and base - default to rover");
         ROS_ERROR_COND(RTK_rover_  && RTK_rover_->enable && GNSS_Compass_, "unable to configure onboard receiver to be both RTK rover as dual GNSS - default to dual GNSS");
 
@@ -2063,7 +2062,7 @@ bool InertialSenseROS::set_current_position_as_refLLA(std_srvs::Trigger::Request
 
     IS_.SendData(DID_FLASH_CONFIG, reinterpret_cast<uint8_t *>(&current_lla_), sizeof(current_lla_), offsetof(nvm_flash_cfg_t, refLla));
 
-    comManagerGetData(0, DID_FLASH_CONFIG, 0, 0, 1);
+    comManagerGetData(0, DID_FLASH_CONFIG, 0, 0, 0);
 
     int i = 0;
     nvm_flash_cfg_t current_flash;
@@ -2098,7 +2097,7 @@ bool InertialSenseROS::set_refLLA_to_value(inertial_sense_ros::refLLAUpdate::Req
 {
     IS_.SendData(DID_FLASH_CONFIG, reinterpret_cast<uint8_t *>(&req.lla), sizeof(req.lla), offsetof(nvm_flash_cfg_t, refLla));
 
-    comManagerGetData(0, DID_FLASH_CONFIG, 0, 0, 1);
+    comManagerGetData(0, DID_FLASH_CONFIG, 0, 0, 0);
 
     int i = 0;
     nvm_flash_cfg_t current_flash;

--- a/ros/src/inertial_sense_ros.cpp
+++ b/ros/src/inertial_sense_ros.cpp
@@ -135,13 +135,13 @@ void InertialSenseROS::initializeROS()
     // Publishers
     strobe_pub_ = nh_.advertise<std_msgs::Header>(rs_.strobe_in.topic, 1);
 
-    if (rs_.did_ins1.enabled)               { rs_.did_ins1.pub = nh_.advertise<inertial_sense_ros::DID_INS1>(rs_.did_ins1.topic, 1); }
-    if (rs_.did_ins2.enabled)               { rs_.did_ins2.pub = nh_.advertise<inertial_sense_ros::DID_INS2>(rs_.did_ins2.topic, 1); }
-    if (rs_.did_ins4.enabled)               { rs_.did_ins4.pub = nh_.advertise<inertial_sense_ros::DID_INS4>(rs_.did_ins4.topic, 1); }
-    if (rs_.odom_ins_ned.enabled)           { rs_.odom_ins_ned.pub = nh_.advertise<nav_msgs::Odometry>(rs_.odom_ins_ned.topic, 1); }
-    if (rs_.odom_ins_enu.enabled)           { rs_.odom_ins_enu.pub = nh_.advertise<nav_msgs::Odometry>(rs_.odom_ins_enu.topic, 1); }
+    if (rs_.did_ins1.enabled)               { rs_.did_ins1.pub      = nh_.advertise<inertial_sense_ros::DID_INS1>(rs_.did_ins1.topic, 1); }
+    if (rs_.did_ins2.enabled)               { rs_.did_ins2.pub      = nh_.advertise<inertial_sense_ros::DID_INS2>(rs_.did_ins2.topic, 1); }
+    if (rs_.did_ins4.enabled)               { rs_.did_ins4.pub      = nh_.advertise<inertial_sense_ros::DID_INS4>(rs_.did_ins4.topic, 1); }
+    if (rs_.odom_ins_ned.enabled)           { rs_.odom_ins_ned.pub  = nh_.advertise<nav_msgs::Odometry>(rs_.odom_ins_ned.topic, 1); }
+    if (rs_.odom_ins_enu.enabled)           { rs_.odom_ins_enu.pub  = nh_.advertise<nav_msgs::Odometry>(rs_.odom_ins_enu.topic, 1); }
     if (rs_.odom_ins_ecef.enabled)          { rs_.odom_ins_ecef.pub = nh_.advertise<nav_msgs::Odometry>(rs_.odom_ins_ecef.topic, 1); }
-    if (rs_.inl2_states.enabled)            { rs_.inl2_states.pub = nh_.advertise<inertial_sense_ros::INL2States>(rs_.inl2_states.topic, 1); }
+    if (rs_.inl2_states.enabled)            { rs_.inl2_states.pub   = nh_.advertise<inertial_sense_ros::INL2States>(rs_.inl2_states.topic, 1); }
 
     if (rs_.pimu.enabled)                   { rs_.pimu.pub = nh_.advertise<inertial_sense_ros::PIMU>(rs_.pimu.topic, 1); }
     if (rs_.imu.enabled)                    { rs_.imu.pub = nh_.advertise<sensor_msgs::Imu>(rs_.imu.topic, 1); }
@@ -918,8 +918,11 @@ void InertialSenseROS::flash_config_callback(eDataIDs DID, const nvm_flash_cfg_t
     refLla_[0] = msg->refLla[0];
     refLla_[1] = msg->refLla[1];
     refLla_[2] = msg->refLla[2];
+    if (!refLLA_valid)
+    {
+        ROS_DEBUG("InertialSenseROS: refLla was set");
+    }
     refLLA_valid = true;
-    ROS_DEBUG("InertialSenseROS: refLla was set");
 }
 
 void InertialSenseROS::INS1_callback(eDataIDs DID, const ins_1_t *const msg)
@@ -1077,7 +1080,6 @@ void InertialSenseROS::INS4_callback(eDataIDs DID, const ins_4_t *const msg)
             msg_odom_ecef.twist.twist.angular.x = result[0];
             msg_odom_ecef.twist.twist.angular.y = result[1];
             msg_odom_ecef.twist.twist.angular.z = result[2];
-
             rs_.odom_ins_ecef.pub.publish(msg_odom_ecef);
 
             if (publishTf_)
@@ -1252,8 +1254,8 @@ void InertialSenseROS::INS4_callback(eDataIDs DID, const ins_4_t *const msg)
             msg_odom_enu.twist.twist.angular.x = result[0];
             msg_odom_enu.twist.twist.angular.y = result[1];
             msg_odom_enu.twist.twist.angular.z = result[2];
-
             rs_.odom_ins_enu.pub.publish(msg_odom_enu);
+            
             if (publishTf_)
             {
                 // Calculate the TF from the pose...
@@ -1303,7 +1305,8 @@ void InertialSenseROS::INL2_states_callback(eDataIDs DID, const inl2_states_t *c
     // Use custom INL2 states message
     if (rs_.inl2_states.enabled)
     {
-        rs_.inl2_states.pub.publish(msg_inl2_states);
+        if (rs_.inl2_states.pub.getNumSubscribers() > 0)
+            rs_.inl2_states.pub.publish(msg_inl2_states);
     }
 }
 

--- a/ros/src/inertial_sense_ros.cpp
+++ b/ros/src/inertial_sense_ros.cpp
@@ -2062,6 +2062,7 @@ bool InertialSenseROS::set_current_position_as_refLLA(std_srvs::Trigger::Request
 
     IS_.SendData(DID_FLASH_CONFIG, reinterpret_cast<uint8_t *>(&current_lla_), sizeof(current_lla_), offsetof(nvm_flash_cfg_t, refLla));
 
+    printf("DEBUG: set_current_position_as_refLLA()\n");
     comManagerGetData(0, DID_FLASH_CONFIG, 0, 0, 0);
 
     int i = 0;

--- a/ros/src/inertial_sense_ros.cpp
+++ b/ros/src/inertial_sense_ros.cpp
@@ -918,7 +918,7 @@ void InertialSenseROS::flash_config_callback(eDataIDs DID, const nvm_flash_cfg_t
     refLla_[0] = msg->refLla[0];
     refLla_[1] = msg->refLla[1];
     refLla_[2] = msg->refLla[2];
-    refLLA_known = true;
+    refLLA_valid = true;
     ROS_DEBUG("InertialSenseROS: refLla was set");
 }
 
@@ -983,7 +983,7 @@ void InertialSenseROS::INS4_callback(eDataIDs DID, const ins_4_t *const msg)
 {
     rs_.did_ins4.streamingCheck(DID);
 
-    if (!refLLA_known)
+    if (!refLLA_valid)
     {
         ROS_INFO("InertialSenseROS: Waiting for refLLA to be received from IMX");
         return;

--- a/ros/src/inertial_sense_ros.cpp
+++ b/ros/src/inertial_sense_ros.cpp
@@ -2062,7 +2062,6 @@ bool InertialSenseROS::set_current_position_as_refLLA(std_srvs::Trigger::Request
 
     IS_.SendData(DID_FLASH_CONFIG, reinterpret_cast<uint8_t *>(&current_lla_), sizeof(current_lla_), offsetof(nvm_flash_cfg_t, refLla));
 
-    printf("DEBUG: set_current_position_as_refLLA()\n");
     comManagerGetData(0, DID_FLASH_CONFIG, 0, 0, 0);
 
     int i = 0;

--- a/ros/test/test_communications.cpp
+++ b/ros/test/test_communications.cpp
@@ -39,14 +39,12 @@ public:
 
 TEST(ROSCommunicationsTests, test_navsatfix )
 {
-
     gpsTestNode testNode;
     testNode.init();
 
     std::string yaml = "topic: \"inertialsense\"\n"
-                       "port: [/dev/ttyACM0, /dev/ttyACM1]\n"
+                       "port: [/dev/ttyACM0, /dev/ttyACM1, /dev/ttyACM2]\n"
                        "baudrate: 921600\n"
-                       "ioConfig: 0x026B2060\n"
                        "\n"
                        "ins:\n"
                        "  navigation_dt_ms: 16                          # EKF update period.  uINS-3: 4  default, 1 max.  Use `msg/ins.../period` to reduce INS output data rate."

--- a/ros/test/test_main.cpp
+++ b/ros/test/test_main.cpp
@@ -129,6 +129,8 @@ TEST(test_main, gps_ins_time_sync)
         }
     }
 
+    ASSERT_TRUE(false);
+
     TEST_COUT << "Timestamp Deviation (GPS <> pIMU):  [" << testNode.get_min_deviation(testNode.gps_ts, testNode.pimu_ts) << " <= " <<  testNode.get_avg_deviation(testNode.gps_ts, testNode.pimu_ts) << " <= "  << testNode.get_max_deviation(testNode.gps_ts, testNode.pimu_ts) << "]" << :: std::endl;
     TEST_COUT << "Timestamp Deviation (GPS <> IMU):   [" << testNode.get_min_deviation(testNode.gps_ts, testNode.imu_ts)  << " <= " <<  testNode.get_avg_deviation(testNode.gps_ts, testNode.imu_ts) << " <= "  << testNode.get_max_deviation(testNode.gps_ts, testNode.imu_ts) << "]" << :: std::endl;
     TEST_COUT << "Timestamp Deviation (GPS <> INS):   [" << testNode.get_min_deviation(testNode.gps_ts, testNode.ins_ts)  << " <= " <<  testNode.get_avg_deviation(testNode.gps_ts, testNode.ins_ts) << " <= "  << testNode.get_max_deviation(testNode.gps_ts, testNode.ins_ts) << "]" << :: std::endl;

--- a/ros/test/test_main.cpp
+++ b/ros/test/test_main.cpp
@@ -64,9 +64,8 @@ TEST(test_main, basic)
 TEST(test_main, gps_ins_time_sync)
 {
     std::string yaml = "topic: \"inertialsense\"\n"
-                       "port: [/dev/ttyACM0, /dev/ttyACM1]\n"
+                       "port: [/dev/ttyACM0, /dev/ttyACM1, /dev/ttyACM2]\n"
                        "baudrate: 921600\n"
-                       "ioConfig: 0x026B2060\n"
                        "\n"
                        "ins:\n"
                        "  navigation_dt_ms: 16\n"

--- a/ros/test/test_main.cpp
+++ b/ros/test/test_main.cpp
@@ -138,7 +138,6 @@ TEST(test_main, gps_ins_time_sync)
     EXPECT_GE( 0.05,  testNode.get_avg_deviation(testNode.gps_ts, testNode.imu_ts));
     EXPECT_GE( 0.05,  testNode.get_avg_deviation(testNode.gps_ts, testNode.ins_ts));
     EXPECT_GE( 0.005, testNode.get_avg_deviation(testNode.ins_ts, testNode.imu_ts));
-    printf("DEBUG terminate------\n");
     isROS.terminate();
 }
 

--- a/ros/test/test_main.cpp
+++ b/ros/test/test_main.cpp
@@ -7,9 +7,8 @@ cTestNode testNode;
 TEST(test_main, basic)
 {
     std::string yaml = "topic: \"inertialsense\"\n"
-                       "port: [/dev/ttyACM0, /dev/ttyACM1]\n"
+                       "port: [/dev/ttyACM0, /dev/ttyACM1, /dev/ttyACM2]\n"
                        "baudrate: 921600\n"
-                       "ioConfig: 0x026B2060\n"
                        "\n"
                        "ins:\n"
                        "  navigation_dt_ms: 16                          # EKF update period.  uINS-3: 4  default, 1 max.  Use `msg/ins.../period` to reduce INS output data rate."

--- a/ros/test/test_main.cpp
+++ b/ros/test/test_main.cpp
@@ -93,7 +93,6 @@ TEST(test_main, gps_ins_time_sync)
                        "      enable: true\n"
                        "      period: 1";
 
-
     YAML::Node config = YAML::Load(yaml);
     ASSERT_TRUE(config.IsDefined()) << "Unable to parse YAML file. Is the file valid?";
 
@@ -131,14 +130,15 @@ TEST(test_main, gps_ins_time_sync)
     }
 
     TEST_COUT << "Timestamp Deviation (GPS <> pIMU):  [" << testNode.get_min_deviation(testNode.gps_ts, testNode.pimu_ts) << " <= " <<  testNode.get_avg_deviation(testNode.gps_ts, testNode.pimu_ts) << " <= "  << testNode.get_max_deviation(testNode.gps_ts, testNode.pimu_ts) << "]" << :: std::endl;
-    TEST_COUT << "Timestamp Deviation (GPS <> IMU):  [" << testNode.get_min_deviation(testNode.gps_ts, testNode.imu_ts) << " <= " <<  testNode.get_avg_deviation(testNode.gps_ts, testNode.imu_ts) << " <= "  << testNode.get_max_deviation(testNode.gps_ts, testNode.imu_ts) << "]" << :: std::endl;
-    TEST_COUT << "Timestamp Deviation (GPS <> INS):  [" << testNode.get_min_deviation(testNode.gps_ts, testNode.ins_ts) << " <= " <<  testNode.get_avg_deviation(testNode.gps_ts, testNode.ins_ts) << " <= "  << testNode.get_max_deviation(testNode.gps_ts, testNode.ins_ts) << "]" << :: std::endl;
-    TEST_COUT << "Timestamp Deviation (INS <> IMU):  [" << testNode.get_min_deviation(testNode.ins_ts, testNode.imu_ts) << " <= " <<  testNode.get_avg_deviation(testNode.ins_ts, testNode.imu_ts) << " <= "  << testNode.get_max_deviation(testNode.ins_ts, testNode.imu_ts) << "]" << :: std::endl;
+    TEST_COUT << "Timestamp Deviation (GPS <> IMU):   [" << testNode.get_min_deviation(testNode.gps_ts, testNode.imu_ts)  << " <= " <<  testNode.get_avg_deviation(testNode.gps_ts, testNode.imu_ts) << " <= "  << testNode.get_max_deviation(testNode.gps_ts, testNode.imu_ts) << "]" << :: std::endl;
+    TEST_COUT << "Timestamp Deviation (GPS <> INS):   [" << testNode.get_min_deviation(testNode.gps_ts, testNode.ins_ts)  << " <= " <<  testNode.get_avg_deviation(testNode.gps_ts, testNode.ins_ts) << " <= "  << testNode.get_max_deviation(testNode.gps_ts, testNode.ins_ts) << "]" << :: std::endl;
+    TEST_COUT << "Timestamp Deviation (INS <> IMU):   [" << testNode.get_min_deviation(testNode.ins_ts, testNode.imu_ts)  << " <= " <<  testNode.get_avg_deviation(testNode.ins_ts, testNode.imu_ts) << " <= "  << testNode.get_max_deviation(testNode.ins_ts, testNode.imu_ts) << "]" << :: std::endl;
 
-    EXPECT_GE( 0.05, testNode.get_avg_deviation(testNode.gps_ts, testNode.pimu_ts));
-    EXPECT_GE( 0.05, testNode.get_avg_deviation(testNode.gps_ts, testNode.imu_ts));
-    EXPECT_GE( 0.05, testNode.get_avg_deviation(testNode.gps_ts, testNode.ins_ts));
+    EXPECT_GE( 0.05,  testNode.get_avg_deviation(testNode.gps_ts, testNode.pimu_ts));
+    EXPECT_GE( 0.05,  testNode.get_avg_deviation(testNode.gps_ts, testNode.imu_ts));
+    EXPECT_GE( 0.05,  testNode.get_avg_deviation(testNode.gps_ts, testNode.ins_ts));
     EXPECT_GE( 0.005, testNode.get_avg_deviation(testNode.ins_ts, testNode.imu_ts));
+    printf("DEBUG terminate------\n");
     isROS.terminate();
 }
 
@@ -148,8 +148,8 @@ void cTestNode::init()
     ros::NodeHandle nh;
     sub_wheel_encoder_      = nh.subscribe("msg_wheel_encoder", 1, &cTestNode::cbWheelEncoder, this);
     sub_pimu_               = nh.subscribe("pimu", 1, &cTestNode::cbPIMU, this);
-    sub_imu_               = nh.subscribe("imu", 1, &cTestNode::cbIMU, this);
-    sub_ins_               = nh.subscribe("odom_ins_enu", 1, &cTestNode::cbINS, this);
+    sub_imu_                = nh.subscribe("imu", 1, &cTestNode::cbIMU, this);
+    sub_ins_                = nh.subscribe("odom_ins_enu", 1, &cTestNode::cbINS, this);
     sub_gps1_               = nh.subscribe("gps1/pos_vel", 1, &cTestNode::cbGPS, this);
 }
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -163,12 +163,6 @@ bool InertialSense::HasReceivedResponseFromDevice(size_t index)
 		return false;
 	}
 
-	printf("HasReceivedResponseFromDevice() %d %d %d %d\n",
-		(int)index, 
-		m_comManagerState.devices[index].flashCfg.size,
-		m_comManagerState.devices[index].devInfo.serialNumber,
-		m_comManagerState.devices[index].devInfo.manufacturer[0]);
-
 	return (
 		m_comManagerState.devices[index].flashCfg.size != 0 &&
 		m_comManagerState.devices[index].devInfo.serialNumber != 0 &&

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -778,6 +778,10 @@ void InertialSense::ProcessRxData(p_data_t* data, int pHandle)
 			*  is copied to the local memory anyway so you know what the current flash is on the IMX.
 			*/
 			nvm_flash_cfg_t *flashConfig = (nvm_flash_cfg_t*)data->buf;
+
+			is_device_t &device = m_comManagerState.devices[pHandle];
+			printf("ProcessRxData() DID_FLASH_CONFIG,   syncState %d,   checksum 0x%08x 0x%08x\n", device.syncState, flashConfig->checksum, device.flashCfg.checksum);
+
 			UpdateFlashConfigSyncState(flashConfig->checksum, pHandle);
 			
 			if (device.syncState != InertialSense::IMXSyncState::SYNCHRONIZING)
@@ -794,6 +798,10 @@ void InertialSense::ProcessRxData(p_data_t* data, int pHandle)
 			*  final determination of the next actions.
 			*/
 			sys_params_t* sysParamsRx = (sys_params_t*)data->buf;
+
+			is_device_t &device = m_comManagerState.devices[pHandle];
+			printf("ProcessRxData() DID_SYS_PARAMS,   syncState %d,   checksum 0x%08x 0x%08x\n", device.syncState, sysParamsRx->flashCfgChecksum, device.flashCfg.checksum);
+
 			UpdateFlashConfigSyncState(sysParamsRx->flashCfgChecksum, pHandle);
 		}
 	}

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1048,12 +1048,9 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
 
 	if (m_enableDeviceValidation)
 	{
-		// negotiate baud rate by querying device info - don't return out until it negotiates or times out
-		// if the baud rate is already correct, the request for the message should succeed very quickly
 		time_t startTime = time(0);
 
-		// try to auto-baud for up to 10 seconds, then abort if we didn't get a valid packet
-		// we wait until we get a valid serial number and manufacturer
+		// Query devices with 10 second timeout
 		while (!HasReceivedResponseFromAllDevices() && (time(0) - startTime < 10))
 		{
 			for (size_t i = 0; i < m_comManagerState.devices.size(); i++)

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -164,7 +164,7 @@ bool InertialSense::HasReceivedResponseFromDevice(size_t index)
 	}
 
 	printf("HasReceivedResponseFromDevice() %d %d %d %d\n",
-		index, 
+		(int)index, 
 		m_comManagerState.devices[index].flashCfg.size,
 		m_comManagerState.devices[index].devInfo.serialNumber,
 		m_comManagerState.devices[index].devInfo.manufacturer[0]);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1078,7 +1078,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
 				comManagerGetData((int)i, DID_EVB_FLASH_CFG, 0, 0, 0);
 			}
 
-			SLEEP_MS(100);
+			SLEEP_MS(1000);
 			comManagerStep();
 		}
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -719,10 +719,10 @@ void InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
 	// Update checksum 
 	flashCfg.checksum = flashChecksum32(&flashCfg, sizeof(nvm_flash_cfg_t));
 
-	//Compare checksum of flashCfg vs known checksum in m_comManagerState.devices[pHandle].flashCfg
+	// Compare checksum of flashCfg vs known checksum in m_comManagerState.devices[pHandle].flashCfg
 	if (m_comManagerState.devices[pHandle].flashCfg.checksum == flashCfg.checksum)
 	{
-		//If checksum matches then we are already in sync
+		// If checksum matches then we are already in sync
 		m_comManagerState.devices[pHandle].syncState = SYNCHRONIZED;
         m_comManagerState.devices[pHandle].flashCfg = flashCfg;
 	}
@@ -1238,6 +1238,8 @@ int InertialSense::LoadFlashConfig(std::string path, int pHandle)
     try
     {
         nvm_flash_cfg_t loaded_flash;
+        GetFlashConfig(loaded_flash);
+
         YAML::Node inData = YAML::LoadFile(path);
         loaded_flash.size                     = inData["size"].as<uint32_t>();
         loaded_flash.checksum                 = inData["checksum"].as<uint32_t>();
@@ -1252,12 +1254,12 @@ int InertialSense::LoadFlashConfig(std::string path, int pHandle)
         loaded_flash.insRotation[1]           = insRotation[1].as<float>();
         loaded_flash.insRotation[2]           = insRotation[2].as<float>();
 
-        YAML::Node insOffset                    = inData["insOffset"];
+        YAML::Node insOffset                  = inData["insOffset"];
         loaded_flash.insOffset[0]             = insOffset[0].as<float>();
         loaded_flash.insOffset[1]             = insOffset[1].as<float>();
         loaded_flash.insOffset[2]             = insOffset[2].as<float>();
 
-        YAML::Node gps1AntOffset                = inData["gps1AntOffset"];
+        YAML::Node gps1AntOffset              = inData["gps1AntOffset"];
         loaded_flash.gps1AntOffset[0]         = gps1AntOffset[0].as<float>();
         loaded_flash.gps1AntOffset[1]         = gps1AntOffset[1].as<float>();
         loaded_flash.gps1AntOffset[2]         = gps1AntOffset[2].as<float>();
@@ -1267,12 +1269,12 @@ int InertialSense::LoadFlashConfig(std::string path, int pHandle)
         loaded_flash.gnssSatSigConst          = inData["gnssSatSigConst"].as<uint16_t>();
         loaded_flash.sysCfgBits               = inData["sysCfgBits"].as<uint32_t>();
 
-        YAML::Node refLla                       = inData["refLla"];
+        YAML::Node refLla                     = inData["refLla"];
         loaded_flash.refLla[0]                = refLla[0].as<double>();
         loaded_flash.refLla[1]                = refLla[1].as<double>();
         loaded_flash.refLla[2]                = refLla[2].as<double>();
 
-        YAML::Node lastLla                      = inData["lastLla"];
+        YAML::Node lastLla                    = inData["lastLla"];
         loaded_flash.lastLla[0]               = lastLla[0].as<double>();
         loaded_flash.lastLla[1]               = lastLla[1].as<double>();
         loaded_flash.lastLla[2]               = lastLla[2].as<double>();
@@ -1283,18 +1285,17 @@ int InertialSense::LoadFlashConfig(std::string path, int pHandle)
         loaded_flash.ioConfig                 = inData["ioConfig"].as<uint32_t>();
         loaded_flash.platformConfig           = inData["platformConfig"].as<uint32_t>();
 
-
-        YAML::Node gps2AntOffset                = inData["gps2AntOffset"];
+        YAML::Node gps2AntOffset              = inData["gps2AntOffset"];
         loaded_flash.gps2AntOffset[0]         = gps2AntOffset[0].as<float>();
         loaded_flash.gps2AntOffset[1]         = gps2AntOffset[1].as<float>();
         loaded_flash.gps2AntOffset[2]         = gps2AntOffset[2].as<float>();
 
-        YAML::Node zeroVelRotation              = inData["zeroVelRotation"];
+        YAML::Node zeroVelRotation            = inData["zeroVelRotation"];
         loaded_flash.zeroVelRotation[0]       = zeroVelRotation[0].as<float>();
         loaded_flash.zeroVelRotation[1]       = zeroVelRotation[1].as<float>();
         loaded_flash.zeroVelRotation[2]       = zeroVelRotation[2].as<float>();
 
-        YAML::Node zeroVelOffset                = inData["zeroVelOffset"];
+        YAML::Node zeroVelOffset              = inData["zeroVelOffset"];
         loaded_flash.zeroVelOffset[0]         = zeroVelOffset[0].as<float>();
         loaded_flash.zeroVelOffset[1]         = zeroVelOffset[1].as<float>();
         loaded_flash.zeroVelOffset[2]         = zeroVelOffset[2].as<float>();
@@ -1312,25 +1313,25 @@ int InertialSense::LoadFlashConfig(std::string path, int pHandle)
         loaded_flash.wheelConfig.radius       = inData["wheelConfigRadius"].as<float>();
         loaded_flash.wheelConfig.track_width  = inData["wheelConfigTrackWidth"].as<float>();
 
-		YAML::Node wheelCfgTransE_b2w			= inData["wheelCfgTransE_b2w"];
-        loaded_flash.wheelConfig.transform.e_b2w[0] 	= wheelCfgTransE_b2w[0].as<float>();
-        loaded_flash.wheelConfig.transform.e_b2w[1] 	= wheelCfgTransE_b2w[1].as<float>();
-        loaded_flash.wheelConfig.transform.e_b2w[2] 	= wheelCfgTransE_b2w[2].as<float>();
+        YAML::Node wheelCfgTransE_b2w                       = inData["wheelCfgTransE_b2w"];
+        loaded_flash.wheelConfig.transform.e_b2w[0]         = wheelCfgTransE_b2w[0].as<float>();
+        loaded_flash.wheelConfig.transform.e_b2w[1]         = wheelCfgTransE_b2w[1].as<float>();
+        loaded_flash.wheelConfig.transform.e_b2w[2]         = wheelCfgTransE_b2w[2].as<float>();
 
-		YAML::Node wheelCfgTransE_b2wsig			= inData["wheelCfgTransE_b2wsig"];
-        loaded_flash.wheelConfig.transform.e_b2w_sigma[0] 	= wheelCfgTransE_b2wsig[0].as<float>();
-        loaded_flash.wheelConfig.transform.e_b2w_sigma[1] 	= wheelCfgTransE_b2wsig[1].as<float>();
-        loaded_flash.wheelConfig.transform.e_b2w_sigma[2] 	= wheelCfgTransE_b2wsig[2].as<float>();
+        YAML::Node wheelCfgTransE_b2wsig                    = inData["wheelCfgTransE_b2wsig"];
+        loaded_flash.wheelConfig.transform.e_b2w_sigma[0]   = wheelCfgTransE_b2wsig[0].as<float>();
+        loaded_flash.wheelConfig.transform.e_b2w_sigma[1]   = wheelCfgTransE_b2wsig[1].as<float>();
+        loaded_flash.wheelConfig.transform.e_b2w_sigma[2]   = wheelCfgTransE_b2wsig[2].as<float>();
 
-		YAML::Node wheelCfgTransT_b2w			= inData["wheelCfgTransT_b2wsig"];
-        loaded_flash.wheelConfig.transform.t_b2w[0] 	= wheelCfgTransT_b2w[0].as<float>();
-        loaded_flash.wheelConfig.transform.t_b2w[1] 	= wheelCfgTransT_b2w[1].as<float>();
-        loaded_flash.wheelConfig.transform.t_b2w[2] 	= wheelCfgTransT_b2w[2].as<float>();
+        YAML::Node wheelCfgTransT_b2w                       = inData["wheelCfgTransT_b2wsig"];
+        loaded_flash.wheelConfig.transform.t_b2w[0]         = wheelCfgTransT_b2w[0].as<float>();
+        loaded_flash.wheelConfig.transform.t_b2w[1]         = wheelCfgTransT_b2w[1].as<float>();
+        loaded_flash.wheelConfig.transform.t_b2w[2]         = wheelCfgTransT_b2w[2].as<float>();
 
-		YAML::Node wheelCfgTransT_b2wsig			= inData["wheelCfgTransT_b2wsig"];
-        loaded_flash.wheelConfig.transform.t_b2w_sigma[0] 	= wheelCfgTransT_b2wsig[0].as<float>();
-        loaded_flash.wheelConfig.transform.t_b2w_sigma[1] 	= wheelCfgTransT_b2wsig[1].as<float>();
-        loaded_flash.wheelConfig.transform.t_b2w_sigma[2] 	= wheelCfgTransT_b2wsig[2].as<float>();
+        YAML::Node wheelCfgTransT_b2wsig                    = inData["wheelCfgTransT_b2wsig"];
+        loaded_flash.wheelConfig.transform.t_b2w_sigma[0]   = wheelCfgTransT_b2wsig[0].as<float>();
+        loaded_flash.wheelConfig.transform.t_b2w_sigma[1]   = wheelCfgTransT_b2wsig[1].as<float>();
+        loaded_flash.wheelConfig.transform.t_b2w_sigma[2]   = wheelCfgTransT_b2wsig[2].as<float>();
 
         SetFlashConfig(loaded_flash);
     }
@@ -1340,5 +1341,5 @@ int InertialSense::LoadFlashConfig(std::string path, int pHandle)
         return -1;
     }
 
-	return 0;
+    return 0;
 }

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -158,15 +158,15 @@ void InertialSense::DisableLogging()
 
 bool InertialSense::HasReceivedResponseFromDevice(size_t index)
 {
-	printf("HasReceivedResponseFromDevice() %d %d %d\n", 
-		m_comManagerState.devices[index].flashCfg.size,
-		m_comManagerState.devices[index].devInfo.serialNumber,
-		m_comManagerState.devices[index].devInfo.manufacturer[0]);
-
 	if (index >= m_comManagerState.devices.size())
 	{
 		return false;
 	}
+
+	printf("HasReceivedResponseFromDevice() %d %d %d\n", 
+		m_comManagerState.devices[index].flashCfg.size,
+		m_comManagerState.devices[index].devInfo.serialNumber,
+		m_comManagerState.devices[index].devInfo.manufacturer[0]);
 
 	return (
 		m_comManagerState.devices[index].flashCfg.size != 0 &&

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1078,7 +1078,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
 				comManagerGetData((int)i, DID_EVB_FLASH_CFG, 0, 0, 0);
 			}
 
-			SLEEP_MS(13);
+			SLEEP_MS(100);
 			comManagerStep();
 		}
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1064,6 +1064,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
 		// we wait until we get a valid serial number and manufacturer
 		while (!HasReceivedResponseFromAllDevices() && (time(0) - startTime < 10))
 		{
+			printf("DEBUG: init poll for startup data\n");
 			for (size_t i = 0; i < m_comManagerState.devices.size(); i++)
 			{
 				comManagerGetData((int)i, DID_SYS_CMD, 0, 0, 0);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -163,7 +163,8 @@ bool InertialSense::HasReceivedResponseFromDevice(size_t index)
 		return false;
 	}
 
-	printf("HasReceivedResponseFromDevice() %d %d %d\n", 
+	printf("HasReceivedResponseFromDevice() %d %d %d %d\n",
+		index, 
 		m_comManagerState.devices[index].flashCfg.size,
 		m_comManagerState.devices[index].devInfo.serialNumber,
 		m_comManagerState.devices[index].devInfo.manufacturer[0]);
@@ -1078,7 +1079,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
 				comManagerGetData((int)i, DID_EVB_FLASH_CFG, 0, 0, 0);
 			}
 
-			SLEEP_MS(1000);
+			SLEEP_MS(100);
 			comManagerStep();
 		}
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -778,10 +778,6 @@ void InertialSense::ProcessRxData(p_data_t* data, int pHandle)
 			*  is copied to the local memory anyway so you know what the current flash is on the IMX.
 			*/
 			nvm_flash_cfg_t *flashConfig = (nvm_flash_cfg_t*)data->buf;
-
-			is_device_t &device = m_comManagerState.devices[pHandle];
-			printf("ProcessRxData() DID_FLASH_CONFIG,   syncState %d,   checksum 0x%08x 0x%08x\n", device.syncState, flashConfig->checksum, device.flashCfg.checksum);
-
 			UpdateFlashConfigSyncState(flashConfig->checksum, pHandle);
 			
 			if (device.syncState != InertialSense::IMXSyncState::SYNCHRONIZING)
@@ -798,10 +794,6 @@ void InertialSense::ProcessRxData(p_data_t* data, int pHandle)
 			*  final determination of the next actions.
 			*/
 			sys_params_t* sysParamsRx = (sys_params_t*)data->buf;
-
-			is_device_t &device = m_comManagerState.devices[pHandle];
-			printf("ProcessRxData() DID_SYS_PARAMS,   syncState %d,   checksum 0x%08x 0x%08x\n", device.syncState, sysParamsRx->flashCfgChecksum, device.flashCfg.checksum);
-
 			UpdateFlashConfigSyncState(sysParamsRx->flashCfgChecksum, pHandle);
 		}
 	}
@@ -1064,7 +1056,6 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
 		// we wait until we get a valid serial number and manufacturer
 		while (!HasReceivedResponseFromAllDevices() && (time(0) - startTime < 10))
 		{
-			printf("DEBUG: init poll for startup data\n");
 			for (size_t i = 0; i < m_comManagerState.devices.size(); i++)
 			{
 				comManagerGetData((int)i, DID_SYS_CMD, 0, 0, 0);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -158,6 +158,11 @@ void InertialSense::DisableLogging()
 
 bool InertialSense::HasReceivedResponseFromDevice(size_t index)
 {
+	printf("HasReceivedResponseFromDevice() %d %d %d\n", 
+		m_comManagerState.devices[index].flashCfg.size,
+		m_comManagerState.devices[index].devInfo.serialNumber,
+		m_comManagerState.devices[index].devInfo.manufacturer[0]);
+
 	if (index >= m_comManagerState.devices.size())
 	{
 		return false;

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -253,7 +253,7 @@ public:
 	/**
 	* Set device configuration
 	* @param pHandle the pHandle to set sysCmd for
-	* @param command system command value
+	* @param command system command value (see eSystemCommand)
 	*/
 	void SetSysCmd(const uint32_t command, int pHandle = -1);
 

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -406,8 +406,8 @@ public:
 	// Sync state between this class and IMX device
 	enum IMXSyncState
 	{
-		NOT_SYNCHRONIZED    = 0,   // Download needed
-		SYNCHRONIZING       = 1,   // Uploading
+		NOT_SYNCHRONIZED    = 0,   // Download from IMX needed
+		SYNCHRONIZING       = 1,   // Uploading to IMX
 		SYNCHRONIZED        = 2,   // Flash config on IMX and locally match
 	};
 

--- a/src/cltool.cpp
+++ b/src/cltool.cpp
@@ -373,7 +373,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         }
         else if (startsWith(a, "-reset"))
         {
-            g_commandLineOptions.softwareResetUins = true;
+            g_commandLineOptions.softwareResetImx = true;
         }
 		else if (startsWith(a, "-rover="))
 		{

--- a/src/cltool.h
+++ b/src/cltool.h
@@ -58,7 +58,7 @@ typedef struct
 	bool forceBootloaderUpdate;				// -fb
 	bool bootloaderVerify; 					// -bv
 	bool replayDataLog;
-	bool softwareResetUins;
+	bool softwareResetImx;
 	bool softwareResetEvb;
 	bool magRecal;
 	uint32_t magRecalMode;

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -228,13 +228,15 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
 	}
     if (g_commandLineOptions.persistentMessages)
     {   // Save persistent messages to flash
+		cout << "Sending save persistent messages." << endl;
         system_command_t cfg;
         cfg.command = SYS_CMD_SAVE_PERSISTENT_MESSAGES;
         cfg.invCommand = ~cfg.command;
         inertialSenseInterface.SendRawData(DID_SYS_CMD, (uint8_t*)&cfg, sizeof(system_command_t), 0);
     }
-    if (g_commandLineOptions.softwareResetUins)
+    if (g_commandLineOptions.softwareResetImx)
     {   // Issue software reset
+		cout << "Sending software reset." << endl;
         system_command_t cfg;
         cfg.command = SYS_CMD_SOFTWARE_RESET;
         cfg.invCommand = ~cfg.command;
@@ -242,13 +244,14 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     }
     if (g_commandLineOptions.softwareResetEvb)
     {   // Issue software reset to EVB
+		cout << "Sending EVB software reset." << endl;
         uint32_t sysCommand = SYS_CMD_SOFTWARE_RESET;
         inertialSenseInterface.SendRawData(DID_EVB_STATUS, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
     }
     if (g_commandLineOptions.chipEraseEvb2)
     {   // Chip erase EVB
-        uint32_t sysCommand;
-		
+		cout << "Sending EVB chip erase." << endl;
+        uint32_t sysCommand;		
 		sysCommand = SYS_CMD_MANF_UNLOCK;
         inertialSenseInterface.SendRawData(DID_EVB_STATUS, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
         sysCommand = SYS_CMD_MANF_CHIP_ERASE;
@@ -256,7 +259,23 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     }
     if (g_commandLineOptions.sysCommand != 0)
     {   // Send system command to IMX
-		cout << "Sending system command: " << g_commandLineOptions.sysCommand << endl;
+		cout << "Sending system command: " << g_commandLineOptions.sysCommand;
+		switch(g_commandLineOptions.sysCommand)
+		{
+		case SYS_CMD_ENABLE_SERIAL_PORT_BRIDGE_USB_TO_GPS1:
+		case SYS_CMD_ENABLE_SERIAL_PORT_BRIDGE_USB_TO_GPS2:
+		case SYS_CMD_ENABLE_SERIAL_PORT_BRIDGE_USB_TO_SER0:
+		case SYS_CMD_ENABLE_SERIAL_PORT_BRIDGE_USB_TO_SER1:
+		case SYS_CMD_ENABLE_SERIAL_PORT_BRIDGE_USB_TO_SER2:
+		case SYS_CMD_ENABLE_SERIAL_PORT_BRIDGE_SER0_TO_GPS1:
+			cout << " Enable serial bridge"; break;
+		case SYS_CMD_DISABLE_SERIAL_PORT_BRIDGE:
+			cout << "Disable serial bridge"; break;
+		case SYS_CMD_MANF_FACTORY_RESET:            cout << " Factory Reset";           break;
+		case SYS_CMD_MANF_CHIP_ERASE:               cout << " Chip Erase";              break;
+		case SYS_CMD_MANF_DOWNGRADE_CALIBRATION:    cout << " Downgrade Calibration";   break;
+		}
+		cout << endl;
 		system_command_t cfg;
 
 		cfg.command = SYS_CMD_MANF_UNLOCK;

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -170,89 +170,89 @@ typedef uint32_t eDataIDs;
 #define RECEIVER_INDEX_GPS2 3 // DO NOT CHANGE
 
 // Max number of devices across all hardware types: uINS-3, uINS-4, and IMX-5
-#define NUM_IMU_DEVICES     3		// g_numImuDevices defines the actual number of hardware specific devices
-#define NUM_MAG_DEVICES     2		// g_numMagDevices defines the actual number of hardware specific devices
+#define NUM_IMU_DEVICES     3        // g_numImuDevices defines the actual number of hardware specific devices
+#define NUM_MAG_DEVICES     2        // g_numMagDevices defines the actual number of hardware specific devices
 
 /** INS status flags */
 enum eInsStatusFlags
 {
-	/** Attitude estimate is usable but outside spec (COARSE) */
-	INS_STATUS_ATT_ALIGN_COARSE                 = (int)0x00000001,
-	/** Velocity estimate is usable but outside spec (COARSE) */
-	INS_STATUS_VEL_ALIGN_COARSE                 = (int)0x00000002,
-	/** Position estimate is usable but outside spec (COARSE) */
-	INS_STATUS_POS_ALIGN_COARSE                 = (int)0x00000004,
-	/** Estimate is COARSE mask (usable but outside spec) */
-	INS_STATUS_ALIGN_COARSE_MASK                = (int)0x00000007,
+    /** Attitude estimate is usable but outside spec (COARSE) */
+    INS_STATUS_ATT_ALIGN_COARSE                 = (int)0x00000001,
+    /** Velocity estimate is usable but outside spec (COARSE) */
+    INS_STATUS_VEL_ALIGN_COARSE                 = (int)0x00000002,
+    /** Position estimate is usable but outside spec (COARSE) */
+    INS_STATUS_POS_ALIGN_COARSE                 = (int)0x00000004,
+    /** Estimate is COARSE mask (usable but outside spec) */
+    INS_STATUS_ALIGN_COARSE_MASK                = (int)0x00000007,
 
-	/** Velocity aided by wheel sensor */
-	INS_STATUS_WHEEL_AIDING_VEL                 = (int)0x00000008,
+    /** Velocity aided by wheel sensor */
+    INS_STATUS_WHEEL_AIDING_VEL                 = (int)0x00000008,
 
-	/** Attitude estimate is within spec (FINE) */
-	INS_STATUS_ATT_ALIGN_FINE                   = (int)0x00000010,
-	/** Velocity estimate is within spec (FINE) */
-	INS_STATUS_VEL_ALIGN_FINE                   = (int)0x00000020,
-	/** Position estimate is within spec (FINE) */
-	INS_STATUS_POS_ALIGN_FINE                   = (int)0x00000040,
-	/** Estimate is FINE mask */
-	INS_STATUS_ALIGN_FINE_MASK                  = (int)0x00000070,
+    /** Attitude estimate is within spec (FINE) */
+    INS_STATUS_ATT_ALIGN_FINE                   = (int)0x00000010,
+    /** Velocity estimate is within spec (FINE) */
+    INS_STATUS_VEL_ALIGN_FINE                   = (int)0x00000020,
+    /** Position estimate is within spec (FINE) */
+    INS_STATUS_POS_ALIGN_FINE                   = (int)0x00000040,
+    /** Estimate is FINE mask */
+    INS_STATUS_ALIGN_FINE_MASK                  = (int)0x00000070,
 
-	/** Heading aided by GPS */
-	INS_STATUS_GPS_AIDING_HEADING               = (int)0x00000080,
+    /** Heading aided by GPS */
+    INS_STATUS_GPS_AIDING_HEADING               = (int)0x00000080,
 
-	/** Position aided by GPS position */
-	INS_STATUS_GPS_AIDING_POS                   = (int)0x00000100,
-	/** GPS update event occurred in solution, potentially causing discontinuity in position path */
-	INS_STATUS_GPS_UPDATE_IN_SOLUTION           = (int)0x00000200,
-	/** Reserved for internal purpose */
-	INS_STATUS_RESERVED_1                       = (int)0x00000400,																	
-	/** Heading aided by magnetic heading */
-	INS_STATUS_MAG_AIDING_HEADING               = (int)0x00000800,
+    /** Position aided by GPS position */
+    INS_STATUS_GPS_AIDING_POS                   = (int)0x00000100,
+    /** GPS update event occurred in solution, potentially causing discontinuity in position path */
+    INS_STATUS_GPS_UPDATE_IN_SOLUTION           = (int)0x00000200,
+    /** Reserved for internal purpose */
+    INS_STATUS_RESERVED_1                       = (int)0x00000400,
+    /** Heading aided by magnetic heading */
+    INS_STATUS_MAG_AIDING_HEADING               = (int)0x00000800,
 
-	/** Nav mode (set) = estimating velocity and position. AHRS mode (cleared) = NOT estimating velocity and position */
-	INS_STATUS_NAV_MODE							= (int)0x00001000,
+    /** Nav mode (set) = estimating velocity and position. AHRS mode (cleared) = NOT estimating velocity and position */
+    INS_STATUS_NAV_MODE                         = (int)0x00001000,
 
-	/** INS in stationary mode.  If initiated by zero velocity command, user should not move (keep system motionless) to assist on-board processing. */
-	INS_STATUS_STATIONARY_MODE					= (int)0x00002000,	
-	/** Velocity aided by GPS velocity */
-	INS_STATUS_GPS_AIDING_VEL                   = (int)0x00004000,
-	/** Vehicle kinematic calibration is good */
-	INS_STATUS_KINEMATIC_CAL_GOOD	            = (int)0x00008000,
+    /** INS in stationary mode.  If initiated by zero velocity command, user should not move (keep system motionless) to assist on-board processing. */
+    INS_STATUS_STATIONARY_MODE                  = (int)0x00002000,    
+    /** Velocity aided by GPS velocity */
+    INS_STATUS_GPS_AIDING_VEL                   = (int)0x00004000,
+    /** Vehicle kinematic calibration is good */
+    INS_STATUS_KINEMATIC_CAL_GOOD               = (int)0x00008000,
 
-	/** INS/AHRS Solution Status */
-	INS_STATUS_SOLUTION_MASK					= (int)0x000F0000,
-	INS_STATUS_SOLUTION_OFFSET					= 16,
+    /** INS/AHRS Solution Status */
+    INS_STATUS_SOLUTION_MASK                    = (int)0x000F0000,
+    INS_STATUS_SOLUTION_OFFSET                  = 16,
 #define INS_STATUS_SOLUTION(insStatus)          ((insStatus&INS_STATUS_SOLUTION_MASK)>>INS_STATUS_SOLUTION_OFFSET)
 
-	INS_STATUS_SOLUTION_OFF                     = 0,	// System is off 
-	INS_STATUS_SOLUTION_ALIGNING                = 1,	// System is in alignment mode
-	INS_STATUS_SOLUTION_ALIGNMENT_COMPLETE      = 2,	// System is aligned but not enough dynamics have been experienced to be with specifications.
-	INS_STATUS_SOLUTION_NAV                     = 3,	// System is in navigation mode and solution is good.
-	INS_STATUS_SOLUTION_NAV_HIGH_VARIANCE       = 4,	// System is in navigation mode but the attitude uncertainty has exceeded the threshold.
-	INS_STATUS_SOLUTION_AHRS                    = 5,	// System is in AHRS mode and solution is good.
-	INS_STATUS_SOLUTION_AHRS_HIGH_VARIANCE      = 6,	// System is in AHRS mode but the attitude uncertainty has exceeded the threshold.
+    INS_STATUS_SOLUTION_OFF                     = 0,    // System is off 
+    INS_STATUS_SOLUTION_ALIGNING                = 1,    // System is in alignment mode
+    INS_STATUS_SOLUTION_ALIGNMENT_COMPLETE      = 2,    // System is aligned but not enough dynamics have been experienced to be with specifications.
+    INS_STATUS_SOLUTION_NAV                     = 3,    // System is in navigation mode and solution is good.
+    INS_STATUS_SOLUTION_NAV_HIGH_VARIANCE       = 4,    // System is in navigation mode but the attitude uncertainty has exceeded the threshold.
+    INS_STATUS_SOLUTION_AHRS                    = 5,    // System is in AHRS mode and solution is good.
+    INS_STATUS_SOLUTION_AHRS_HIGH_VARIANCE      = 6,    // System is in AHRS mode but the attitude uncertainty has exceeded the threshold.
 
-	/** GPS compassing antenna offsets are not set in flashCfg. */
+    /** GPS compassing antenna offsets are not set in flashCfg. */
     INS_STATUS_RTK_COMPASSING_BASELINE_UNSET    = (int)0x00100000,
     /** GPS antenna baseline specified in flashCfg and measured by GPS do not match. */
     INS_STATUS_RTK_COMPASSING_BASELINE_BAD      = (int)0x00200000,
     INS_STATUS_RTK_COMPASSING_MASK              = (INS_STATUS_RTK_COMPASSING_BASELINE_UNSET|INS_STATUS_RTK_COMPASSING_BASELINE_BAD),
-    
-	/** Magnetometer is being recalibrated.  Device requires rotation to complete the calibration process. HDW_STATUS_MAG_RECAL_COMPLETE is set when complete. */
-	INS_STATUS_MAG_RECALIBRATING				= (int)0x00400000,
-	/** Magnetometer is experiencing interference or calibration is bad.  Attention may be required to remove interference (move the device) or recalibrate the magnetometer. */
-	INS_STATUS_MAG_INTERFERENCE_OR_BAD_CAL		= (int)0x00800000,
+
+    /** Magnetometer is being recalibrated.  Device requires rotation to complete the calibration process. HDW_STATUS_MAG_RECAL_COMPLETE is set when complete. */
+    INS_STATUS_MAG_RECALIBRATING                = (int)0x00400000,
+    /** Magnetometer is experiencing interference or calibration is bad.  Attention may be required to remove interference (move the device) or recalibrate the magnetometer. */
+    INS_STATUS_MAG_INTERFERENCE_OR_BAD_CAL      = (int)0x00800000,
 
     /** GPS navigation fix type (see eGpsNavFixStatus) */
-    INS_STATUS_GPS_NAV_FIX_MASK					= (int)0x03000000,
-    INS_STATUS_GPS_NAV_FIX_OFFSET				= 24,
+    INS_STATUS_GPS_NAV_FIX_MASK                 = (int)0x03000000,
+    INS_STATUS_GPS_NAV_FIX_OFFSET               = 24,
 #define INS_STATUS_NAV_FIX_STATUS(insStatus)    ((insStatus&INS_STATUS_GPS_NAV_FIX_MASK)>>INS_STATUS_GPS_NAV_FIX_OFFSET)
 
-	/** RTK compassing heading is accurate.  (RTK fix and hold status) */
-	INS_STATUS_RTK_COMPASSING_VALID				= (int)0x04000000,
+    /** RTK compassing heading is accurate.  (RTK fix and hold status) */
+    INS_STATUS_RTK_COMPASSING_VALID             = (int)0x04000000,
 
-	/* NOTE: If you add or modify these INS_STATUS_RTK_ values, please update eInsStatusRtkBase in IS-src/python/src/ci_hdw/data_sets.py */
-	/** RTK error: Observations invalid or not received  (i.e. RTK differential corrections) */
+    /* NOTE: If you add or modify these INS_STATUS_RTK_ values, please update eInsStatusRtkBase in IS-src/python/src/ci_hdw/data_sets.py */
+    /** RTK error: Observations invalid or not received  (i.e. RTK differential corrections) */
     INS_STATUS_RTK_RAW_GPS_DATA_ERROR           = (int)0x08000000,
     /** RTK error: Either base observations or antenna position have not been received */
     INS_STATUS_RTK_ERR_BASE_DATA_MISSING        = (int)0x10000000,
@@ -262,13 +262,13 @@ enum eInsStatusFlags
     INS_STATUS_RTK_ERR_BASE_POSITION_INVALID    = (int)0x30000000,
     /** RTK error: NO base position received */
     INS_STATUS_RTK_ERR_BASE_MASK                = (int)0x30000000,
-	/** GPS base mask */
-	INS_STATUS_RTK_ERROR_MASK					= (INS_STATUS_RTK_RAW_GPS_DATA_ERROR|INS_STATUS_RTK_ERR_BASE_MASK),
-	
-	/** RTOS task ran longer than allotted period */
-	INS_STATUS_RTOS_TASK_PERIOD_OVERRUN			= (int)0x40000000,
-	/** General fault (eGenFaultCodes) */
-	INS_STATUS_GENERAL_FAULT					= (int)0x80000000,
+    /** GPS base mask */
+    INS_STATUS_RTK_ERROR_MASK                   = (INS_STATUS_RTK_RAW_GPS_DATA_ERROR|INS_STATUS_RTK_ERR_BASE_MASK),
+    
+    /** RTOS task ran longer than allotted period */
+    INS_STATUS_RTOS_TASK_PERIOD_OVERRUN         = (int)0x40000000,
+    /** General fault (see sys_params_t.genFaultCode) */
+    INS_STATUS_GENERAL_FAULT                    = (int)0x80000000,
 };
 
 /** GPS navigation fix type */
@@ -276,103 +276,103 @@ enum eInsStatusFlags
  *       in IS-src/python/src/ci_hdw/data_sets.py */
 enum eGpsNavFixStatus
 {
-	GPS_NAV_FIX_NONE							= (int)0x00000000,
-	GPS_NAV_FIX_POSITIONING_3D					= (int)0x00000001,
-	GPS_NAV_FIX_POSITIONING_RTK_FLOAT			= (int)0x00000002,
-	GPS_NAV_FIX_POSITIONING_RTK_FIX				= (int)0x00000003,		// Includes fix & hold
+    GPS_NAV_FIX_NONE                            = (int)0x00000000,
+    GPS_NAV_FIX_POSITIONING_3D                  = (int)0x00000001,
+    GPS_NAV_FIX_POSITIONING_RTK_FLOAT           = (int)0x00000002,
+    GPS_NAV_FIX_POSITIONING_RTK_FIX             = (int)0x00000003,        // Includes fix & hold
 };
 
 /** Hardware status flags */
 enum eHdwStatusFlags
 {
-	/** Gyro motion detected sigma */
-	HDW_STATUS_MOTION_GYR_SIG					= (int)0x00000001,
-	/** Accelerometer motion detected sigma */
-	HDW_STATUS_MOTION_ACC_SIG					= (int)0x00000002,
-	/** Unit is moving and NOT stationary */
-	HDW_STATUS_MOTION_SIG_MASK					= (int)0x00000003,
-	/** Gyro motion detected deviation */
-	HDW_STATUS_MOTION_GYR_DEV					= (int)0x00000004,
-	/** Accelerometer motion detected deviation */
-	HDW_STATUS_MOTION_ACC_DEV					= (int)0x00000008,
-	/** Motion mask */
-	HDW_STATUS_MOTION_MASK						= (int)0x0000000F,
+    /** Gyro motion detected sigma */
+    HDW_STATUS_MOTION_GYR_SIG                   = (int)0x00000001,
+    /** Accelerometer motion detected sigma */
+    HDW_STATUS_MOTION_ACC_SIG                   = (int)0x00000002,
+    /** Unit is moving and NOT stationary */
+    HDW_STATUS_MOTION_SIG_MASK                  = (int)0x00000003,
+    /** Gyro motion detected deviation */
+    HDW_STATUS_MOTION_GYR_DEV                   = (int)0x00000004,
+    /** Accelerometer motion detected deviation */
+    HDW_STATUS_MOTION_ACC_DEV                   = (int)0x00000008,
+    /** Motion mask */
+    HDW_STATUS_MOTION_MASK                      = (int)0x0000000F,
 
-	/** GPS satellite signals are being received (antenna and cable are good) */
-	HDW_STATUS_GPS_SATELLITE_RX					= (int)0x00000010,
-	/** Event occurred on strobe input pin */
-	HDW_STATUS_STROBE_IN_EVENT					= (int)0x00000020,
-	/** GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time. */
-	HDW_STATUS_GPS_TIME_OF_WEEK_VALID			= (int)0x00000040,
-	/** Reference IMU data being received */
-	HDW_STATUS_REFERENCE_IMU_RX	                = (int)0x00000080,
+    /** GPS satellite signals are being received (antenna and cable are good) */
+    HDW_STATUS_GPS_SATELLITE_RX                 = (int)0x00000010,
+    /** Event occurred on strobe input pin */
+    HDW_STATUS_STROBE_IN_EVENT                  = (int)0x00000020,
+    /** GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time. */
+    HDW_STATUS_GPS_TIME_OF_WEEK_VALID           = (int)0x00000040,
+    /** Reference IMU data being received */
+    HDW_STATUS_REFERENCE_IMU_RX                 = (int)0x00000080,
 
-	/** Sensor saturation on gyro */
-	HDW_STATUS_SATURATION_GYR					= (int)0x00000100,
-	/** Sensor saturation on accelerometer */
-	HDW_STATUS_SATURATION_ACC					= (int)0x00000200,
-	/** Sensor saturation on magnetometer */
-	HDW_STATUS_SATURATION_MAG					= (int)0x00000400,
-	/** Sensor saturation on barometric pressure */
-	HDW_STATUS_SATURATION_BARO					= (int)0x00000800,
+    /** Sensor saturation on gyro */
+    HDW_STATUS_SATURATION_GYR                   = (int)0x00000100,
+    /** Sensor saturation on accelerometer */
+    HDW_STATUS_SATURATION_ACC                   = (int)0x00000200,
+    /** Sensor saturation on magnetometer */
+    HDW_STATUS_SATURATION_MAG                   = (int)0x00000400,
+    /** Sensor saturation on barometric pressure */
+    HDW_STATUS_SATURATION_BARO                  = (int)0x00000800,
 
-	/** Sensor saturation mask */
-	HDW_STATUS_SATURATION_MASK					= (int)0x00000F00,
-	/** Sensor saturation offset */
-	HDW_STATUS_SATURATION_OFFSET				= 8,
+    /** Sensor saturation mask */
+    HDW_STATUS_SATURATION_MASK                  = (int)0x00000F00,
+    /** Sensor saturation offset */
+    HDW_STATUS_SATURATION_OFFSET                = 8,
 
-	/** System Reset is Required for proper function */
-	HDW_STATUS_SYSTEM_RESET_REQUIRED			= (int)0x00001000,
-	/** Reference IMU used in EKF */
-	HDW_STATUS_EKF_USING_REFERENCE_IMU		    = (int)0x00002000,
-	/** Magnetometer recalibration has finished (when INS_STATUS_MAG_RECALIBRATING is unset).  */
-	HDW_STATUS_MAG_RECAL_COMPLETE	            = (int)0x00004000,
-	/** System flash write staging or occuring now.  Processor will pause and not respond during a flash write, typicaly 150-250 ms. */
-	HDW_STATUS_FLASH_WRITE_PENDING              = (int)0x00008000,
+    /** System Reset is Required for proper function */
+    HDW_STATUS_SYSTEM_RESET_REQUIRED            = (int)0x00001000,
+    /** Reference IMU used in EKF */
+    HDW_STATUS_EKF_USING_REFERENCE_IMU          = (int)0x00002000,
+    /** Magnetometer recalibration has finished (when INS_STATUS_MAG_RECALIBRATING is unset).  */
+    HDW_STATUS_MAG_RECAL_COMPLETE               = (int)0x00004000,
+    /** System flash write staging or occuring now.  Processor will pause and not respond during a flash write, typicaly 150-250 ms. */
+    HDW_STATUS_FLASH_WRITE_PENDING              = (int)0x00008000,
 
-	/** Communications Tx buffer limited */
-	HDW_STATUS_ERR_COM_TX_LIMITED				= (int)0x00010000,
-	/** Communications Rx buffer overrun */
-	HDW_STATUS_ERR_COM_RX_OVERRUN				= (int)0x00020000,
+    /** Communications Tx buffer limited */
+    HDW_STATUS_ERR_COM_TX_LIMITED               = (int)0x00010000,
+    /** Communications Rx buffer overrun */
+    HDW_STATUS_ERR_COM_RX_OVERRUN               = (int)0x00020000,
 
-	/** GPS PPS timepulse signal has not been received or is in error */
-	HDW_STATUS_ERR_NO_GPS_PPS					= (int)0x00040000,
-	/** Time synchronized by GPS PPS */
-	HDW_STATUS_GPS_PPS_TIMESYNC					= (int)0x00080000,
+    /** GPS PPS timepulse signal has not been received or is in error */
+    HDW_STATUS_ERR_NO_GPS_PPS                   = (int)0x00040000,
+    /** Time synchronized by GPS PPS */
+    HDW_STATUS_GPS_PPS_TIMESYNC                 = (int)0x00080000,
 
-	/** Communications parse error count */
-	HDW_STATUS_COM_PARSE_ERR_COUNT_MASK			= (int)0x00F00000,
-	HDW_STATUS_COM_PARSE_ERR_COUNT_OFFSET		= 20,
+    /** Communications parse error count */
+    HDW_STATUS_COM_PARSE_ERR_COUNT_MASK         = (int)0x00F00000,
+    HDW_STATUS_COM_PARSE_ERR_COUNT_OFFSET       = 20,
 #define HDW_STATUS_COM_PARSE_ERROR_COUNT(hdwStatus) ((hdwStatus&HDW_STATUS_COM_PARSE_ERR_COUNT_MASK)>>HDW_STATUS_COM_PARSE_ERR_COUNT_OFFSET)
 
-	/** (BIT) Built-in self-test running */
-	HDW_STATUS_BIT_RUNNING						= (int)0x01000000,
-	/** (BIT) Built-in self-test passed */
-	HDW_STATUS_BIT_PASSED						= (int)0x02000000,
-	/** (BIT) Built-in self-test failure */
-	HDW_STATUS_BIT_FAULT						= (int)0x03000000,
-	/** (BIT) Built-in self-test mask */
-	HDW_STATUS_BIT_MASK							= (int)0x03000000,
+    /** (BIT) Built-in self-test running */
+    HDW_STATUS_BIT_RUNNING                      = (int)0x01000000,
+    /** (BIT) Built-in self-test passed */
+    HDW_STATUS_BIT_PASSED                       = (int)0x02000000,
+    /** (BIT) Built-in self-test failure */
+    HDW_STATUS_BIT_FAULT                        = (int)0x03000000,
+    /** (BIT) Built-in self-test mask */
+    HDW_STATUS_BIT_MASK                         = (int)0x03000000,
 
-	/** Temperature outside spec'd operating range */
-	HDW_STATUS_ERR_TEMPERATURE					= (int)0x04000000,
-	
-	/** IMX pins G5-G8 are configure for SPI use */
-	HDW_STATUS_SPI_INTERFACE_ENABLED			= (int)0x08000000,
+    /** Temperature outside spec'd operating range */
+    HDW_STATUS_ERR_TEMPERATURE                  = (int)0x04000000,
+    
+    /** IMX pins G5-G8 are configure for SPI use */
+    HDW_STATUS_SPI_INTERFACE_ENABLED            = (int)0x08000000,
 
-	/** Fault reset cause */
-	HDW_STATUS_FAULT_RESET_MASK					= (int)0x70000000,	
-	/** Reset from Backup mode (low-power state w/ CPU off) */
-	HDW_STATUS_FAULT_RESET_BACKUP_MODE			= (int)0x10000000,
-	/** Reset from Watchdog */
-	HDW_STATUS_FAULT_RESET_WATCHDOG				= (int)0x20000000,
-	/** Reset from Software */
-	HDW_STATUS_FAULT_RESET_SOFT					= (int)0x30000000,
-	/** Reset from Hardware (NRST pin low) */
-	HDW_STATUS_FAULT_RESET_HDW					= (int)0x40000000,
+    /** Fault reset cause */
+    HDW_STATUS_FAULT_RESET_MASK                 = (int)0x70000000,    
+    /** Reset from Backup mode (low-power state w/ CPU off) */
+    HDW_STATUS_FAULT_RESET_BACKUP_MODE          = (int)0x10000000,
+    /** Reset from Watchdog */
+    HDW_STATUS_FAULT_RESET_WATCHDOG             = (int)0x20000000,
+    /** Reset from Software */
+    HDW_STATUS_FAULT_RESET_SOFT                 = (int)0x30000000,
+    /** Reset from Hardware (NRST pin low) */
+    HDW_STATUS_FAULT_RESET_HDW                  = (int)0x40000000,
 
-	/** Critical System Fault - CPU error */
-	HDW_STATUS_FAULT_SYS_CRITICAL				= (int)0x80000000,
+    /** Critical System Fault - CPU error */
+    HDW_STATUS_FAULT_SYS_CRITICAL               = (int)0x80000000,
 };
 
 /** System status flags */


### PR DESCRIPTION
ioConfig and platform no longer need to be set by unless they are used to overwrite the default in flash config.  With the platform type in OTP memory, the factory default settings will ensure ioConfig is correct for the GPS configuration.  