### PR TITLE
SN-4325 Allow users to specify NMEA output rates slower than DID output rates

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1687,7 +1687,8 @@ enum eNmeaAsciiMsgId
     NMEA_MSG_ID_PSTRB     = 12,
     NMEA_MSG_ID_INFO      = 13,
     NMEA_MSG_ID_GSV       = 14,
-    NMEA_MSG_ID_VTG       = 15
+    NMEA_MSG_ID_VTG       = 15,
+    NMEA_MSG_ID_COUNT
 }; 
 
 #define NMEA_RMC_BITS_PIMU    		(1<<NMEA_MSG_ID_PIMU)
@@ -1720,7 +1721,10 @@ typedef struct PACKED
     uint8_t                 periodMultiple[DID_COUNT_UINS];
 
     /** NMEA data stream enable bits for the specified ports.  (see NMEA_RMC_BITS_...) */
-    uint32_t                bitsNmea;
+    uint32_t                nmeaBits;
+
+    /** NMEA period multiple of above period multiple indexed by NMEA_MSG_ID... */
+    uint8_t                 nmeaPeriod[NMEA_MSG_ID_COUNT];
 
 } rmci_t;
 

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -381,8 +381,6 @@ double timeToGpst(gtime_t t, int *week)
 	return (double)(sec-(double)w*86400*7)+t.sec;
 }
 
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
 void nmea_enable_stream(rmci_t &rmci, uint32_t nmeaId, uint8_t periodMultiple)
 {
 	uint32_t nmeaBits = (1<<nmeaId);
@@ -452,7 +450,6 @@ void nmea_set_rmc_period_multiple(rmci_t &rmci, nmea_msgs_t tmp)
 	nmea_enable_stream(rmci, NMEA_MSG_ID_GSV,   tmp.gsv);
 	nmea_enable_stream(rmci, NMEA_MSG_ID_VTG,   tmp.vtg);
 }
-#pragma GCC pop_options
 
 //////////////////////////////////////////////////////////////////////////
 // Binary to NMEA

--- a/src/test/test_protocol_nmea.cpp
+++ b/src/test/test_protocol_nmea.cpp
@@ -22,7 +22,7 @@ TEST(protocol_nmea, nmea_parse_ascb)
     r.periodMultiple[DID_INS_2] = 2;
     r.periodMultiple[DID_PIMU] = 1;
     r.periodMultiple[DID_GPS1_POS] = 1;
-    r.bitsNmea = 
+    r.nmeaBits = 
         NMEA_RMC_BITS_PINS2 |
         NMEA_RMC_BITS_PPIMU |
         NMEA_RMC_BITS_GGA;
@@ -47,7 +47,7 @@ TEST(protocol_nmea, nmea_parse_ascb)
         rmci_t &a = rmci[i];
         rmci_t &b = outRmci[i];
         ASSERT_EQ( a.bits, b.bits );
-        ASSERT_EQ( a.bitsNmea, b.bitsNmea );
+        ASSERT_EQ( a.nmeaBits, b.nmeaBits );
         for (int j=0; j<DID_COUNT_UINS; j++)
         {
             ASSERT_EQ( a.periodMultiple[j], b.periodMultiple[j] );
@@ -65,7 +65,7 @@ TEST(protocol_nmea, nmea_parse_asce)
     r.periodMultiple[DID_INS_2] = 2;
     r.periodMultiple[DID_PIMU] = 1;
     r.periodMultiple[DID_GPS1_POS] = 1;
-    r.bitsNmea = 
+    r.nmeaBits = 
         NMEA_RMC_BITS_PINS2 |
         NMEA_RMC_BITS_PPIMU |
         NMEA_RMC_BITS_GGA;
@@ -88,7 +88,7 @@ TEST(protocol_nmea, nmea_parse_asce)
         rmci_t &a = rmci[i];
         rmci_t &b = outRmci[i];
         ASSERT_EQ( a.bits, b.bits );
-        ASSERT_EQ( a.bitsNmea, b.bitsNmea );
+        ASSERT_EQ( a.nmeaBits, b.nmeaBits );
         for (int j=0; j<DID_COUNT_UINS; j++)
         {
             ASSERT_EQ( a.periodMultiple[j], b.periodMultiple[j] );


### PR DESCRIPTION
Prior to this change, matching NMEA and DID messages had to be streamed at the same output data rate as they shared the same periodMultiple variable.   Now NMEA messages have their own periodMultiple to allow slower output data rates than the DID message.