### PR TITLE
Sn 3991 FTDI update time out 

### DIFF
--- a/src/ISBootloaderThread.cpp
+++ b/src/ISBootloaderThread.cpp
@@ -664,6 +664,11 @@ is_operation_result cISBootloaderThread::update(
     void						(*waitAction)()
 )
 {
+    string tmp;
+    uint32_t timeDeltaMs; 
+    uint32_t beginTimeMs;
+    uint32_t timeout;
+
     // Only allow one firmware update sequence to happen at a time
     m_update_mutex.lock();
     m_update_in_progress = true;
@@ -818,11 +823,12 @@ is_operation_result cISBootloaderThread::update(
 
     m_continue_update = true;
     m_timeStart = current_timeMs();
-    uint32_t timeoutLong = current_timeMs();
 
     ////////////////////////////////////////////////////////////////////////////
     // Run `update_thread_serial` to update devices
     ////////////////////////////////////////////////////////////////////////////
+
+    beginTimeMs = current_timeMs();
 
     while (m_continue_update && !true_if_cancelled())
     {
@@ -910,14 +916,29 @@ is_operation_result cISBootloaderThread::update(
         m_libusb_thread_mutex.unlock();
         m_serial_thread_mutex.unlock();
 
-        // Timeout after 60 seconds
-        uint32_t timeout = (baudRate < 921600) ? 360000 : 120000;
-        if (current_timeMs() - timeoutLong > timeout)
+        // Timeout after 180 seconds
+        timeout = (baudRate < 921600) ? 360000 : 180000;
+        timeDeltaMs = current_timeMs() - beginTimeMs;
+
+        if (timeDeltaMs > timeout)
         {
             m_continue_update = false;
-            m_infoProgress(NULL, "Update timeout", IS_LOG_LEVEL_ERROR);
+
+            tmp = "Update timeout... Timeout of ";
+            tmp.append(to_string(((double)timeout) / 1000));
+            tmp.append(" Seconds reached.");
+
+            m_infoProgress(NULL, tmp.c_str(), IS_LOG_LEVEL_ERROR);
         }
     }
+
+    timeDeltaMs = current_timeMs() - beginTimeMs;
+
+    tmp = "Update run time: ";
+    tmp.append(to_string(((double)timeDeltaMs) / 1000));
+    tmp.append(" Seconds.");
+
+    m_infoProgress(NULL, tmp.c_str(), IS_LOG_LEVEL_INFO);
 
     threadJoinAndFree(libusb_thread);
 


### PR DESCRIPTION
Fortem was reporting issues upgrading from 1.8. The issue was looked into and eventually, the difference was found that were using a UART to USB FTDI part versus our normal workflow of using the built-in USB CDC. This caused the full update(Bootloader and Application) to run beyond the 120-second maximum update time, approximately 147 seconds running at default baud(921600). This maximum time was increased to 180 seconds for the default baud. Any other supported baud has a maximum time of 360 seconds. This was tested with the FTDI at the minimum supported baud (115200). Run time of the minimum baud was apporximatly 220 seconds.