### PR TITLE
SN-4422 cltool flash cfg zeros seg fault

### DIFF
--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1560,7 +1560,7 @@ string cInertialSenseDisplay::DataToStringGeneric(const p_data_t* data)
 
 string cInertialSenseDisplay::DatasetToString(const p_data_t* data)
 {
-	if (m_editData.mapInfo == NULL)
+	if (m_editData.mapInfo == NULL || data->ptr == NULL)
 	{
 		return "";
 	}

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -557,8 +557,10 @@ static int inertialSenseMain()
         // Create InertialSense object, passing in data callback function pointer.
         InertialSense inertialSenseInterface(cltool_dataCallback);
 
-        // Disable device response requirement to validate open port
-        inertialSenseInterface.EnableDeviceValidation(false);
+        if (g_commandLineOptions.flashCfg.size() == 0)
+        {   // Disable device response requirement to validate open port
+            inertialSenseInterface.EnableDeviceValidation(false);
+        }
 
         // [C++ COMM INSTRUCTION] STEP 2: Open serial port
         if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose))

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -557,10 +557,10 @@ static int inertialSenseMain()
         // Create InertialSense object, passing in data callback function pointer.
         InertialSense inertialSenseInterface(cltool_dataCallback);
 
-        if (g_commandLineOptions.flashCfg.size() == 0)
-        {   // Disable device response requirement to validate open port
-            inertialSenseInterface.EnableDeviceValidation(false);
-        }
+        // Disable device response requirement to validate open port and flash config sync IF flash config is not needed
+        inertialSenseInterface.EnableDeviceValidation(
+            g_commandLineOptions.flashCfg.size() ||
+            g_commandLineOptions.evbFlashCfg.size() );
 
         // [C++ COMM INSTRUCTION] STEP 2: Open serial port
         if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose))


### PR DESCRIPTION
- (cltool) Fix issue where `cltool -flashCfg` returns all zeros because DID_FLASH_CONFIG had not been queried.  
- (cltool) Fixed seg fault in ISDisplay DataSetToString for uninitialized data pointer.