### PR TITLE
Fix high speed baud rates

### DIFF
--- a/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
+++ b/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
@@ -505,7 +505,7 @@
       </framework-data>
     </AsfFrameworkConfig>
     <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
-    <avrtoolserialnumber>J41800054309</avrtoolserialnumber>
+    <avrtoolserialnumber>J41800082852</avrtoolserialnumber>
     <avrdeviceexpectedsignature>0xA1020C01</avrdeviceexpectedsignature>
     <avrtoolinterface>SWD</avrtoolinterface>
     <com_atmel_avrdbg_tool_edbg>
@@ -540,7 +540,7 @@
         <InterfaceName>SWD</InterfaceName>
       </ToolOptions>
       <ToolType>com.atmel.avrdbg.tool.atmelice</ToolType>
-      <ToolNumber>J41800054309</ToolNumber>
+      <ToolNumber>J41800082852</ToolNumber>
       <ToolName>Atmel-ICE</ToolName>
     </com_atmel_avrdbg_tool_atmelice>
     <com_atmel_avrdbg_tool_samice>

--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -183,13 +183,13 @@ void callback_cdc_set_config(uint8_t port, usb_cdc_line_coding_t * cfg)
         // Set baudrate based on USB CDC baudrate
         if (g_flashCfg->cbf[EVB2_PORT_USB] & (1<<EVB2_PORT_UINS0))
         {
-            serSetBaudRate(EVB2_PORT_UINS0, baudrate);
+            serSyncBaudRate(EVB2_PORT_UINS0, &baudrate);
         }
 
         if (g_flashCfg->cbf[EVB2_PORT_USB] & (1<<EVB2_PORT_UINS1) &&
 		  !(g_flashCfg->cbOptions&EVB2_CB_OPTIONS_SPI_ENABLE))
         {
-            serSetBaudRate(EVB2_PORT_UINS1, baudrate);
+            serSyncBaudRate(EVB2_PORT_UINS1, &baudrate);
         }
     }
 
@@ -197,26 +197,25 @@ void callback_cdc_set_config(uint8_t port, usb_cdc_line_coding_t * cfg)
     {
         // 	    if(g_flashCfg->cbf[EVB2_PORT_USB] & (1<<EVB2_PORT_XBEE))
         // 	    {
-        // 		    serSetBaudRate(EVB2_PORT_XBEE, baudrate);
+        // 		    serSyncBaudRate(EVB2_PORT_XBEE, &baudrate);
         // 	    }
         if (g_flashCfg->cbf[EVB2_PORT_USB] & (1<<EVB2_PORT_XRADIO))
         {
-            serSetBaudRate(EVB2_PORT_XRADIO, baudrate);
+            serSyncBaudRate(EVB2_PORT_XRADIO, &baudrate);
         }
         if (g_flashCfg->cbf[EVB2_PORT_USB] & (1<<EVB2_PORT_BLE))
         {
-            serSetBaudRate(EVB2_PORT_BLE, baudrate);
+            serSyncBaudRate(EVB2_PORT_BLE, &baudrate);
         }
         if (g_flashCfg->cbf[EVB2_PORT_USB] & (1<<EVB2_PORT_SP330))
         {
-            serSetBaudRate(EVB2_PORT_SP330, baudrate);
+            serSyncBaudRate(EVB2_PORT_SP330, &baudrate);
         }
         if (g_flashCfg->cbf[EVB2_PORT_USB] & (1<<EVB2_PORT_GPIO_H8))
         {
-            serSetBaudRate(EVB2_PORT_GPIO_H8, baudrate);
+            serSyncBaudRate(EVB2_PORT_GPIO_H8, &baudrate);
         }
     }
-
 }
 
 void callback_cdc_set_dtr(uint8_t port, bool b_enable)

--- a/EVB-2/IS_EVB-2/src/misc/init.c
+++ b/EVB-2/IS_EVB-2/src/misc/init.c
@@ -474,7 +474,7 @@ void board_IO_config(void)
 	    ioport_set_pin_output_mode(SP330_N485_RXEN_PIN, IOPORT_PIN_LEVEL_HIGH);     // Disable RS485 receiver
     	ioport_set_pin_output_mode(SP330_485_N232_PIN, IOPORT_PIN_LEVEL_LOW);       // Enable RS232 mode
     }
