### PR TITLE
Include only available serial ports

### DIFF
--- a/src/ISSerialPort.cpp
+++ b/src/ISSerialPort.cpp
@@ -14,9 +14,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISLogger.h"
 #include "ISFileManager.h"
 
-#include <stdio.h>
-#include <string.h>
-
 #if PLATFORM_IS_LINUX
 #include <fcntl.h>
 #include <sys/ioctl.h>

--- a/src/ISSerialPort.cpp
+++ b/src/ISSerialPort.cpp
@@ -191,9 +191,9 @@ void cISSerialPort::GetComPorts(vector<string>& ports)
 
 #if 0
 	cout << "Available ports: " << endl;
-	for (vector<string>::iterator it = ports.begin(); it < ports.end(); it++) 
+    for (int i = 0; i < ports.size(); i++)
 	{
-        cout << *it << endl;
+        cout << ports[i] << endl;
     }
 #endif
 }


### PR DESCRIPTION
Change how we populate cISSerialPort::GetComPorts() to use all currently available functional serial ports in Linux.