### PR TITLE
Sn 4293 iscomm parser refactor

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -908,7 +908,6 @@ protocol_type_t is_comm_parse_byte(is_comm_instance_t* c, uint8_t byte)
 protocol_type_t is_comm_parse(is_comm_instance_t* c)
 {
 	is_comm_buffer_t *buf = &(c->rxBuf);
-	is_comm_parser_t *p = &(c->parser);
 
 	// Search for packet
 	while (buf->scan < buf->tail)

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -185,9 +185,7 @@ void is_comm_init(is_comm_instance_t* c, uint8_t *buffer, int bufferSize)
 
 static protocol_type_t parseErrorResetState(is_comm_instance_t* c)
 {
-	c->parser.state = 0;
-	c->rxBuf.scan = c->rxBuf.head;
-	c->processPkt = NULL;
+	is_comm_reset_parser(c);
 	if (!c->rxErrorState)
 	{
 		c->rxErrorState = 1;

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -183,6 +183,14 @@ void is_comm_init(is_comm_instance_t* c, uint8_t *buffer, int bufferSize)
 	c->rxPkt.data.ptr = c->rxBuf.start;
 }
 
+void setParserStart(is_comm_instance_t* c, pFnProcessPkt processPkt)
+{
+	is_comm_parser_t *p = &(c->parser);
+	p->state = 1;
+	c->rxBuf.head = c->rxBuf.scan;
+	c->processPkt = processPkt;
+}
+
 static protocol_type_t parseErrorResetState(is_comm_instance_t* c)
 {
 	is_comm_reset_parser(c);
@@ -883,14 +891,6 @@ int is_comm_free(is_comm_instance_t* c)
 	}
 
 	return bytesFree;
-}
-
-void setParserStart(is_comm_instance_t* c, pFnProcessPkt processPkt)
-{
-	is_comm_parser_t *p = &(c->parser);
-	p->state = 1;
-	c->rxBuf.head = c->rxBuf.scan;
-	c->processPkt = processPkt;
 }
 
 protocol_type_t is_comm_parse_byte(is_comm_instance_t* c, uint8_t byte)

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -12,7 +12,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "ISComm.h"
 
-#define DISABLE_RTCM_DURING_SONY_PARSE		1		// Disable RTCM3 parsing while Sony parsing is happening to prevent parsing of embedded RTCM.
 #define MAX_MSG_LENGTH_ISB					PKT_BUF_SIZE
 #define MAX_MSG_LENGTH_NMEA					200
 #define MAX_MSG_LENGTH_RTCM					1024
@@ -184,52 +183,33 @@ void is_comm_init(is_comm_instance_t* c, uint8_t *buffer, int bufferSize)
 	c->rxPkt.data.ptr = c->rxBuf.start;
 }
 
-static inline void resetAllParsers(is_comm_instance_t *c)
+static protocol_type_t parseErrorResetState(is_comm_instance_t* c)
 {
-	c->isb.state = 0;
-	c->nmea.state = 0;
-	c->rtcm.state = 0;
-	c->sony.state = 0;
-	c->sprt.state = 0;
-	c->ubx.state = 0;
+	c->parser.state = 0;
+	c->rxBuf.scan = c->rxBuf.head;
+	c->processPkt = NULL;
+	c->rxErrorCount++;
+	return _PTYPE_PARSE_ERROR;
 }
 
-static inline void resetParserState(is_comm_instance_t *c, protocol_type_t ptype)
+static inline void validPacketFound(is_comm_instance_t* c, int pktSize, int dataSize)
 {
-	if (ptype != _PTYPE_PARSE_ERROR)
-	{
-		resetAllParsers(c);
-	}
-}
-
-static protocol_type_t parseErrorResetState(is_comm_instance_t* c, is_comm_parser_t* p)
-{
-	p->state = 0;
-
-	if (!(p->concurrentParse))
-	{	// Parse errors are only detectable when no concurrent parse was happening
-		c->rxErrorCount++;
-		return _PTYPE_PARSE_ERROR;
-	}
-	return _PTYPE_NONE;
-}
-
-static inline void validPacketFound(is_comm_instance_t* c, is_comm_parser_t* p, int pktSize, int dataSize)
-{
-	c->rxBuf.head = p->head + pktSize;
-	c->rxPktCount++;
-
 	// Update data pointer and info
 	c->rxPkt.size      = pktSize;
-	c->rxPkt.data.ptr  = p->head;
+	c->rxPkt.data.ptr  = c->rxBuf.head;
 	c->rxPkt.data.size = dataSize;
 	c->rxPkt.hdr.id    = 0;
 	c->rxPkt.offset    = 0;
+
+	c->rxBuf.head = c->rxBuf.head + pktSize;
+	c->rxPktCount++;
+	c->processPkt = NULL;
 }
 
-static protocol_type_t processIsbPkt(is_comm_instance_t* c)
+static protocol_type_t processIsbPkt(void* v)
 {
-	is_comm_parser_t* p = &(c->isb);
+	is_comm_instance_t* c = (is_comm_instance_t*)v;
+	is_comm_parser_t* p = &(c->parser);
 	int numBytes;
 	
 	switch (p->state)
@@ -244,26 +224,14 @@ static protocol_type_t processIsbPkt(is_comm_instance_t* c)
 	case 1:
 		if (*(c->rxBuf.scan) == PSC_ISB_PREAMBLE_BYTE2)
 		{	// Found complete preamble
-			p->head = c->rxBuf.scan-1;
 			p->state++;
-
-			// Other parser(s) running?  Used for parse error reporting
-			p->concurrentParse = 
-			 	c->nmea.state || 
-				c->rtcm.state ||
-				c->sony.state ||
-				c->sprt.state ||
-				c->ubx.state;
-		}
-		else
-		{	// Invalid preamble - Reset state
-			p->state = 0;
 			return _PTYPE_NONE;
 		}
-		return _PTYPE_NONE;
+		// Invalid preamble - Reset state
+		return parseErrorResetState(c);
 
 	case 2:		// Wait for packet header
-		numBytes = (int)(c->rxBuf.scan - p->head);
+		numBytes = (int)(c->rxBuf.scan - c->rxBuf.head);
 		if (numBytes < (int)(sizeof(packet_hdr_t)-1))
 		{	
 			return _PTYPE_NONE;
@@ -271,16 +239,16 @@ static protocol_type_t processIsbPkt(is_comm_instance_t* c)
 		p->state++;
 
 		// Parse header 
-		packet_buf_t *isbPkt = (packet_buf_t*)(p->head);
+		packet_buf_t *isbPkt = (packet_buf_t*)(c->rxBuf.head);
 		p->size = sizeof(packet_hdr_t) + isbPkt->hdr.payloadSize + 2;		// Header + payload + footer (checksum)
 		if (p->size > MAX_MSG_LENGTH_ISB)
 		{	// Invalid size
-			return parseErrorResetState(c, p);
+			return parseErrorResetState(c);
 		}
 		return _PTYPE_NONE;
 
 	default:	// Wait for entire packet 
-		numBytes = (int)(c->rxBuf.scan - p->head) + 1;
+		numBytes = (int)(c->rxBuf.scan - c->rxBuf.head) + 1;
 		if (numBytes < (int)(p->size))
 		{
 			return _PTYPE_NONE;
@@ -293,21 +261,22 @@ static protocol_type_t processIsbPkt(is_comm_instance_t* c)
 	p->state = 0;
 
 	// Validate checksum
-	packet_buf_t *isbPkt = (packet_buf_t*)(p->head);
+	packet_buf_t *isbPkt = (packet_buf_t*)(c->rxBuf.head);
 	uint16_t payloadSize = isbPkt->hdr.payloadSize;
-	uint8_t *payload = p->head + sizeof(packet_hdr_t);
+	uint8_t *payload = c->rxBuf.head + sizeof(packet_hdr_t);
 	checksum16_u *cksum = (checksum16_u*)(payload + payloadSize);
 	int bytes_cksum = p->size - 2;
-	uint16_t calcCksum = is_comm_isb_checksum16(0, p->head, bytes_cksum);
+	uint16_t calcCksum = is_comm_isb_checksum16(0, c->rxBuf.head, bytes_cksum);
 	if (cksum->ck != calcCksum)
 	{	// Invalid checksum
-		return parseErrorResetState(c, p);
+		return parseErrorResetState(c);
 	}
 
 	/////////////////////////////////////////////////////////
 	// Valid packet found - Checksum passed - Populate rxPkt
-	c->rxBuf.head = p->head + numBytes;
+	c->rxBuf.head = c->rxBuf.head + numBytes;
 	c->rxPktCount++;
+	c->processPkt = NULL;
 
 	packet_t *pkt = &(c->rxPkt);
 
@@ -380,12 +349,13 @@ static protocol_type_t processIsbPkt(is_comm_instance_t* c)
 	}                    
 
 	// Invalid data type
-	return parseErrorResetState(c, p);
+	return parseErrorResetState(c);
 }
 
-static protocol_type_t processNmeaPkt(is_comm_instance_t* c)
+static protocol_type_t processNmeaPkt(void* v)
 {
-	is_comm_parser_t* p = &(c->nmea);
+	is_comm_instance_t* c = (is_comm_instance_t*)v;
+	is_comm_parser_t* p = &(c->parser);
 	int numBytes;
 
 	switch (p->state)
@@ -393,16 +363,7 @@ static protocol_type_t processNmeaPkt(is_comm_instance_t* c)
 	case 0:	// Find start
 		if (*(c->rxBuf.scan) == PSC_NMEA_START_BYTE)
 		{	// Found
-			p->head = c->rxBuf.scan;
 			p->state++;
-
-			// Other parser(s) running?  Used for parse error reporting
-			p->concurrentParse = 
-			 	c->isb.state  || 
-				c->rtcm.state ||
-				c->sony.state ||
-				c->sprt.state ||
-				c->ubx.state;
 		}
 		return _PTYPE_NONE;
 
@@ -413,10 +374,10 @@ static protocol_type_t processNmeaPkt(is_comm_instance_t* c)
 		}
 		else
 		{
-			numBytes = (int)(c->rxBuf.scan - p->head);
+			numBytes = (int)(c->rxBuf.scan - c->rxBuf.head);
 			if (numBytes > MAX_MSG_LENGTH_NMEA)
 			{	// Exceeds max length
-				return parseErrorResetState(c, p);
+				return parseErrorResetState(c);
 			}
 		}
 		return _PTYPE_NONE;
@@ -424,7 +385,7 @@ static protocol_type_t processNmeaPkt(is_comm_instance_t* c)
 	case 3:		// Wait for end of packet
 		if (*(c->rxBuf.scan) != PSC_NMEA_END_BYTE)
 		{	// Invalid end
-			return parseErrorResetState(c, p);
+			return parseErrorResetState(c);
 		}
 		// Found packet end
 		break;
@@ -434,10 +395,10 @@ static protocol_type_t processNmeaPkt(is_comm_instance_t* c)
 	p->state = 0;
 
 	// Validate length
-	numBytes = (int)(c->rxBuf.scan - p->head) + 1;
+	numBytes = (int)(c->rxBuf.scan - c->rxBuf.head) + 1;
 	if (numBytes < 8)
 	{	// Packet length too short
-		return parseErrorResetState(c, p);
+		return parseErrorResetState(c);
 	}
 
 	// Validate checksum
@@ -446,18 +407,18 @@ static protocol_type_t processNmeaPkt(is_comm_instance_t* c)
 	int msgChecksum = (int)strtol((const char*)c->rxBuf.scan-3, NULL, 16);
 	*(c->rxBuf.scan-1) = tmp;			// Restore value
 	int calChecksum = 0;
-	for (uint8_t* ptr = p->head + 1, *ptrEnd = c->rxBuf.scan - 4; ptr < ptrEnd; ptr++)
+	for (uint8_t* ptr = c->rxBuf.head + 1, *ptrEnd = c->rxBuf.scan - 4; ptr < ptrEnd; ptr++)
 	{
 		calChecksum ^= (int)*ptr;
 	}
 	if (msgChecksum != calChecksum)
 	{	// Invalid checksum
-		return parseErrorResetState(c, p);
+		return parseErrorResetState(c);
 	}
 
 	/////////////////////////////////////////////////////////
 	// Valid packet found - Checksum passed - Populate rxPkt
-	validPacketFound(c, p, numBytes, numBytes);
+	validPacketFound(c, numBytes, numBytes);
 
 	return _PTYPE_NMEA;
 }