-    serSetBaudRate(EVB2_PORT_SP330, g_flashCfg->h3sp330BaudRate);
+    serSyncBaudRate(EVB2_PORT_SP330, &(g_flashCfg->h3sp330BaudRate));
 #endif
 
 	//////////////////////////////////////////////////////////////////////////
@@ -550,8 +550,8 @@ void board_IO_config(void)
 		}
     }
     serSetBaudRate(EVB2_PORT_BLE, 115200);
-    serSetBaudRate(EVB2_PORT_XRADIO, g_flashCfg->h4xRadioBaudRate);
-    serSetBaudRate(EVB2_PORT_GPIO_H8, g_flashCfg->h8gpioBaudRate);
+    serSyncBaudRate(EVB2_PORT_XRADIO, &(g_flashCfg->h4xRadioBaudRate));
+    serSyncBaudRate(EVB2_PORT_GPIO_H8, &(g_flashCfg->h8gpioBaudRate));
 
 	//////////////////////////////////////////////////////////////////////////
 	// CAN
@@ -700,7 +700,7 @@ void board_init()
 #ifdef CONF_BOARD_SERIAL_EXT_RADIO      // External Radio
     ioport_set_pin_peripheral_mode(UART_EXT_RADIO_RXD_PIN, UART_EXT_RADIO_RXD_FLAGS);
     ioport_set_pin_peripheral_mode(UART_EXT_RADIO_TXD_PIN, UART_EXT_RADIO_TXD_FLAGS);
-    serInit(EVB2_PORT_XRADIO, g_flashCfg->h4xRadioBaudRate, NULL);
+    serInitSyncBaudrate(EVB2_PORT_XRADIO, &(g_flashCfg->h4xRadioBaudRate), NULL);
 //     ioport_set_pin_dir(EXT_RADIO_RST, IOPORT_DIR_OUTPUT);
 //     ioport_set_pin_level(EXT_RADIO_RST, IOPORT_PIN_LEVEL_HIGH);         // Low assert
 #endif
@@ -716,7 +716,7 @@ void board_init()
 #ifdef CONF_BOARD_SERIAL_SP330          // RS232/RS422/RS485 converter
     ioport_set_pin_peripheral_mode(UART_SP330_RXD_PIN, UART_SP330_RXD_FLAGS);
     ioport_set_pin_peripheral_mode(UART_SP330_TXD_PIN, UART_SP330_TXD_FLAGS);
-    serInit(EVB2_PORT_SP330, g_flashCfg->h3sp330BaudRate, NULL);
+    serInitSyncBaudrate(EVB2_PORT_SP330, &(g_flashCfg->h3sp330BaudRate), NULL);
 	ioport_set_pin_output_mode(SP330_NSLEW_PIN, IOPORT_PIN_LEVEL_HIGH);         // Don't limit data rate to less than 250 Kbps
 	ioport_set_pin_output_mode(SP330_NFULL_DPLX_PIN, IOPORT_PIN_LEVEL_LOW);    // RS485 full duplex (RS232 N/A)
 	ioport_set_pin_output_mode(SP330_NSHDN_PIN, IOPORT_PIN_LEVEL_HIGH);         // Enable device
@@ -727,7 +727,7 @@ void board_init()
     ioport_set_pin_peripheral_mode(GPIO_H8_UART_RXD_PIN, GPIO_H8_UART_RXD_FLAGS);
 	MATRIX->CCFG_SYSIO |= CCFG_SYSIO_SYSIO4;
     ioport_set_pin_peripheral_mode(GPIO_H8_UART_TXD_PIN, GPIO_H8_UART_TXD_FLAGS);
-    serInit(EVB2_PORT_GPIO_H8, g_flashCfg->h8gpioBaudRate, NULL);
+    serInitSyncBaudrate(EVB2_PORT_GPIO_H8, &(g_flashCfg->h8gpioBaudRate), NULL);
 #endif
 
     //////////////////////////////////////////////////////////////////////////

--- a/hw-libs/drivers/SAMx70/ASF/sam/drivers/uart/uart.h
+++ b/hw-libs/drivers/SAMx70/ASF/sam/drivers/uart/uart.h
@@ -65,6 +65,7 @@ typedef struct sam_uart_opt {
 } sam_uart_opt_t;
 
 uint32_t uart_init(Uart *p_uart, const sam_uart_opt_t *p_uart_opt);
