### PR TITLE
Forced latency to reduce lost FirmwareUpdate packets.

### DIFF
--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -148,7 +148,7 @@ fwUpdate::msg_types_e ISFirmwareUpdater::step() {
 }
 
 bool ISFirmwareUpdater::writeToWire(fwUpdate::target_t target, uint8_t *buffer, int buff_len) {
-    nextChunkSend = current_timeMs() + 5; // give *at_least* enough time for the send buffer to actually transmit before we send the next message
+    nextChunkSend = current_timeMs() + 15; // give *at_least* enough time for the send buffer to actually transmit before we send the next message
     int result = comManagerSendData(pHandle, DID_FIRMWARE_UPDATE, buffer, buff_len, 0);
     return (result == 0);
 }


### PR DESCRIPTION
Add 10ms (15ms total) to each fnWrite in ISFirmwareUpdater.cpp to reduce overruns (but still keep moving).