@@ -471,9 +432,10 @@ enum
 	UBX_PARSE_STATE_LENGTH_2    = 5,
 };
 
-static protocol_type_t processUbloxPkt(is_comm_instance_t* c)
+static protocol_type_t processUbloxPkt(void* v)
 {
-	is_comm_parser_t* p = &(c->ubx);
+	is_comm_instance_t* c = (is_comm_instance_t*)v;
+	is_comm_parser_t* p = &(c->parser);
 	int numBytes;
 
 	switch (p->state)
@@ -488,38 +450,28 @@ static protocol_type_t processUbloxPkt(is_comm_instance_t* c)
 	case 1:
 		if (*(c->rxBuf.scan) == UBLOX_START_BYTE2)
 		{	// Found complete preamble 
-			p->head = c->rxBuf.scan-1;
 			p->state++;
-
-			// Other parser(s) running?  Used for parse error reporting
-			p->concurrentParse =
-				c->isb.state  || 
-			 	c->nmea.state || 
-				c->rtcm.state ||
-				c->sony.state ||
-				c->sprt.state;
 		}
 		else
         {	// Invalid preamble - Reset state
-            p->state = 0;
-            return _PTYPE_NONE;
+			return parseErrorResetState(c);
 		}
 		return _PTYPE_NONE;
 
 	case 2:		// Wait for packet header
-		if ((int)(c->rxBuf.scan - p->head) < (int)(sizeof(ubx_pkt_hdr_t)-1))
+		if ((int)(c->rxBuf.scan - c->rxBuf.head) < (int)(sizeof(ubx_pkt_hdr_t)-1))
 		{	
 			return _PTYPE_NONE;
 		}
 
 		// Parse header 
-		ubx_pkt_hdr_t *hdr = (ubx_pkt_hdr_t*)(p->head);
+		ubx_pkt_hdr_t *hdr = (ubx_pkt_hdr_t*)(c->rxBuf.head);
 		p->size = sizeof(ubx_pkt_hdr_t) + hdr->payloadSize + 2;		// Header + payload + footer (checksum)
 		p->state++;
 		return _PTYPE_NONE;
 
 	default:	// Wait for end of packet
-		numBytes = (int)(c->rxBuf.scan - p->head) + 1;
+		numBytes = (int)(c->rxBuf.scan - c->rxBuf.head) + 1;
 		if (numBytes < p->size)
 		{
 			return _PTYPE_NONE;
@@ -533,47 +485,35 @@ static protocol_type_t processUbloxPkt(is_comm_instance_t* c)
 
 	// Validate checksum
 	uint16_t pktChecksum = *((uint16_t*)(c->rxBuf.scan - 1));
-	uint8_t* cksum_start = p->head + 2;
+	uint8_t* cksum_start = c->rxBuf.head + 2;
 	uint8_t* cksum_end   = c->rxBuf.scan - 1;
 	uint32_t cksum_size  = (uint32_t)(cksum_end - cksum_start);
 	checksum16_u cksum;
 	cksum.ck = is_comm_fletcher16(0, cksum_start, cksum_size);
 	if (pktChecksum != cksum.ck)
 	{	// Invalid checksum
-		return parseErrorResetState(c, p);
+		return parseErrorResetState(c);
 	}
 
 	/////////////////////////////////////////////////////////
 	// Valid packet found - Checksum passed - Populate rxPkt
-	validPacketFound(c, p, numBytes, p->size);
+	validPacketFound(c, numBytes, p->size);
 
 	return _PTYPE_UBLOX;
 }
 
-static protocol_type_t processRtcm3Pkt(is_comm_instance_t* c)
+static protocol_type_t processRtcm3Pkt(void* v)
 {
-	is_comm_parser_t* p = &(c->rtcm);
+	is_comm_instance_t* c = (is_comm_instance_t*)v;
+	is_comm_parser_t* p = &(c->parser);
 	int numBytes;
 
 	switch (p->state)
 	{
 	case 0:		// Find start
-		if (*(c->rxBuf.scan) == RTCM3_START_BYTE
-#if DISABLE_RTCM_DURING_SONY_PARSE
-			&& c->sony.state == 0
-#endif
-		)
+		if (*(c->rxBuf.scan) == RTCM3_START_BYTE)
 		{	// Found start
-			p->head = c->rxBuf.scan;
 			p->state++;
-
-			// Other parser(s) running?  Used for parse error reporting
-			p->concurrentParse = 
-				c->isb.state  ||
-			 	c->nmea.state || 
-				c->sony.state ||
-				c->sprt.state ||
-				c->ubx.state;
 		}
 		return _PTYPE_NONE;
 
@@ -582,18 +522,18 @@ static protocol_type_t processRtcm3Pkt(is_comm_instance_t* c)
 		return _PTYPE_NONE;
 
 	case 2:
-		p->size = (int)getBitsAsUInt32(p->head, 14, 10) + 6;		// Header + payload + footer (checksum)
+		p->size = (int)getBitsAsUInt32(c->rxBuf.head, 14, 10) + 6;		// Header + payload + footer (checksum)
 		p->state++;
 
 		// Validate packet length
 		if (p->size > MAX_MSG_LENGTH_RTCM || p->size > c->rxBuf.size - 6)
 		{	// Corrupt data
-			return parseErrorResetState(c, p);
+			return parseErrorResetState(c);
 		}
 		return _PTYPE_NONE;
 
 	default:	// Wait for end of packet
-		numBytes = (int)(c->rxBuf.scan - p->head) + 1;
+		numBytes = (int)(c->rxBuf.scan - c->rxBuf.head) + 1;
 		if (numBytes < p->size)
 		{
 			return _PTYPE_NONE;
@@ -608,17 +548,17 @@ static protocol_type_t processRtcm3Pkt(is_comm_instance_t* c)
 
 	// Validate checksum - len without 3 crc bytes
 	int lenWithoutCrc = (int)(p->size - 3);
-	uint32_t actualCRC = calculate24BitCRCQ(p->head, lenWithoutCrc);
-	uint32_t correctCRC = getBitsAsUInt32(p->head + lenWithoutCrc, 0, 24);
+	uint32_t actualCRC = calculate24BitCRCQ(c->rxBuf.head, lenWithoutCrc);
+	uint32_t correctCRC = getBitsAsUInt32(c->rxBuf.head + lenWithoutCrc, 0, 24);
 
 	if (actualCRC != correctCRC)
 	{	// Invalid checksum
-		return parseErrorResetState(c, p);
+		return parseErrorResetState(c);
 	}
 
 	/////////////////////////////////////////////////////////
 	// Valid packet found - Checksum passed - Populate rxPkt
-	validPacketFound(c, p, numBytes, p->size);
+	validPacketFound(c, numBytes, p->size);
 
 	return _PTYPE_RTCM3;
 }
@@ -675,9 +615,10 @@ static uint8_t computeCrc4Ccitt(const uint8_t *buf, const uint32_t numBytes)
     return remainder & 0x0FU;
 }
 
-static protocol_type_t processSonyByte(is_comm_instance_t* c)
+static protocol_type_t processSonyByte(void* v)
 {
-	is_comm_parser_t* p = &(c->sony);
+	is_comm_instance_t* c = (is_comm_instance_t*)v;
+	is_comm_parser_t* p = &(c->parser);
 	int numBytes;
 	uint8_t checksum;
 
@@ -686,36 +627,26 @@ static protocol_type_t processSonyByte(is_comm_instance_t* c)
 	case 0:		// Find start
 		if (*(c->rxBuf.scan) == SONY_START_BYTE)
 		{	// Found start
-			p->head = c->rxBuf.scan;
 			p->state++;
-
-			// Other parser(s) running?  Used for parse error reporting
-			p->concurrentParse = 
-				c->isb.state  ||
-			 	c->nmea.state || 
-			 	c->rtcm.state || 
-				c->sprt.state ||
-				c->ubx.state;
 		}
 		return _PTYPE_NONE;
 
 	case 1:		// Wait for header
-		if ((int)(c->rxBuf.scan - p->head) < (int)(sizeof(sony_pkt_hdr_t)-1))
+		if ((int)(c->rxBuf.scan - c->rxBuf.head) < (int)(sizeof(sony_pkt_hdr_t)-1))
 		{	
 			return _PTYPE_NONE;
 		}
 
 		// Validate header checksum
-		sony_pkt_hdr_t *hdr = (sony_pkt_hdr_t *)(p->head);
+		sony_pkt_hdr_t *hdr = (sony_pkt_hdr_t *)(c->rxBuf.head);
     	checksum = 0;
 		for (size_t i = 0; i < 4; i++)
 		{
-			checksum += p->head[i];
+			checksum += c->rxBuf.head[i];
 		}
 		if (checksum != hdr->fcsh || hdr->dataSize > MAX_MSG_LENGTH_SONY || hdr->dataSize > c->rxBuf.size)
 		{	// Invalid header - Reset state
-			p->state = 0;
-			return _PTYPE_NONE;
+			return parseErrorResetState(c);
 		}
 
 		// Valid header
@@ -724,7 +655,7 @@ static protocol_type_t processSonyByte(is_comm_instance_t* c)
 		return _PTYPE_NONE;
 
 	default:	// Wait for end of packet
-		numBytes = (int)(c->rxBuf.scan - p->head) + 1;
+		numBytes = (int)(c->rxBuf.scan - c->rxBuf.head) + 1;
 		if (numBytes < (int)(p->size))
 		{
 			return _PTYPE_NONE;
@@ -737,28 +668,29 @@ static protocol_type_t processSonyByte(is_comm_instance_t* c)
 	p->state = 0;
 
 	// Validate data checksum
-	sony_pkt_hdr_t *hdr = (sony_pkt_hdr_t *)(p->head);
+	sony_pkt_hdr_t *hdr = (sony_pkt_hdr_t *)(c->rxBuf.head);
 	checksum = 0;
-	uint8_t *ptr = p->head + sizeof(sony_pkt_hdr_t);
+	uint8_t *ptr = c->rxBuf.head + sizeof(sony_pkt_hdr_t);
 	for (size_t i = 0; i < hdr->dataSize; i++)
 	{
 		checksum += ptr[i];
 	}
 	if (checksum != c->rxBuf.scan[0])
 	{	// Invalid data checksum
-		return parseErrorResetState(c, p);
+		return parseErrorResetState(c);
 	}
 
 	/////////////////////////////////////////////////////////
 	// Valid packet found - Checksum passed - Populate rxPkt
-	validPacketFound(c, p, numBytes, p->size);
+	validPacketFound(c, numBytes, p->size);
 
 	return _PTYPE_SONY;
 }
 
-static protocol_type_t processSpartnByte(is_comm_instance_t* c)
+static protocol_type_t processSpartnByte(void* v)
 {
-	is_comm_parser_t* p = &(c->sprt);
+	is_comm_instance_t* c = (is_comm_instance_t*)v;
+	is_comm_parser_t* p = &(c->parser);
 
 	switch (p->state)
 	{
@@ -780,12 +712,11 @@ static protocol_type_t processSpartnByte(is_comm_instance_t* c)
 
 	case 3: {
 		// Check length and header CRC4
-		const uint8_t dbuf[3] = { p->head[1], p->head[2], p->head[3] & 0xF0 };
+		const uint8_t dbuf[3] = { c->rxBuf.head[1], c->rxBuf.head[2], c->rxBuf.head[3] & 0xF0 };
         uint8_t calc = computeCrc4Ccitt(dbuf, 3);
-        if((p->head[3] & 0x0F) != calc)
+        if((c->rxBuf.head[3] & 0x0F) != calc)
         {  	// Invalid header - Reset state
-			p->state = 0;
-			return _PTYPE_NONE;
+			return parseErrorResetState(c);
         }
 
         p->state++;
@@ -796,15 +727,15 @@ static protocol_type_t processSpartnByte(is_comm_instance_t* c)
 	case 9:
 	case 10:
 	case 11: {		// we may need to parse up to byte 11 (12th byte) to get the timestamp and encryption length
-		uint16_t payloadLen = ((((uint16_t)(p->head[1]) & 0x01) << 9) |
-						(((uint16_t)(p->head[2])) << 1) |
-						((p->head[3] & 0x80) >> 7)) & 0x3FF;
+		uint16_t payloadLen = ((((uint16_t)(c->rxBuf.head[1]) & 0x01) << 9) |
+						(((uint16_t)(c->rxBuf.head[2])) << 1) |
+						((c->rxBuf.head[3] & 0x80) >> 7)) & 0x3FF;
 
 		// Variable length CRC {0x0, 0x1, 0x2, 0x3} = {1, 2, 3, 4}bytes - appears at end of message
-		payloadLen += (((p->head[3] >> 4) & 0x03) + 1);
+		payloadLen += (((c->rxBuf.head[3] >> 4) & 0x03) + 1);
 
-		uint8_t extendedTs = p->head[4] & 0x08;
-		uint8_t encrypt = p->head[3] & 0x40;
+		uint8_t extendedTs = c->rxBuf.head[4] & 0x08;
+		uint8_t encrypt = c->rxBuf.head[3] & 0x40;
 		uint8_t *encryptPtr = NULL;
 
 		if(extendedTs)
@@ -816,7 +747,7 @@ static protocol_type_t processSpartnByte(is_comm_instance_t* c)
 			}
 			else if(encrypt && p->state == 11)
 			{	// Encryption is ENABLED, and we have all the bytes we need to compute the length of payload
-				encryptPtr = &p->head[10];
+				encryptPtr = &c->rxBuf.head[10];
 				// Don't break yet; continue to calculate encryption
 			}
 			else
@@ -834,7 +765,7 @@ static protocol_type_t processSpartnByte(is_comm_instance_t* c)
 			}
 			else if(encrypt && p->state == 9)
 			{	// Encryption is ENABLED, and we have all the bytes we need to compute the length of payload
-				encryptPtr = &p->head[8];
+				encryptPtr = &c->rxBuf.head[8];
 				// Don't break yet; continue to calculate encryption
 			}
 			else
@@ -873,7 +804,7 @@ static protocol_type_t processSpartnByte(is_comm_instance_t* c)
 		}
 		else
 		{	// Invalid data
-			return parseErrorResetState(c, p);
+			return parseErrorResetState(c);
 		}
 
 		p->state = -((int32_t)payloadLen);
@@ -891,14 +822,14 @@ static protocol_type_t processSpartnByte(is_comm_instance_t* c)
 
 			/////////////////////////////////////////////////////////
 			// Valid packet found - Checksum passed - Populate rxPkt
-			int numBytes = (int)(c->rxBuf.scan - p->head) + 1;
-			validPacketFound(c, p, numBytes, numBytes);
+			int numBytes = (int)(c->rxBuf.scan - c->rxBuf.head) + 1;
+			validPacketFound(c, numBytes, numBytes);
 
 			return _PTYPE_SPARTN;
 		}
 		else if(p->state > 0)
 		{	// corrupt data or bad state
-			return parseErrorResetState(c, p);
+			return parseErrorResetState(c);
 		}
 
 		break;
@@ -921,37 +852,23 @@ int is_comm_free(is_comm_instance_t* c)
 	// if we are out of free space, we need to either move bytes over or start over
 	if (bytesFree == 0)
 	{
-		uint8_t* head = buf->head;
-		int shift = (int)(head - buf->start);
+		int shift = (int)(buf->head - buf->start);
 
 		if (shift < (int)(buf->size / 3))	
 		{	// If the buffer is mostly full and can only be shifted less than 1/3 of the buffer
 			// we will be hung unless we flush the ring buffer, we have to drop bytes in this case and the caller
 			// will need to resend the data
+			parseErrorResetState(c);
 			buf->head = 
 			buf->tail = 
-			buf->scan = 
-			c->isb.head  = 
-			c->ubx.head  = 
-			c->nmea.head = 
-			c->rtcm.head = 
-			c->sprt.head = 
-			c->sony.head = buf->start;
-			resetAllParsers(c);
-			c->rxErrorCount++;
+			buf->scan = buf->start;
 		}
 		else
 		{	// Shift current data to start of buffer
-			memmove(buf->start, head, buf->tail - head);
+			memmove(buf->start, buf->head, buf->tail - buf->head);
 			buf->head = buf->start;
 			buf->tail -= shift;
 			buf->scan -= shift;
-			c->isb.head -= shift;
-			c->ubx.head -= shift;
-			c->nmea.head -= shift;
-			c->rtcm.head -= shift;
-			c->sprt.head -= shift;
-			c->sony.head -= shift;
 		}
 
 		// re-calculate free byte count
@@ -959,6 +876,14 @@ int is_comm_free(is_comm_instance_t* c)
 	}
 
 	return bytesFree;
+}
+
+void setParserStart(is_comm_instance_t* c, pFnProcessPkt processPkt)
+{
+	is_comm_parser_t *p = &(c->parser);
+	p->state = 1;
+	c->rxBuf.head = c->rxBuf.scan;
+	c->processPkt = processPkt;
 }
 
 protocol_type_t is_comm_parse_byte(is_comm_instance_t* c, uint8_t byte)
@@ -976,79 +901,37 @@ protocol_type_t is_comm_parse_byte(is_comm_instance_t* c, uint8_t byte)
 protocol_type_t is_comm_parse(is_comm_instance_t* c)
 {
 	is_comm_buffer_t *buf = &(c->rxBuf);
-	protocol_type_t ptype = _PTYPE_NONE;
+	is_comm_parser_t *p = &(c->parser);
 
 	// Search for packet
 	while (buf->scan < buf->tail)
 	{
-		if (c->config.enabledMask & ENABLE_PROTOCOL_ISB)
-		{
-			ptype = processIsbPkt(c);
-			if (ptype != _PTYPE_NONE) break;
-		}
-
-		if (c->config.enabledMask & ENABLE_PROTOCOL_NMEA)
-		{
-			ptype = processNmeaPkt(c);
-			if (ptype != _PTYPE_NONE) break;
-		}
-
-		if (c->config.enabledMask & ENABLE_PROTOCOL_UBLOX)
-		{
-			ptype = processUbloxPkt(c);
-			if (ptype != _PTYPE_NONE) break;
-		}
-
-		if (c->config.enabledMask & ENABLE_PROTOCOL_RTCM3)
-		{
-			ptype = processRtcm3Pkt(c);
-			if (ptype != _PTYPE_NONE) break;
-		}
-
-		// if (c->config.enabledMask & ENABLE_PROTOCOL_SPARTN)
-		// {
-		// 	ptype = processSpartnByte(c);
-		// 	if (ptype != _PTYPE_NONE) break;
-		// }
-
-		if (c->config.enabledMask & ENABLE_PROTOCOL_SONY)
-		{
-			ptype = processSonyByte(c);
-			if (ptype != _PTYPE_NONE) break;
-		}
-
-		buf->scan++;
-
-#if ENABLE_RX_ERROR_ON_NON_PKT_DATA	
-		// Count stray data not contained inside a packet as parse error
-		if (!(c->isb.state  ||
-			  c->nmea.state ||
-			  c->rtcm.state ||
-			  c->sony.state ||
-			  c->sprt.state ||
-			  c->ubx.state) )
-		{	// Stray data received not contained inside a packet
-			if (!c->strayData)
-			{
-				c->strayData = 1;
-				c->rxErrorCount++;
-				return _PTYPE_PARSE_ERROR;
+		if (c->processPkt == NULL)
+		{	// Scan for packet start
+			switch (*(buf->scan))
+			{			
+			case PSC_ISB_PREAMBLE_BYTE1:    if (c->config.enabledMask & ENABLE_PROTOCOL_ISB)    { setParserStart(c, processIsbPkt); }      break;
+			case PSC_NMEA_START_BYTE:       if (c->config.enabledMask & ENABLE_PROTOCOL_NMEA)   { setParserStart(c, processNmeaPkt); }     break;
+			case UBLOX_START_BYTE1:         if (c->config.enabledMask & ENABLE_PROTOCOL_UBLOX)  { setParserStart(c, processUbloxPkt); }    break;
+			case RTCM3_START_BYTE:          if (c->config.enabledMask & ENABLE_PROTOCOL_RTCM3)  { setParserStart(c, processRtcm3Pkt); }    break;
+			case SPARTN_START_BYTE:         if (c->config.enabledMask & ENABLE_PROTOCOL_SPARTN) { setParserStart(c, processSpartnByte); }  break;
+			case SONY_START_BYTE:           if (c->config.enabledMask & ENABLE_PROTOCOL_SONY)   { setParserStart(c, processSonyByte); }    break;
 			}
 		}
 		else
-		{
-			c->strayData = 0;
+		{	// Parsing packet
+			protocol_type_t ptype = c->processPkt(c);
+			if (ptype != _PTYPE_NONE)
+			{	// Packet found or packet error
+				buf->scan++; 
+				return ptype;
+			}
 		}
-#endif
+
+		buf->scan++;
 	}
 
-	if (ptype != _PTYPE_NONE) 
-	{	// Packet found or packet error
-		buf->scan++; 
-		resetParserState(c, ptype); 
-	}
-
-	return ptype; 
+	return _PTYPE_NONE; 
 }
 
 int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t* comm, uint32_t did, uint32_t offset, uint32_t size, uint32_t periodMultiple)

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -561,7 +561,7 @@ typedef struct
 	/** Communications error counter */
 	uint32_t rxErrorCount;
 
-	/** Process packet function pointer. Null pointer indicates packet parsing is currently not running. */
+	/** Process packet function pointer.  Null pointer indicates no parsing is in progress. */
 	pFnProcessPkt processPkt;
 
 	/** Protocol parser state */
@@ -773,13 +773,13 @@ char copyDataBufPToStructP(void *sptr, const p_data_buf_t *data, const unsigned 
 char copyDataPToStructP2(void *sptr, const p_data_hdr_t *dataHdr, const uint8_t *dataBuf, const unsigned int maxsize);
 
 /** Indicates whether there is overlap in the data received and the backing data structure */
-inline uint8_t dataOverlap( uint32_t dstOffset, uint32_t dstSize, p_data_t* src)
+static inline uint8_t dataOverlap( uint32_t dstOffset, uint32_t dstSize, p_data_t* src)
 {
 	return _MAX(dstOffset, (uint32_t)(src->hdr.offset)) < _MIN(dstOffset + dstSize, (uint32_t)(src->hdr.offset + src->hdr.size));
 }
 
 /** Reset parser state */
-inline void is_comm_reset_parser(is_comm_instance_t* c)
+static inline void is_comm_reset_parser(is_comm_instance_t* c)
 {
 	c->parser.state = 0;
 	c->rxBuf.scan = c->rxBuf.head;

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -537,11 +537,11 @@ typedef struct
 
 typedef struct  
 {
-	uint8_t* head;
-	int16_t state;
-	uint16_t size;
-	uint8_t concurrentParse;	// Other parser was running when this parser started.  Don't report parse error in this case.
+	int16_t     state;
+	uint16_t    size;
 } is_comm_parser_t;
+
+typedef protocol_type_t (*pFnProcessPkt)(void*);
 
 /** An instance of an is_comm interface.  Do not modify these values. */
 typedef struct
@@ -561,13 +561,10 @@ typedef struct
 	/** Communications error counter */
 	uint32_t rxErrorCount;
 
-	/** Protocol parser states */
-	is_comm_parser_t isb;
-	is_comm_parser_t ubx;
-	is_comm_parser_t nmea;
-	is_comm_parser_t rtcm;
-	is_comm_parser_t sony;
-	is_comm_parser_t sprt;
+	pFnProcessPkt processPkt;
+
+	/** Protocol parser state */
+	is_comm_parser_t parser;
 
 	/** Acknowledge packet needed in response to the last packet received */
 	uint32_t ackNeeded;

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -561,6 +561,7 @@ typedef struct
 	/** Communications error counter */
 	uint32_t rxErrorCount;
 
+	/** Process packet function pointer. Null pointer indicates packet parsing is currently not running. */
 	pFnProcessPkt processPkt;
 
 	/** Protocol parser state */
@@ -572,8 +573,8 @@ typedef struct
 	/** Receive packet */
 	packet_t rxPkt;
 
-	/** Data received outside of packet */
-	uint8_t strayData;
+	/** Used to prevent counting more than one error count between valid packets */
+	uint8_t rxErrorState;
 
 } is_comm_instance_t;
 

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -772,10 +772,18 @@ char copyDataBufPToStructP(void *sptr, const p_data_buf_t *data, const unsigned 
 /** Copies packet data into a data structure.  Returns 0 on success, -1 on failure. */
 char copyDataPToStructP2(void *sptr, const p_data_hdr_t *dataHdr, const uint8_t *dataBuf, const unsigned int maxsize);
 
-// Indicates whether there is overlap in the data received and the backing data structure
+/** Indicates whether there is overlap in the data received and the backing data structure */
 inline uint8_t dataOverlap( uint32_t dstOffset, uint32_t dstSize, p_data_t* src)
 {
 	return _MAX(dstOffset, (uint32_t)(src->hdr.offset)) < _MIN(dstOffset + dstSize, (uint32_t)(src->hdr.offset + src->hdr.size));
+}
+
+/** Reset parser state */
+inline void is_comm_reset_parser(is_comm_instance_t* c)
+{
+	c->parser.state = 0;
+	c->rxBuf.scan = c->rxBuf.head;
+	c->processPkt = NULL;
 }
 
 /** Copies is_comm_instance data into a data structure.  Returns 0 on success, -1 on failure. */

--- a/src/com_manager.c
+++ b/src/com_manager.c
@@ -228,20 +228,26 @@ void comManagerRegisterInstance(CMHANDLE cmInstance_, uint16_t did, pfnComManage
 	cmInstance->regData[did].pktFlags = pktFlags;
 }
 
-void comManagerStep(void)
+void comManagerStep()
 {
-	comManagerStepRxInstance(&s_cm);
+	comManagerStepRxInstance(&s_cm, 0);
+	comManagerStepTxInstance(&s_cm);
+}
+
+void comManagerStepTimeout(uint32_t timeMs)
+{
+	comManagerStepRxInstance(&s_cm, timeMs);
 	comManagerStepTxInstance(&s_cm);
 }
 
 void comManagerStepInstance(CMHANDLE cmInstance_)
 {
 	com_manager_t* cmInstance = (com_manager_t*)cmInstance_;
-	comManagerStepRxInstance(cmInstance);
+	comManagerStepRxInstance(cmInstance, 0);
 	comManagerStepTxInstance(cmInstance);
 }
 
-void comManagerStepRxInstance(CMHANDLE cmInstance_)
+void comManagerStepRxInstance(CMHANDLE cmInstance_, uint32_t timeMs)
 {
 	com_manager_t* cmInstance = (com_manager_t*)cmInstance_;
 	int32_t port;
@@ -267,7 +273,7 @@ void comManagerStepRxInstance(CMHANDLE cmInstance_)
 			comm->rxBuf.tail += n;
 
 			// Search comm buffer for valid packets
-			while ((ptype = is_comm_parse(comm)) != _PTYPE_NONE)
+			while ((ptype = is_comm_parse_timeout(comm, timeMs)) != _PTYPE_NONE)
 			{	
 				int error = comManagerStepRxInstanceHandler(cmInstance, cmPort, comm, port, ptype);		
 				if(error == CM_ERROR_FORWARD_OVERRUN) 

--- a/src/com_manager.h
+++ b/src/com_manager.h
@@ -21,20 +21,6 @@ extern "C" {
 #include "ISComm.h"
 #include "linked_list.h"
 
-/**
-Types of pass through data where the com manager will simply forward the data on to a pass through handler
-*/
-// typedef enum
-// {
-// 	/** No pass through */
-// 	COM_MANAGER_PASS_THROUGH_NONE = 0,
-// 
-// 	/** UBLOX pass through */
-// 	COM_MANAGER_PASS_THROUGH_UBLOX = UBLOX_START_BYTE1,
-// 
-// 	/** RTCM3 pass through */
-// 	COM_MANAGER_PASS_THROUGH_RTCM3 = RTCM3_START_BYTE
-// } com_manager_pass_through_t;
 
 /* Contains data that determines what messages are being broadcast */
 typedef struct
@@ -109,14 +95,8 @@ typedef void(*pfnComManagerDisableBroadcasts)(int port);
 // Called right before data is to be sent.  Data is not sent if this callback returns 0.
 typedef int(*pfnComManagerPreSend)(int port, p_data_hdr_t *dataHdr);
 
-// NMEA message handler function, return 1 if message handled
-// typedef int(*pfnComManagerAsciiMessageHandler)(int port, unsigned char* messageId, unsigned char* line, int lineLength);
-
 // Generic message handler function, return 1 if message handled
 typedef int(*pfnComManagerGenMsgHandler)(int port, const unsigned char* msg, int msgSize);
-
-// pass through handler
-// typedef int(*pfnComManagerPassThrough)(com_manager_pass_through_t passThroughType, int port, const unsigned char* data, int dataLength);
 
 // broadcast message handler
 typedef int(*pfnComManagerAsapMsg)(int port, p_data_get_t* req);
@@ -213,25 +193,25 @@ typedef struct
 CMHANDLE comManagerGetGlobal(void);
 
 /**
-Initializes the default global com manager. This is generally only called once on program start.
-The global com manager is used by the functions that do not have the Instance suffix and first parameter of void* cmInstance.
-The instance functions can be ignored, unless you have a reason to have two com managers in the same process.
-
-@param numPorts the max number of serial ports possible
-@param stepPeriodMilliseconds how many milliseconds you are waiting in between calls to comManagerStep
-@param readFnc read data from the serial port represented by pHandle
-@param sendFnc send data to the serial port represented by pHandle
-@param txFreeFnc optional, return the number of free bytes in the send buffer for the serial port represented by pHandle
-@param pstRxFnc optional, called after new data is available (successfully parsed and checksum passed) from the serial port represented by pHandle
-@param pstAckFnc optional, called after an ACK is received by the serial port represented by pHandle
-@param disableBcastFnc mostly for internal use, this can be left as 0 or NULL
-@param timeMs pointer to current time in milliseconds, used for parser state timeout.  Leave NULL if timeout feature is not used.
-@return 0 on success, -1 on failure
-
-Example:
-@code
-comManagerInit(20, 20, 10, 25, staticReadData, staticSendData, NULL, staticProcessRxData, staticProcessAck, 0);
-@endcode
+* Initializes the default global com manager. This is generally only called once on program start.
+* The global com manager is used by the functions that do not have the Instance suffix and first parameter of void* cmInstance.
+* The instance functions can be ignored, unless you have a reason to have two com managers in the same process.
+* 
+* @param numPorts the max number of serial ports possible
+* @param stepPeriodMilliseconds how many milliseconds you are waiting in between calls to comManagerStep
+* @param readFnc read data from the serial port represented by pHandle
+* @param sendFnc send data to the serial port represented by pHandle
+* @param txFreeFnc optional, return the number of free bytes in the send buffer for the serial port represented by pHandle
+* @param pstRxFnc optional, called after new data is available (successfully parsed and checksum passed) from the serial port represented by pHandle
+* @param pstAckFnc optional, called after an ACK is received by the serial port represented by pHandle
+* @param disableBcastFnc mostly for internal use, this can be left as 0 or NULL
+* @param timeMs pointer to current time in milliseconds, used for parser state timeout.  Leave NULL if timeout feature is not used.
+* @return 0 on success, -1 on failure
+* 
+* Example:
+* @code
+* comManagerInit(20, 20, 10, 25, staticReadData, staticSendData, NULL, staticProcessRxData, staticProcessAck, 0);
+* @endcode
 */
 int comManagerInit
 (	int numPorts,
@@ -261,7 +241,7 @@ int comManagerInitInstance
 	com_manager_port_t *cmPorts);
 
 /**
-Performs one round of sending and receiving message. This should be called as often as you want to send and receive data.
+* Performs one round of sending and receiving message. Call as frequently as needed to send and receive data.
 */
 void comManagerStep(void);
 void comManagerStepInstance(CMHANDLE cmInstance_);
@@ -269,232 +249,232 @@ void comManagerStepRxInstance(CMHANDLE cmInstance);
 void comManagerStepTxInstance(CMHANDLE cmInstance);
 
 /**
-Make a request to a port handle to broadcast a piece of data at a set interval.
-
-@param pHandle the port handle to request broadcast data from
-@param dataId the data id to broadcast
-@param size number of bytes in the data structure from offset to broadcast - pass size and offset of 0 to receive the entire data set
-@param offset offset into the structure for the data id to broadcast - pass size and offset of 0 to receive the entire data set
-@param periodMultiple the data broadcast period in multiples of the base update period
-
-Example that makes a request to receive the device info just once:
-@code
-comManagerGetData(0, DID_DEV_INFO, 0, 0, 0);
-@endcode
-
-Example that broadcasts INS data every 50 milliseconds:
-@code
-comManagerGetData(0, DID_INS_1, 0, 0, 50);
-@endcode
+* Make a request to a port handle to broadcast a piece of data at a set interval.
+* 
+* @param pHandle the port handle to request broadcast data from
+* @param dataId the data id to broadcast
+* @param size number of bytes in the data structure from offset to broadcast - pass size and offset of 0 to receive the entire data set
+* @param offset offset into the structure for the data id to broadcast - pass size and offset of 0 to receive the entire data set
+* @param periodMultiple the data broadcast period in multiples of the base update period
+* 
+* Example that makes a request to receive the device info just once:
+* @code
+* comManagerGetData(0, DID_DEV_INFO, 0, 0, 0);
+* @endcode
+* 
+* Example that broadcasts INS data every 50 milliseconds:
+* @code
+* comManagerGetData(0, DID_INS_1, 0, 0, 50);
+* @endcode
 */
 void comManagerGetData(int port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period);
 void comManagerGetDataInstance(CMHANDLE cmInstance, int port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period);
 
 /**
-Make a request to a port handle to broadcast a piece of data at a set interval.
-
-@param pHandle the port handle to request broadcast data from
-@param RMC bits specifying data messages to stream.  See presets: RMC_PRESET_PPD_BITS = post processing data, RMC_PRESET_INS_BITS = INS2 and GPS data at full rate
-@param RMC options to enable data streaming on ports other than the current port. 
-@param offset offset into the structure for the data id to broadcast - pass offset and size of 0 to receive the entire data set
-@param size number of bytes in the data structure from offset to broadcast - pass offset and size of 0 to receive the entire data set
-@param periodMultiple the data broadcast period in multiples of the base update period
-
-Example that enables streaming of all data messages necessary for post processing:
-@code
-comManagerGetDataRmc(pHandle, RMC_PRESET_PPD_BITS, 0);
-@endcode
-
-Example that broadcasts INS and GPS data at full rate:
-@code
-comManagerGetDataRmc(pHandle, RMC_PRESET_INS_BITS, 0);
-@endcode
+* Make a request to a port handle to broadcast a piece of data at a set interval.
+* 
+* @param pHandle the port handle to request broadcast data from
+* @param RMC bits specifying data messages to stream.  See presets: RMC_PRESET_PPD_BITS = post processing data, RMC_PRESET_INS_BITS = INS2 and GPS data at full rate
+* @param RMC options to enable data streaming on ports other than the current port. 
+* @param offset offset into the structure for the data id to broadcast - pass offset and size of 0 to receive the entire data set
+* @param size number of bytes in the data structure from offset to broadcast - pass offset and size of 0 to receive the entire data set
+* @param periodMultiple the data broadcast period in multiples of the base update period
+* 
+* Example that enables streaming of all data messages necessary for post processing:
+* @code
+* comManagerGetDataRmc(pHandle, RMC_PRESET_PPD_BITS, 0);
+* @endcode
+* 
+* Example that broadcasts INS and GPS data at full rate:
+* @code
+* comManagerGetDataRmc(pHandle, RMC_PRESET_INS_BITS, 0);
+* @endcode
 */
 void comManagerGetDataRmc(int port, uint64_t rmcBits, uint32_t rmcOptions);
 void comManagerGetDataRmcInstance(CMHANDLE cmInstance, int port, uint64_t rmcBits, uint32_t rmcOptions);
 
 /**
-Disable a broadcast for a specified port handle and data identifier
-
-@param pHandle the port handle to disable a broadcast for
-@param dataId the data id to disable boradcast for
-@return 0 if success, anything else if failure
-
-Example:
-@code
-comManagerDisableData(0, DID_INS_1);
-@endcode
+* Disable a broadcast for a specified port handle and data identifier
+* 
+* @param pHandle the port handle to disable a broadcast for
+* @param dataId the data id to disable boradcast for
+* @return 0 if success, anything else if failure
+* 
+* Example:
+* @code
+* comManagerDisableData(0, DID_INS_1);
+* @endcode
 */
 int comManagerDisableData(int port, uint16_t did);
 int comManagerDisableDataInstance(CMHANDLE cmInstance, int port, uint16_t did);
 
 /**
-Send a packet to a port handle
-
-@param pHandle the port handle to send the packet to
-@param pktInfo the type of packet (PID)
-@param bodyHdr optional, can contain information about the actual data of the body (txData), usually the data id, offset and size
-@param txData optional, the actual body of the packet
-@return 0 if success, anything else if failure
-
-Example:
-@code
-p_data_get_t request;
-bufPtr_t data;
-request.id = DID_INS_1;
-request.offset = 0;
-request.size = sizeof(ins_1_t);
-request.bc_period_ms = 50;
-data.ptr = (uint8_t*)&request;
-data.size = sizeof(request);
-comManagerSend(pHandle, PKT_TYPE_GET_DATA, 0, &data)
-@endcode
+* Send a packet to a port handle
+* 
+* @param pHandle the port handle to send the packet to
+* @param pktInfo the type of packet (PID)
+* @param bodyHdr optional, can contain information about the actual data of the body (txData), usually the data id, offset and size
+* @param txData optional, the actual body of the packet
+* @return 0 if success, anything else if failure
+* 
+* Example:
+* @code
+* p_data_get_t request;
+* bufPtr_t data;
+* request.id = DID_INS_1;
+* request.offset = 0;
+* request.size = sizeof(ins_1_t);
+* request.bc_period_ms = 50;
+* data.ptr = (uint8_t*)&request;
+* data.size = sizeof(request);
+* comManagerSend(pHandle, PKT_TYPE_GET_DATA, 0, &data)
+* @endcode
 */
 int comManagerSend(int port, uint8_t pFlags, void *data, uint16_t did, uint16_t size, uint16_t offset);
 int comManagerSendInstance(CMHANDLE cmInstance, int port, uint8_t pFlags, void *data, uint16_t did, uint16_t size, uint16_t offset);
 
 /**
-Convenience function that wraps comManagerSend for sending data structures.  Must be multiple of 4 bytes in size.
-
-@param pHandle the port handle to send data to
-@param dataId the data id of the data to send
-@param dataPtr pointer to the data structure to send
-@param dataSize number of bytes to send
-@param dataOffset offset into dataPtr to send at
-@return 0 if success, anything else if failure
-
-Example:
-@code
-comManagerSendData(0, DID_DEV_INFO, &g_devInfo, sizeof(dev_info_t), 0);
-@endcode
+* Convenience function that wraps comManagerSend for sending data structures.  Must be multiple of 4 bytes in size.
+* 
+* @param pHandle the port handle to send data to
+* @param dataId the data id of the data to send
+* @param dataPtr pointer to the data structure to send
+* @param dataSize number of bytes to send
+* @param dataOffset offset into dataPtr to send at
+* @return 0 if success, anything else if failure
+* 
+* Example:
+* @code
+* comManagerSendData(0, DID_DEV_INFO, &g_devInfo, sizeof(dev_info_t), 0);
+* @endcode
 */
 int comManagerSendData(int port, void* data, uint16_t did, uint16_t size, uint16_t offset);
 int comManagerSendDataInstance(CMHANDLE cmInstance, int port, void* data, uint16_t did, uint16_t size, uint16_t offset);
 
 // INTERNAL FUNCTIONS...
 /**
-Same as comManagerSend, except that no retry is attempted
-
-@param pHandle the port handle to send the packet to
-@param dataId Data structure ID number.
-@param dataPtr Pointer to actual data.
-@param dataSize Size of data to send in number of bytes.
-@param dataOffset Offset into data structure where copied data starts.
-@param pFlags Additional packet flags if needed.
-@return 0 if success, anything else if failure
+* Same as comManagerSend, except that no retry is attempted
+* 
+* @param pHandle the port handle to send the packet to
+* @param dataId Data structure ID number.
+* @param dataPtr Pointer to actual data.
+* @param dataSize Size of data to send in number of bytes.
+* @param dataOffset Offset into data structure where copied data starts.
+* @param pFlags Additional packet flags if needed.
+* @return 0 if success, anything else if failure
 */
 int comManagerSendDataNoAck(int port, void *data, uint16_t did, uint16_t size, uint16_t offset);
 int comManagerSendDataNoAckInstance(CMHANDLE cmInstance, int port, void *data, uint16_t did, uint16_t size, uint16_t offset);
 
 /**
-Convenience function that wraps comManagerSend for sending data structures.  Allows arbitrary bytes size, 4 byte multiple not required. 
-No byte swapping occurs.
-
-@param pHandle the port handle to send data to
-@param dataId the data id of the data to send
-@param dataPtr pointer to the data structure to send
-@param dataSize number of bytes to send
-@param dataOffset offset into dataPtr to send at
-@return 0 if success, anything else if failure
-
-Example:
-@code
-comManagerSendRawData(0, DID_DEV_INFO, &g_devInfo, sizeof(dev_info_t), 0);
-@endcode
+* Convenience function that wraps comManagerSend for sending data structures.  Allows arbitrary bytes size, 4 byte multiple not required. 
+* No byte swapping occurs.
+* 
+* @param pHandle the port handle to send data to
+* @param dataId the data id of the data to send
+* @param dataPtr pointer to the data structure to send
+* @param dataSize number of bytes to send
+* @param dataOffset offset into dataPtr to send at
+* @return 0 if success, anything else if failure
+* 
+* Example:
+* @code
+* comManagerSendRawData(0, DID_DEV_INFO, &g_devInfo, sizeof(dev_info_t), 0);
+* @endcode
 */
 int comManagerSendRawData(int port, void* data, uint16_t did, uint16_t size, uint16_t offset);
 int comManagerSendRawDataInstance(CMHANDLE cmInstance, int port, void* data, uint16_t did, uint16_t size, uint16_t offset);
 
 /**
-Write bare data directly to the serial port.
-
-@param pHandle the port handle to send data to
-@param dataPtr pointer to the data structure to send
-@param dataSize number of bytes to send
-@return 0 if success, anything else if failure
-
-Example:
-@code
-comManagerSendRaw(0, &g_devInfo, sizeof(dev_info_t));
-@endcode
+* Write bare data directly to the serial port.
+* 
+* @param pHandle the port handle to send data to
+* @param dataPtr pointer to the data structure to send
+* @param dataSize number of bytes to send
+* @return 0 if success, anything else if failure
+* 
+* Example:
+* @code
+* comManagerSendRaw(0, &g_devInfo, sizeof(dev_info_t));
+* @endcode
 */
 int comManagerSendRaw(int pHandle, void* dataPtr, int dataSize);
 int comManagerSendRawInstance(CMHANDLE cmInstance, int pHandle, void* dataPtr, int dataSize);
 
 /**
-Write bare data directly to the serial port.
-
-@param pHandle the port handle to send data to
-@param dataPtr pointer to the data structure to send
-@param dataSize number of bytes to send
-@return 0 if success, anything else if failure
-
-Example:
-@code
-comManagerSendRaw(0, &g_devInfo, sizeof(dev_info_t));
-@endcode
+* Write bare data directly to the serial port.
+* 
+* @param pHandle the port handle to send data to
+* @param dataPtr pointer to the data structure to send
+* @param dataSize number of bytes to send
+* @return 0 if success, anything else if failure
+* 
+* Example:
+* @code
+* comManagerSendRaw(0, &g_devInfo, sizeof(dev_info_t));
+* @endcode
 */
 int comManagerSendRaw(int pHandle, void* dataPtr, int dataSize);
 int comManagerSendRawInstance(CMHANDLE cmInstance, int pHandle, void* dataPtr, int dataSize);
 
 /**
-Disables broadcasts of all messages on specified port, or all ports if phandle == -1.
-@param pHandle the pHandle to disable broadcasts on, -1 for all
+* Disables broadcasts of all messages on specified port, or all ports if phandle == -1.
+* @param pHandle the pHandle to disable broadcasts on, -1 for all
 */
 void comManagerDisableBroadcasts(int port);
 void comManagerDisableBroadcastsInstance(CMHANDLE cmInstance, int port);
 
 /**
-Get the ISComm structure. 
-
-@return com manager ISComm structure, this pointer is owned by the com manager
+* Get the ISComm structure. 
+* 
+* @return com manager ISComm structure, this pointer is owned by the com manager
 */
 is_comm_instance_t* comManagerGetIsComm(int port);
 is_comm_instance_t* comManagerGetIsCommInstance(CMHANDLE cmInstance, int port);
 
 /**
-Internal use mostly, get data info for a the specified pre-registered dataId
-
-@return 0 on failure, pointer on success
+* Internal use mostly, get data info for a the specified pre-registered dataId
+* 
+* @return 0 on failure, pointer on success
 */
 bufTxRxPtr_t* comManagerGetRegisteredDataInfo(uint16_t did);
 bufTxRxPtr_t* comManagerGetRegisteredDataInfoInstance(CMHANDLE cmInstance, uint16_t did);
 
 /**
-Internal use mostly, process a get data request for a message that needs to be broadcasted
-
-@return 0 on success, anything else is failure
+* Internal use mostly, process a get data request for a message that needs to be broadcasted
+* 
+* @return 0 on success, anything else is failure
 */
 int comManagerGetDataRequest(int port, p_data_get_t* req);
 int comManagerGetDataRequestInstance(CMHANDLE cmInstance, int port, p_data_get_t* req);
 
 /**
-Register message handling function for a received data id (binary). This is mostly an internal use function,
-but can be used if you are implementing your own receiver on a device.
-
-@param dataId the data id to register the handler for
-@param txFnc called right before the data is sent
-@param pstRxFnc called after data is received for the data id
-@param txDataPtr a pointer to the structure in memory of the data to send
-@param rxDataPtr a pointer to the structure in memory to copy received data to
-@param dataSize size of the data structure in txDataPtr and rxDataPtr
-@param pktFlags packet flags, usually 0
-
-Example:
-@code
-registerComManager(DID_INS_1, prepMsgINS, writeMsgINS, &g_insData, &g_insData, sizeof(ins_1_t));
-@endcode
+* Register message handling function for a received data id (binary). This is mostly an internal use function,
+* but can be used if you are implementing your own receiver on a device.
+* 
+* @param dataId the data id to register the handler for
+* @param txFnc called right before the data is sent
+* @param pstRxFnc called after data is received for the data id
+* @param txDataPtr a pointer to the structure in memory of the data to send
+* @param rxDataPtr a pointer to the structure in memory to copy received data to
+* @param dataSize size of the data structure in txDataPtr and rxDataPtr
+* @param pktFlags packet flags, usually 0
+* 
+* Example:
+* @code
+* registerComManager(DID_INS_1, prepMsgINS, writeMsgINS, &g_insData, &g_insData, sizeof(ins_1_t));
+* @endcode
 */
 void comManagerRegister(uint16_t did, pfnComManagerPreSend txFnc, pfnComManagerPostRead pstRxFnc, const void* txDataPtr, void* rxDataPtr, uint16_t size, uint8_t pktFlags);
 void comManagerRegisterInstance(CMHANDLE cmInstance, uint16_t did, pfnComManagerPreSend txFnc, pfnComManagerPostRead pstRxFnc, const void* txDataPtr, void* rxDataPtr, uint16_t size, uint8_t pktFlags);
 
 /**
-Register message handler callback functions.  Pass in NULL to disable any of these callbacks.
-
-@param msgFunc handler for Realtime Message Controller (RMC) called whenever we get a message broadcast request or message disable command.
-@param msgFunc handler for NMEA messages.
-@param msgFunc handler for ublox messages.
-@param msgFunc handler for RTCM3 messages.
+* Register message handler callback functions.  Pass in NULL to disable any of these callbacks.
+* 
+* @param msgFunc handler for Realtime Message Controller (RMC) called whenever we get a message broadcast request or message disable command.
+* @param msgFunc handler for NMEA messages.
+* @param msgFunc handler for ublox messages.
+* @param msgFunc handler for RTCM3 messages.
 */
 void comManagerSetCallbacks(
 	pfnComManagerAsapMsg rmcHandler,
@@ -510,12 +490,12 @@ void comManagerSetCallbacksInstance(CMHANDLE cmInstance,
 	pfnComManagerGenMsgHandler spartnHandler);
 
 /**
-Attach user defined data to a com manager instance
+* Attach user defined data to a com manager instance
 */
 void comManagerAssignUserPointer(CMHANDLE cmInstance, void* userPointer);
 
 /**
-Get user defined data to from a com manager instance
+* Get user defined data to from a com manager instance
 */
 void* comManagerGetUserPointer(CMHANDLE cmInstance);
 

--- a/src/com_manager.h
+++ b/src/com_manager.h
@@ -242,10 +242,13 @@ int comManagerInitInstance
 
 /**
 * Performs one round of sending and receiving message. Call as frequently as needed to send and receive data.
+* 
+* @param timeMs current time in milliseconds used for paser timeout.  Used to invalidate packet parsing if PKT_PARSER_TIMEOUT_MS time has lapsed since any data has been received.  
 */
 void comManagerStep(void);
+void comManagerStepTimeout(uint32_t timeMs);
 void comManagerStepInstance(CMHANDLE cmInstance_);
-void comManagerStepRxInstance(CMHANDLE cmInstance);
+void comManagerStepRxInstance(CMHANDLE cmInstance, uint32_t timeMs);
 void comManagerStepTxInstance(CMHANDLE cmInstance);
 
 /**

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -54,16 +54,16 @@ add_library(SDK_test
 	)
 
 add_executable(run_tests
-	test_com_manager.cpp
-	# test_com_manager_2.cpp
-	test_InertialSense.cpp
+	# test_com_manager.cpp
+	# # test_com_manager_2.cpp
+	# test_InertialSense.cpp
 	test_ISComm.cpp
-	test_ISDataMappings.cpp
-	test_ISFirmwareUpdate.cpp
-	test_ISPolynomial.cpp
-	test_math.cpp
-	test_ring_buffer.cpp
-	test_protocol_nmea.cpp
+	# test_ISDataMappings.cpp
+	# test_ISFirmwareUpdate.cpp
+	# test_ISPolynomial.cpp
+	# test_math.cpp
+	# test_ring_buffer.cpp
+	# test_protocol_nmea.cpp
 	../com_manager.c
 	../convert_ins.cpp
 	../data_sets.c

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -54,16 +54,16 @@ add_library(SDK_test
 	)
 
 add_executable(run_tests
-	# test_com_manager.cpp
-	# # test_com_manager_2.cpp
-	# test_InertialSense.cpp
+	test_com_manager.cpp
+	# test_com_manager_2.cpp
+	test_InertialSense.cpp
 	test_ISComm.cpp
-	# test_ISDataMappings.cpp
-	# test_ISFirmwareUpdate.cpp
-	# test_ISPolynomial.cpp
-	# test_math.cpp
-	# test_ring_buffer.cpp
-	# test_protocol_nmea.cpp
+	test_ISDataMappings.cpp
+	test_ISFirmwareUpdate.cpp
+	test_ISPolynomial.cpp
+	test_math.cpp
+	test_ring_buffer.cpp
+	test_protocol_nmea.cpp
 	../com_manager.c
 	../convert_ins.cpp
 	../data_sets.c

--- a/src/test/setup_debug.sh
+++ b/src/test/setup_debug.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+pushd "$(dirname "$(realpath $0)")" > /dev/null
+
+mkdir -p build
+rm -rf build/*
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make -j 7
+
+popd > /dev/null

--- a/src/test/test_ISComm.cpp
+++ b/src/test/test_ISComm.cpp
@@ -43,9 +43,6 @@ extern "C"
 
 typedef struct
 {
-	// com_manager_t			cm;
-	// com_manager_status_t	cmBufStatus[NUM_COM_PORTS] = { 0 };
-	// broadcast_msg_t			cmBufBcastMsg[MAX_NUM_BCAST_MSGS] = { 0 };
 	struct 
 	{
 		dev_info_t			devInfo;
@@ -1192,7 +1189,7 @@ TEST(ISComm, alternating_isb_nmea_parse_error_check)
 
 
 #if TEST_TRUNCATED_PACKETS
-TEST(ISComm, IncompletePackets)
+TEST(ISComm, TruncatedPackets)
 {
 	// Initialize Com Manager
 	init(tcm);

--- a/src/test/test_ISComm.cpp
+++ b/src/test/test_ISComm.cpp
@@ -546,7 +546,7 @@ void addDequeToRingBuf(std::deque<data_holder_t> &testDeque, ring_buf_t *rbuf)
 		{
 		case _PTYPE_INERTIAL_SENSE_DATA:
 			// Packetize data 
-			uint8_t buf[1024];
+			uint8_t buf[COM_BUFFER_SIZE];
 			n = is_comm_set_data_to_buf(buf, sizeof(buf), &comm, td.did, td.size, 0, (void*)&(td.data));
 			td.pktSize = n;
 			EXPECT_FALSE(ringBufWrite(rbuf, buf, n));
@@ -703,7 +703,7 @@ TEST(ISComm, BasicTxBufferRxByteTest)
 		switch (td.ptype)
 		{
 		default:	// IS binary
-			uint8_t buf[1024];
+			uint8_t buf[COM_BUFFER_SIZE];
 			n = is_comm_data_to_buf(buf, sizeof(buf), &g_comm, td.did, td.size, 0, td.data.buf);
 			portWrite(0, buf, n);
 			break;
@@ -1083,7 +1083,7 @@ TEST(ISComm, IsCommGetDataTest)
 
 #if TEST_ALTERNATING_ISB_NMEA_PARSE_ERRORS
 uint8_t rxBuf[8192] = {0};
-uint8_t txBuf[1024] = {0};
+uint8_t txBuf[1024] = {0};		// This buffer is intentially left smaller for testing
 
 #define BUF_FREE    (uint32_t)(txEnd-txPtr)
 #define BUF_USED    (uint32_t)(txPtr-txBuf)
@@ -1198,7 +1198,7 @@ TEST(ISComm, TruncatedPackets)
 	generateData(g_testTxDeque);
 
 	int badPktCount = 0, goodPktCount = 0;
-	uint8_t buf[4096] = {0};
+	uint8_t buf[COM_BUFFER_SIZE] = {0};
 
 	// Use Com Manager to send deque data to Tx port ring buffer
 	for(int i=0; i<g_testTxDeque.size(); i++)

--- a/src/test/test_ISComm.cpp
+++ b/src/test/test_ISComm.cpp
@@ -1313,10 +1313,9 @@ TEST(ISComm, IncompletePackets)
 
 		if (ringBufUsed(&tcm.portTxBuf)<=0)
 		{
-			// No more data left in ring buffer.  Reset parser and try again with remaining data.
-			comm.parser.state = 0;
-			comm.rxBuf.scan = ++(comm.rxBuf.head);
-			comm.processPkt = NULL;
+			// No more data left in ring buffer.  Reset parser one byte ahead of head and try again until there's no more data iscomm buffer.
+			comm.rxBuf.head++;
+			is_comm_reset_parser(&comm);
 
 			if (comm.rxBuf.head >= comm.rxBuf.tail)
 			{	// No more data to parse. 
@@ -1327,8 +1326,10 @@ TEST(ISComm, IncompletePackets)
 
 	// Check that we got all data
 	EXPECT_TRUE(ringBufUsed(&tcm.portTxBuf) == 0);
+	EXPECT_TRUE(g_testTxDeque.empty());
 
-	// Check 
+	// Check good and bad packet count
 	EXPECT_EQ(g_comm.rxPktCount, goodPktCount);
+	EXPECT_EQ(g_comm.rxErrorCount, badPktCount);
 }
 #endif


### PR DESCRIPTION
Revise v2 protocol packet parser to only parse one packet at a time (no concurrent parsing anymore).  We only care to parse the highest level packets.  Packet parsing is invalidate either by 1.) exceeding max packet length or 2.) incomplete packet received by timeout.  The prior method of allowing concurrent parsing was a bad idea as it allowed encapsulated packets (packets inside packets) to invalidate the outer packet parse.