+uint32_t uart_baud_rate(Uart *p_uart, uint32_t ul_mck);
 void uart_enable_tx(Uart *p_uart);
 void uart_disable_tx(Uart *p_uart);
 void uart_reset_tx(Uart *p_uart);

--- a/hw-libs/drivers/SAMx70/d_serial.c
+++ b/hw-libs/drivers/SAMx70/d_serial.c
@@ -1028,7 +1028,7 @@ int serSetBaudRate( int serialNum, int baudrate )
 /**
  * \brief Read USART baudrate.  Return value is the baudrate or -1 on failure.
  */
-int serGetBaudRate( int serialNum )
+int serBaudRate( int serialNum )
 {
 	usartDMA_t *ser = (usartDMA_t*)&g_usartDMA[serialNum];
 	if( !ser ) return -1;

--- a/hw-libs/drivers/SAMx70/d_serial.c
+++ b/hw-libs/drivers/SAMx70/d_serial.c
@@ -1006,7 +1006,9 @@ static int spiEnable(int serialNum)
 }
 #endif
 
-// 0 on success, -1 on failure
+/**
+ * \brief Set USART baudrate.  Return value is 0 on success or -1 on failure.
+ */
 int serSetBaudRate( int serialNum, int baudrate )
 {
 	usartDMA_t *ser = (usartDMA_t*)&g_usartDMA[serialNum];
@@ -1026,6 +1028,28 @@ int serSetBaudRate( int serialNum, int baudrate )
 }
 
 /**
+ * \brief Set USART baudrate.  Return value is 0 on success or -1 on failure.  Parameter 'baudRate' returns actual baud rate in hardware if non-standard (>921600).
+ */
+int serSyncBaudRate(int serialNum, uint32_t *baudRate)
+{
+	if (baudRate == NULL)
+		return -1;
+
+	if (serSetBaudRate(serialNum, *baudRate) == 0)
+	{	// Success
+		if (*baudRate > IS_BAUDRATE_STANDARD_MAX) 
+		{ 	// Report back actual non-standard baudrate
+			*baudRate = serBaudRate(serialNum); 
+		}
+
+		return 0;
+	}
+
+	// Failure
+	return -1;
+}
+
+/**
  * \brief Read USART baudrate.  Return value is the baudrate or -1 on failure.
  */
 int serBaudRate( int serialNum )
@@ -1034,7 +1058,7 @@ int serBaudRate( int serialNum )
 	if( !ser ) return -1;
 	
 	// Baudrate setting
-	return ser->usart_options.baudrate;
+	return uart_baud_rate((Uart*)ser->peripheral, sysclk_get_peripheral_hz());
 }
 
 /********************************* INITIALIZATION ROUTINES ***************************************************************************************************/
@@ -1672,6 +1696,22 @@ int serInit(int serialNum, uint32_t baudRate, sam_usart_opt_t *options)
 #endif
 
 	return 0;
+}
+
+int serInitSyncBaudrate(int serialNum, uint32_t *baudrate, sam_usart_opt_t *options)
+{
+	if (serInit(serialNum, *baudrate, options) == 0)
+	{
+		if (*baudrate > IS_BAUDRATE_STANDARD_MAX) 
+		{ 	// Report back actual non-standard baud rate
+			*baudrate = serBaudRate(serialNum); 
+		}
+		// Success
+		return 0;
+	}
+
+	// Failure
+	return -1;
 }
 
 //Interrupts get enabled for errors. Clear error in interrupt.

--- a/hw-libs/drivers/SAMx70/d_serial.h
+++ b/hw-libs/drivers/SAMx70/d_serial.h
@@ -105,7 +105,7 @@ int serSetBaudRate( int serialNum, int baudrate );
 /**
  * \brief Read USART baudrate.  Return value is the baudrate or -1 on failure.
  */
