### PR TITLE
check index out of bounce issue

### DIFF
--- a/src/com_manager.c
+++ b/src/com_manager.c
@@ -1026,9 +1026,16 @@ int comManagerGetDataRequestInstance(CMHANDLE _cmInstance, int pHandle, p_data_g
 
 	// Prep data if callback exists
 	int sendData = 1;
-	if (cmInstance->regData[req->id].preTxFnc)
+	if (req->id < DID_COUNT_UINS)
 	{
-		sendData = cmInstance->regData[req->id].preTxFnc(cmInstance, pHandle, &msg->dataHdr);
+		if (cmInstance->regData[req->id].preTxFnc)
+		{
+			sendData = cmInstance->regData[req->id].preTxFnc(cmInstance, pHandle, &msg->dataHdr);
+		}
+	}
+	else
+	{
+		// This is a GPS command. Does IMX need to do anything
 	}
 
 	if (req->id == DID_REFERENCE_IMU)

--- a/src/com_manager.c
+++ b/src/com_manager.c
@@ -1033,10 +1033,6 @@ int comManagerGetDataRequestInstance(CMHANDLE _cmInstance, int pHandle, p_data_g
 			sendData = cmInstance->regData[req->id].preTxFnc(cmInstance, pHandle, &msg->dataHdr);
 		}
 	}
-	else
-	{
-		// This is a GPS command. Does IMX need to do anything
-	}
 
 	if (req->id == DID_REFERENCE_IMU)
 	{


### PR DESCRIPTION
A hard fault was caused by an index out-of-bounce exception when GPX flash config was requested. This is because the did is 121 which tries to access an array of 100 elements. The check that was already in place only checked that the value was non-zero.