### PR TITLE
SN-3702 gps imx not passing rms

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -319,16 +319,16 @@ static protocol_type_t processIsbPkt(void* v)
 	// Payload
 	if (pkt->hdr.flags & ISB_FLAGS_PAYLOAD_W_OFFSET)
 	{	// Offset is first two bytes in payload  
-		pkt->data.size = _MAX(payloadSize-2, 0);
-		pkt->data.ptr  = (pkt->data.size ? payload+2 : NULL);
-		pkt->offset    = *((uint16_t*)payload);
-		// Data starts after offset if data size is non-zero
+		pkt->data.size     = _MAX(payloadSize-2, 0);
+		pkt->data.ptr      = (pkt->data.size ? payload+2 : NULL);	// Data starts after offset if data size is non-zero
+		pkt->offset        = *((uint16_t*)payload);
+		pkt->dataHdr.size  = pkt->data.size;		// rxPkt.hdr.payloadSize and rxPkt.dataHdr.size share same memory.  Remove offset size from payload/data size.
 	}
 	else
 	{	// No offset
-		pkt->data.size = payloadSize;
-		pkt->data.ptr  = (payloadSize ? payload : NULL);
-		pkt->offset    = 0;
+		pkt->data.size     = payloadSize;
+		pkt->data.ptr      = (payloadSize ? payload : NULL);
+		pkt->offset        = 0;
 	}
 
 	// Footer

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -2309,6 +2309,17 @@ enum eGnssSatSigConst
     GNSS_SAT_SIG_CONST_IME                              = (uint16_t)0x4000,
 
     /*! GNSS default */
+    GNSS_SAT_SIG_CONST_ALL = \
+        GNSS_SAT_SIG_CONST_GPS | \
+        GNSS_SAT_SIG_CONST_QZS | \
+        GNSS_SAT_SIG_CONST_GAL | \
+        GNSS_SAT_SIG_CONST_BDS | \
+        GNSS_SAT_SIG_CONST_GLO | \
+        GNSS_SAT_SIG_CONST_SBS | \
+        GNSS_SAT_SIG_CONST_IRN | \
+    	GNSS_SAT_SIG_CONST_IME,
+
+    /*! GNSS default */
     GNSS_SAT_SIG_CONST_DEFAULT = \
         GNSS_SAT_SIG_CONST_GPS | \
         GNSS_SAT_SIG_CONST_SBS | \


### PR DESCRIPTION
Fixed issue in ISComm where parsing packets that contain a data offset did not correct the size of the actual data in the header.   rxPkt.hdr.payloadSize and rxPkt.dataHdr.size share same memory in the packet through a union.  The packet full payload sized in contained in this value but needs to be reduced by 2 bytes if there is an offset so that it properly reflects the data size not included the offset.  This issue incorrectly caused two extra bytes to be written to the destination when the offset was non-zero.