-int serGetBaudRate( int serialNum );
+int serBaudRate( int serialNum );
 
 /**
  * \brief Initialize serial port with specific USART/UART and DMA settings.  If not NULL, the overrun status will have bits HDW_STATUS_ERR_COM_TX_LIMITED and HDW_STATUS_ERR_COM_RX_OVERRUN set during buffer limitation.  

--- a/hw-libs/drivers/SAMx70/d_serial.h
+++ b/hw-libs/drivers/SAMx70/d_serial.h
@@ -103,6 +103,11 @@ int serFindCharacter( int serialNum, uint8_t ch);
 int serSetBaudRate( int serialNum, int baudrate );
 
 /**
+ * \brief Change USART baudrate.  0 on success, -1 on failure.  Parameter 'baudRate' returns actual baud rate in hardware if non-standard (>921600).
+ */
+int serSyncBaudRate(int serialNum, uint32_t *baudRate);
+
+/**
  * \brief Read USART baudrate.  Return value is the baudrate or -1 on failure.
  */
 int serBaudRate( int serialNum );
@@ -110,7 +115,13 @@ int serBaudRate( int serialNum );
 /**
  * \brief Initialize serial port with specific USART/UART and DMA settings.  If not NULL, the overrun status will have bits HDW_STATUS_ERR_COM_TX_LIMITED and HDW_STATUS_ERR_COM_RX_OVERRUN set during buffer limitation.  
  */
-int serInit( int serialNum, uint32_t baudRate, sam_usart_opt_t *options);
+int serInit( int serialNum, uint32_t baudrate, sam_usart_opt_t *options);
+
+/**
+ * \brief Initialize serial port with specific USART/UART and DMA settings.  If not NULL, the overrun status will have bits HDW_STATUS_ERR_COM_TX_LIMITED and HDW_STATUS_ERR_COM_RX_OVERRUN set during buffer limitation.  
+ * \param baudrate Returns the actual baud rate in hardware if non-standard (>921600).
+ */
+int serInitSyncBaudrate(int serialNum, uint32_t *baudrate, sam_usart_opt_t *options);
 
 #ifdef __cplusplus
 }

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -113,7 +113,7 @@ int validateBaudRate(unsigned int baudRate)
 		}
 	}
 	else if (baudRate <= IS_BAUDRATE_MAX)
-	{	// High speed baud rates
+	{	// High speed custom baud rates
 		return 0;
 	}
 

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -15,12 +15,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define PKT_PARSER_TIMEOUT_MS               100		// Set to 0 to disable timeout
 
 const unsigned int g_validBaudRates[IS_BAUDRATE_COUNT] = {
-                                    // Actual on IMX-5.1:
-    IS_BAUDRATE_3200000_IMX5p0,     // 10000000
-    IS_BAUDRATE_10000000_IMX5p0,    //  3200000
-    IS_BAUDRATE_921600,             //   930233 (default baudrate)
-    IS_BAUDRATE_460800,             //   462428
-    IS_BAUDRATE_230400,             //   230547
+                            // Actual on IMX-5:
+    IS_BAUDRATE_10000000,  	// 10000000
+    IS_BAUDRATE_921600,    	//   930233 (default baudrate)
+    IS_BAUDRATE_460800,    	//   462428
+    IS_BAUDRATE_230400,    	//   230547
     IS_BAUDRATE_115200,
     IS_BAUDRATE_57600,
     IS_BAUDRATE_38400,
@@ -102,14 +101,22 @@ unsigned int getBitsAsUInt32(const unsigned char* buffer, unsigned int pos, unsi
 
 int validateBaudRate(unsigned int baudRate)
 {
-	// Valid baudrates for InertialSense hardware
-	for (size_t i = 0; i < _ARRAY_ELEMENT_COUNT(g_validBaudRates); i++)
+	if (baudRate <= IS_BAUDRATE_STANDARD_MAX)
 	{
-		if (g_validBaudRates[i] == baudRate)
+		// Valid baudrates for InertialSense hardware
+		for (size_t i = 0; i < _ARRAY_ELEMENT_COUNT(g_validBaudRates); i++)
 		{
-			return 0;
+			if (g_validBaudRates[i] == baudRate)
+			{
+				return 0;
+			}
 		}
 	}
+	else if (baudRate <= IS_BAUDRATE_MAX)
+	{	// High speed baud rates
+		return 0;
+	}
+
 	return -1;
 }
 

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -15,18 +15,17 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define PKT_PARSER_TIMEOUT_MS               100		// Set to 0 to disable timeout
 
 const unsigned int g_validBaudRates[IS_BAUDRATE_COUNT] = {
-	// Actual on uINS:
-	IS_BAUDRATE_18750000,   // 18750000 (uINS ser1 only)
-	IS_BAUDRATE_9375000,    // 9375000
-	IS_BAUDRATE_3125000,    // 3125000
-	IS_BAUDRATE_921600,     // 937734 (default)
-	IS_BAUDRATE_460800,     // 468600
-	IS_BAUDRATE_230400,     // 232700
-	IS_BAUDRATE_115200,
-	IS_BAUDRATE_57600,
-	IS_BAUDRATE_38400,
-	IS_BAUDRATE_19200,
-	IS_BAUDRATE_9600 
+                                    // Actual on IMX-5.1:
+    IS_BAUDRATE_3200000_IMX5p0,     // 10000000
+    IS_BAUDRATE_10000000_IMX5p0,    //  3200000
+    IS_BAUDRATE_921600,             //   930233 (default baudrate)
+    IS_BAUDRATE_460800,             //   462428
+    IS_BAUDRATE_230400,             //   230547
+    IS_BAUDRATE_115200,
+    IS_BAUDRATE_57600,
+    IS_BAUDRATE_38400,
+    IS_BAUDRATE_19200,
+    IS_BAUDRATE_9600 
 };
 
 static int s_packetEncodingEnabled = 1;

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -136,19 +136,21 @@ PUSH_PACK_1
 /** Valid baud rates for Inertial Sense hardware */
 typedef enum
 {
-	IS_BAUDRATE_9600        = 9600,
-	IS_BAUDRATE_19200       = 19200,
-	IS_BAUDRATE_38400       = 38400,
-	IS_BAUDRATE_57600       = 57600,
-	IS_BAUDRATE_115200      = 115200,		// Actual on uINS:
-	IS_BAUDRATE_230400      = 230400,		// 232700
-	IS_BAUDRATE_460800      = 460800,		// 468600
-	IS_BAUDRATE_921600      = 921600,		// 937734 (default)
-	IS_BAUDRATE_3125000     = 3125000,		// 3125000
-	IS_BAUDRATE_9375000     = 9375000,		// 9375000
-	IS_BAUDRATE_18750000    = 18750000,		// 18750000 (uINS ser1 only)
+    IS_BAUDRATE_9600            = 9600,
+    IS_BAUDRATE_19200           = 19200,
+    IS_BAUDRATE_38400           = 38400,
+    IS_BAUDRATE_57600           = 57600,
+    IS_BAUDRATE_115200          = 115200,       //  IMX-5.0,  uINS-3,  Actual baudrates                                             
+    IS_BAUDRATE_230400          = 230400,       //   230547,  232700, 
+    IS_BAUDRATE_460800          = 460800,       //   462428,  468600, 
+    IS_BAUDRATE_921600          = 921600,       //   930233,  937734,  (default baudrate)
+    IS_BAUDRATE_3200000_IMX5p0  = 3200000,      //  3200000  ( IMX-5 only)
+    IS_BAUDRATE_10000000_IMX5p0 = 10000000,     // 10000000  ( IMX-5 only)
+    IS_BAUDRATE_COUNT           = 10,
 
-	IS_BAUDRATE_COUNT = 12
+    IS_BAUDRATE_3125000_UINS3   = 3125000,      //  3125000  (uINS-3 only)
+    IS_BAUDRATE_9375000_UINS3   = 9375000,      //  9375000  (uINS-3 only)
+    IS_BAUDRATE_18750000_UINS3  = 18750000,     // 18750000  (uINS-3 ser1 only)
 } baud_rate_t;
 
 /** List of valid baud rates */

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -84,9 +84,6 @@ typedef enum
 	_PTYPE_RTCM3                = 0x9FFFFFFF,				/** Protocol Type: RTCM3 binary (Radio Technical Commission for Maritime Services) */
 } protocol_type_t;
 
-/** uINS default baud rate */
-#define IS_COM_BAUDRATE_DEFAULT IS_BAUDRATE_921600
-
 /** The maximum allowable dataset size */
 #define MAX_DATASET_SIZE        1024
 

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -143,14 +143,12 @@ typedef enum
     IS_BAUDRATE_115200          = 115200,       //  IMX-5.0,  uINS-3,  Actual baudrates                                             
     IS_BAUDRATE_230400          = 230400,       //   230547,  232700, 
     IS_BAUDRATE_460800          = 460800,       //   462428,  468600, 
-    IS_BAUDRATE_921600          = 921600,       //   930233,  937734,  (default baudrate)
-    IS_BAUDRATE_3200000_IMX5p0  = 3200000,      //  3200000  ( IMX-5 only)
-    IS_BAUDRATE_10000000_IMX5p0 = 10000000,     // 10000000  ( IMX-5 only)
-    IS_BAUDRATE_COUNT           = 10,
-
-    IS_BAUDRATE_3125000_UINS3   = 3125000,      //  3125000  (uINS-3 only)
-    IS_BAUDRATE_9375000_UINS3   = 9375000,      //  9375000  (uINS-3 only)
-    IS_BAUDRATE_18750000_UINS3  = 18750000,     // 18750000  (uINS-3 ser1 only)
+    IS_BAUDRATE_921600          = 921600,       //   930233,  937734,
+    IS_BAUDRATE_10000000        = 10000000,     // 10000000  ( IMX-5 only)
+    IS_BAUDRATE_COUNT           = 9,
+	IS_BAUDRATE_DEFAULT         = IS_BAUDRATE_921600,
+	IS_BAUDRATE_STANDARD_MAX    = IS_BAUDRATE_921600,
+	IS_BAUDRATE_MAX             = IS_BAUDRATE_10000000,
 } baud_rate_t;
 
 /** List of valid baud rates */

--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -318,8 +318,12 @@ extern void vPortFree(void* pv);
 #define _LIMIT2(x, xmin, xmax) { if ((x) < (xmin)) { (x) = (xmin); } else { if ((x) > (xmax)) { (x) = (xmax); } } }
 #endif
 
+#ifndef _ROUND_CLOSEST
+#define _ROUND_CLOSEST(dividend, divisor) (((dividend) + ((divisor)/2)) / (divisor))
+#endif
+
 #ifndef _ROUNDUP
-#define _ROUNDUP(numToRound, multiple) (((numToRound + multiple - 1) / multiple) * multiple)
+#define _ROUNDUP(numToRound, multiple) ((((numToRound) + (multiple) - 1) / (multiple)) * (multiple))
 #endif
 
 #ifndef _ISNAN

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -122,7 +122,7 @@ public:
 	* @param disableBroadcastsOnClose whether to send a stop broadcasts command to all units on Close
 	* @return true if opened, false if failure (i.e. baud rate is bad or port fails to open)
 	*/
-	bool Open(const char* port, int baudRate=IS_COM_BAUDRATE_DEFAULT, bool disableBroadcastsOnClose=false);
+	bool Open(const char* port, int baudRate=IS_BAUDRATE_DEFAULT, bool disableBroadcastsOnClose=false);
 
 	/**
 	* Check if the connection is open

--- a/src/cltool.cpp
+++ b/src/cltool.cpp
@@ -61,7 +61,7 @@ static bool matches(const char* str, const char* pre)
 	return lenstr != lenpre ? false : strncasecmp(pre, str, lenpre) == 0;
 }
 
-#define CL_DEFAULT_BAUD_RATE				IS_COM_BAUDRATE_DEFAULT 
+#define CL_DEFAULT_BAUD_RATE				IS_BAUDRATE_DEFAULT 
 #define CL_DEFAULT_COM_PORT					"*"
 #define CL_DEFAULT_DISPLAY_MODE				cInertialSenseDisplay::DMODE_PRETTY 
 #define CL_DEFAULT_LOG_TYPE					"dat"

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -1974,21 +1974,18 @@ uint32_t nmea_parse_ascb(int pHandle, const char msg[], int msgSize, rmci_t rmci
 	if(*ptr!=','){ tmp.gsv = (uint16_t)atoi(ptr);	}
 		
 	// Copy tmp to corresponding port(s)
-	switch (options&RMC_OPTIONS_PORT_MASK)
+	uint32_t ports = options&RMC_OPTIONS_PORT_MASK;
+	switch (ports)
 	{	
-	case 0xFF:	// All ports
-		for(int i=0; i<NUM_COM_PORTS; i++)
-		{
-			nmea_set_rmc_period_multiple(rmci[i], tmp);
-		}
-		break;
+	case RMC_OPTIONS_PORT_CURRENT:	nmea_set_rmc_period_multiple(rmci[pHandle], tmp); break;
+	case RMC_OPTIONS_PORT_ALL:		for(int i=0; i<NUM_COM_PORTS; i++) { nmea_set_rmc_period_multiple(rmci[i], tmp); } break;
 		
 	default:	// Current port
-	case RMC_OPTIONS_PORT_CURRENT:	nmea_set_rmc_period_multiple(rmci[pHandle], tmp);	break;
-	case RMC_OPTIONS_PORT_SER0:		nmea_set_rmc_period_multiple(rmci[0], tmp);			break;
-	case RMC_OPTIONS_PORT_SER1:		nmea_set_rmc_period_multiple(rmci[1], tmp);			break;
-	case RMC_OPTIONS_PORT_SER2:		nmea_set_rmc_period_multiple(rmci[2], tmp);			break;
-	case RMC_OPTIONS_PORT_USB:		nmea_set_rmc_period_multiple(rmci[3], tmp);			break;
+		if (ports & RMC_OPTIONS_PORT_SER0)	{ nmea_set_rmc_period_multiple(rmci[0], tmp); }
+		if (ports & RMC_OPTIONS_PORT_SER1)	{ nmea_set_rmc_period_multiple(rmci[1], tmp); }
+		if (ports & RMC_OPTIONS_PORT_SER2)	{ nmea_set_rmc_period_multiple(rmci[2], tmp); }
+		if (ports & RMC_OPTIONS_PORT_USB)	{ nmea_set_rmc_period_multiple(rmci[3], tmp); }
+		break;
 	}
 		
 	return options;
@@ -2039,21 +2036,17 @@ uint32_t nmea_parse_asce(int pHandle, const char msg[], int msgSize, rmci_t rmci
 	}
 
 	// Copy tmp to corresponding port(s)
-	switch (options&RMC_OPTIONS_PORT_MASK)
+	uint32_t ports = options&RMC_OPTIONS_PORT_MASK; 
+	switch (ports)
 	{	
-	case 0xFF:	// All ports
-		for(int i=0; i<NUM_COM_PORTS; i++)
-		{
-			nmea_set_rmc_period_multiple(rmci[i], tmp);
-		}
-		break;
-		
-	default:	// Current port
 	case RMC_OPTIONS_PORT_CURRENT:	nmea_set_rmc_period_multiple(rmci[pHandle], tmp);	break;
-	case RMC_OPTIONS_PORT_SER0:		nmea_set_rmc_period_multiple(rmci[0], tmp);			break;
-	case RMC_OPTIONS_PORT_SER1:		nmea_set_rmc_period_multiple(rmci[1], tmp);			break;
-	case RMC_OPTIONS_PORT_SER2:		nmea_set_rmc_period_multiple(rmci[2], tmp);			break;
-	case RMC_OPTIONS_PORT_USB:		nmea_set_rmc_period_multiple(rmci[3], tmp);			break;
+	case RMC_OPTIONS_PORT_ALL:		for(int i=0; i<NUM_COM_PORTS; i++) { nmea_set_rmc_period_multiple(rmci[i], tmp); } break;	
+	default:
+		if (ports & RMC_OPTIONS_PORT_SER0)	{ nmea_set_rmc_period_multiple(rmci[0], tmp); }
+		if (ports & RMC_OPTIONS_PORT_SER1)	{ nmea_set_rmc_period_multiple(rmci[1], tmp); }
+		if (ports & RMC_OPTIONS_PORT_SER2)	{ nmea_set_rmc_period_multiple(rmci[2], tmp); }
+		if (ports & RMC_OPTIONS_PORT_USB)	{ nmea_set_rmc_period_multiple(rmci[3], tmp); }
+		break;
 	}
 		
 	return options;


### PR DESCRIPTION
### FEATURES:
- (IMX) UART baudrate can now be set to arbitrary custom non-standard baudrates when greater than 921600 bps to improve compatibility with host UARTs.  When >921600 bps, the `DID_FLASH_CONFIG.serXBaudRate` parameter is automatically adjusted to the closest available baud rate in order to inform the user of the actual hardware baud rate.    
- (EvalTool, cltool, SDK) Serial port can now be set to custom non-standard baud rates above 921600 bps. 

### BUG FIXES:
- (IMX) Fixed non-standard high speed UART baud rates greater than 921600 bps.  Now supporting up to 10 Mbps on the IMX-5 UART. 
- (IMX) Fixed RMC options to set multiple ports besides RMC_OPTIONS_PORT_ALL and RMC_OPTIONS_PORT_CURRENT.