### PR TITLE
Sn 4508 add ability to send fpk files

### DIFF
--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -385,7 +385,9 @@ int ISFirmwareUpdater::getImageFileDetails(std::string filename, size_t& filesiz
     {
         ifs.read((char *)buff, sizeof(buff));
         size_t len = ifs.gcount();
+
         hashMd5(len, buff);
+
         if (ifs.eof())
             filesize += len;
         else

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -14,7 +14,7 @@ bool ISFirmwareUpdater::setCommands(std::vector<std::string> cmds) {
     return true;
 }
 
-fwUpdate::update_status_e ISFirmwareUpdater::initializeUpdate(fwUpdate::target_t _target, const std::string &filename, int slot, bool forceUpdate, int chunkSize, int progressRate)
+fwUpdate::update_status_e ISFirmwareUpdater::initializeUpdate(fwUpdate::target_t _target, const std::string &filename, int slot, int flags, bool forceUpdate, int chunkSize, int progressRate)
 {
     srand(time(NULL)); // get *some kind* of seed/appearance of a random number.
 
@@ -26,7 +26,7 @@ fwUpdate::update_status_e ISFirmwareUpdater::initializeUpdate(fwUpdate::target_t
 
     updateStartTime = current_timeMs();
     nextStartAttempt = current_timeMs() + attemptInterval;
-    fwUpdate::update_status_e result = (fwUpdate_requestUpdate(_target, slot, chunkSize, fileSize, session_md5, progressRate) ? fwUpdate::NOT_STARTED : fwUpdate::ERR_UNKNOWN);
+    fwUpdate::update_status_e result = (fwUpdate_requestUpdate(_target, slot, flags, chunkSize, fileSize, session_md5, progressRate) ? fwUpdate::NOT_STARTED : fwUpdate::ERR_UNKNOWN);
     printf("Requested Firmware Update to device '%s' with Image '%s', md5: %08x-%08x-%08x-%08x\n", fwUpdate_getSessionTargetName(), filename.c_str(), session_md5[0], session_md5[1], session_md5[2], session_md5[3]);
     return result;
 }
@@ -49,7 +49,7 @@ bool ISFirmwareUpdater::fwUpdate_handleUpdateResponse(const fwUpdate::payload_t 
 
     switch (session_status) {
         case fwUpdate::ERR_MAX_CHUNK_SIZE:    // indicates that the maximum chunk size requested in the original upload request is too large.  The host is expected to begin a new session with a smaller chunk size.
-            return fwUpdate_requestUpdate(session_target, session_image_slot, session_chunk_size / 2, session_image_size, md5hash);
+            return fwUpdate_requestUpdate(session_target, session_image_slot, session_image_flags, session_chunk_size / 2, session_image_size, md5hash);
         case fwUpdate::ERR_INVALID_SESSION:   // indicates that the requested session ID is invalid.
         case fwUpdate::ERR_INVALID_SLOT:      // indicates that the request slot does not exist. Different targets have different number of slots which can be written to.
         case fwUpdate::ERR_NOT_ALLOWED:       // indicates that writing to the requested slot is not allowed, usually due to security constrains such as a locked firmware, Read-Only FLASH, etc.
@@ -245,7 +245,17 @@ void ISFirmwareUpdater::runCommand(std::string cmd) {
             progressRate = strtol(args[1].c_str(), nullptr, 10);
         } else if ((args[0] == "upload") && (args.size() == 2)) {
             filename = args[1];
-            fwUpdate::update_status_e status = initializeUpdate(target, filename, slotNum, forceUpdate, chunkSize, progressRate);
+
+            // check if any flags should be set
+            uint8_t flags = 0;
+
+            // TODO move this to it's own function before we expand this any father
+            // check for non encrypted file CXD update slot 4 or slot 2 if .fpk
+            if((target == fwUpdate::TARGET_SONY_CXD5610__1 || target == fwUpdate::TARGET_SONY_CXD5610__2) && (slotNum == 4 || (slotNum == 2 && filename.substr(filename.find_last_of(".") + 1) == "fpk")))
+                flags |= fwUpdate::image_flags_imageNotEncrypted;
+
+            fwUpdate::update_status_e status = initializeUpdate(target, filename, slotNum, flags, forceUpdate, chunkSize, progressRate);
+
             if (status < fwUpdate::NOT_STARTED) {
                 // there was an error -- probably should flush the command queue
                 printf("Error initiating Firmware upload: [%s] %s\n", filename.c_str(), fwUpdate_getStatusName(status));

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -71,7 +71,7 @@ public:
     bool hasPendingCommands() { return !commands.empty(); }
     void clearAllCommands() { commands.clear(); }
 
-    fwUpdate::update_status_e initializeUpdate(fwUpdate::target_t _target, const std::string& filename, int slot = 0, bool forceUpdate = false, int chunkSize = 2048, int progressRate = 500);
+    fwUpdate::update_status_e initializeUpdate(fwUpdate::target_t _target, const std::string& filename, int slot = 0, int flags = 0, bool forceUpdate = false, int chunkSize = 2048, int progressRate = 500);
 
     /**
      * @param offset the offset into the image file to pull data from
@@ -108,7 +108,6 @@ public:
     virtual fwUpdate::msg_types_e fwUpdate_step() override;
 
     bool fwUpdate_writeToWire(fwUpdate::target_t target, uint8_t* buffer, int buff_len) override;
-
 
     /**
      * Firmware Package Support -- Firmware packages are zip files with a YAML-based manifest, which describes the devices, images, and related metadata necessary to update multiple devices

--- a/src/protocol/FirmwareUpdate.cpp
+++ b/src/protocol/FirmwareUpdate.cpp
@@ -338,6 +338,10 @@ namespace fwUpdate {
         //append "0" bit until message length in bit ≡ 448 (mod 512)
         //append length mod (2 pow 64) to message
 
+        // If data has not length return
+        if (data_len == 0)
+            return (uint8_t*)&md5hash[0];
+
         int new_len = ((((data_len + 8) / 64) + 1) * 64) - 8;
 
         msg = static_cast<uint8_t *>(calloc(new_len + 64, 1)); // also appends "0" bits
@@ -398,10 +402,6 @@ namespace fwUpdate {
 
         // cleanup
         free(msg);
-
-        //debug
-        //Md5Cnt++;
-        //printf("%d:{%x,%x,%x,%x}\r\n",TonyMd5Cnt, md5hash[0], md5hash[1], md5hash[2], md5hash[3]);
 
         return (uint8_t *)&md5hash[0];
     }

--- a/src/protocol/FirmwareUpdate.cpp
+++ b/src/protocol/FirmwareUpdate.cpp
@@ -615,6 +615,7 @@ namespace fwUpdate {
 
         if (session_status > NOT_STARTED) {
             session_image_slot = payload.data.req_update.image_slot;
+            session_image_flags = payload.data.req_update.image_flags;
             session_total_chunks = (uint16_t) ceil((float)session_image_size / (float)session_chunk_size);
             session_md5[0] = payload.data.req_update.md5_hash[0];
             session_md5[1] = payload.data.req_update.md5_hash[1];
@@ -676,7 +677,7 @@ namespace fwUpdate {
         if (last_chunk_id >= (session_total_chunks-1)) { // remember, chunk_ids are 0-based
             fwUpdate_sendProgress(); // force sending of a final progress message (which should report 100% complete)
 
-            session_status = (memcmp(session_md5, md5hash, sizeof(md5hash)) != 0) ? ERR_CHECKSUM_MISMATCH : fwUpdate_finishUpdate(session_target, session_image_slot);
+            session_status = (memcmp(session_md5, md5hash, sizeof(md5hash)) != 0) ? ERR_CHECKSUM_MISMATCH : fwUpdate_finishUpdate(session_target, session_image_slot, session_image_flags);
             if (session_status != fwUpdate::FINALIZING)
                 fwUpdate_sendDone(session_status, false, false);
         }
@@ -778,7 +779,7 @@ namespace fwUpdate {
      * @param chunk_size
      * @return
      */
-    bool FirmwareUpdateHost::fwUpdate_requestUpdate(target_t target_id, int image_slot, uint16_t chunk_size, uint32_t image_size, uint32_t image_md5[4], int32_t progress_rate) {
+    bool FirmwareUpdateHost::fwUpdate_requestUpdate(target_t target_id, int image_slot, int image_flags, uint16_t chunk_size, uint32_t image_size, uint32_t image_md5[4], int32_t progress_rate) {
 
         // FIXME:  Should probably check to see if an update is already in progress, and attempt to finish it first?
         fwUpdate_resetEngine();
@@ -795,6 +796,7 @@ namespace fwUpdate {
         request.hdr.msg_type = fwUpdate::MSG_REQ_UPDATE;
         request.data.req_update.session_id = session_id;
         request.data.req_update.image_slot = session_image_slot = image_slot;
+        request.data.req_update.image_flags = session_image_flags = image_flags;
         request.data.req_update.chunk_size = session_chunk_size = chunk_size;
         request.data.req_update.file_size = session_image_size = image_size;
         request.data.req_update.progress_rate = progress_rate;
@@ -816,6 +818,7 @@ namespace fwUpdate {
         request.hdr.msg_type = fwUpdate::MSG_REQ_UPDATE;
         request.data.req_update.session_id = session_id;
         request.data.req_update.image_slot = session_image_slot;
+        request.data.req_update.image_flags = session_image_flags;
         request.data.req_update.chunk_size = session_chunk_size;
         request.data.req_update.file_size = session_image_size;
         request.data.req_update.md5_hash[0] = session_md5[0];

--- a/src/test/test_ISFirmwareUpdate.cpp
+++ b/src/test/test_ISFirmwareUpdate.cpp
@@ -204,7 +204,7 @@ public:
     }
 
     // this marks the finish of the upgrade, that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization
-    fwUpdate::update_status_e  fwUpdate_finishUpdate(fwUpdate::target_t target_id, int slot_id) {
+    fwUpdate::update_status_e  fwUpdate_finishUpdate(fwUpdate::target_t target_id, int slot_id, int flags) {
         uint32_t hash[4];
         // check that our md5 matches.  Return >0 is we're error free.
         getCurrentMd5(hash);
@@ -659,7 +659,7 @@ TEST(ISFirmwareUpdate, exchange__req_update_repl)
     fuDev.sendProgressUpdates = false;
 
     // Make the request to the device
-    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, 1024,1234567, fake_md5);
+    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, 0, 1024,1234567, fake_md5);
 
     fuDev.pullAndProcessNextMessage();
 
@@ -702,7 +702,7 @@ TEST(ISFirmwareUpdate, exchange__req_resend)
 #endif
     int imageSize = fuSDK.MaxChunkSize * 8;
     fuSDK.calcChecksumForTest(imageSize, fuSDK.MaxChunkSize, real_md5);
-    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, fuSDK.MaxChunkSize, imageSize, real_md5);
+    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, 0, fuSDK.MaxChunkSize, imageSize, real_md5);
 
     fuDev.pullAndProcessNextMessage(); // make sure the device-side processes it...
     fuSDK.fwUpdate_step(); // advance Host, to process the Device response
@@ -781,7 +781,7 @@ TEST(ISFirmwareUpdate, exchange__invalid_checksum)
     PRINTF("Requesting firmware update of remote device (should send 8 chunks total (Ids 0-7)...\n");
     int imageSize = fuSDK.MaxChunkSize * 8;
     fuSDK.calcChecksumForTest(imageSize, fuSDK.MaxChunkSize, real_md5);
-    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, fuSDK.MaxChunkSize, imageSize, fake_md5);
+    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, 0, fuSDK.MaxChunkSize, imageSize, fake_md5);
 
     fuDev.pullAndProcessNextMessage(); // advance Device, to process the request and send the response
     fuSDK.fwUpdate_step(); // advance Host, to process the Device response
@@ -838,7 +838,7 @@ TEST(ISFirmwareUpdate, exchange__success)
     PRINTF("Requesting firmware update of remote device (should send 8 chunks total (Ids 0-7)...\n");
     int imageSize = fuSDK.MaxChunkSize * 8;
     fuSDK.calcChecksumForTest(imageSize, fuSDK.MaxChunkSize, real_md5);
-    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, fuSDK.MaxChunkSize, imageSize, real_md5);
+    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, 0, fuSDK.MaxChunkSize, imageSize, real_md5);
 
     fuDev.pullAndProcessNextMessage();
     fuSDK.fwUpdate_step(); // advance Host, to process the Device response
@@ -884,7 +884,7 @@ TEST(ISFirmwareUpdate, exchange__success_non_chunk_boundary)
     PRINTF("Requesting firmware update of remote device (should send 8 chunks total (Ids 0-7)...\n");
     int imageSize = fuSDK.MaxChunkSize * 8.5;
     fuSDK.calcChecksumForTest(imageSize, fuSDK.MaxChunkSize, real_md5);
-    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, fuSDK.MaxChunkSize, imageSize, real_md5);
+    fuSDK.fwUpdate_requestUpdate(fwUpdate::TARGET_IMX5, 0, 0, fuSDK.MaxChunkSize, imageSize, real_md5);
 
     fuDev.pullAndProcessNextMessage();
     fuSDK.fwUpdate_step(); // advance Host, to process the Device response


### PR DESCRIPTION
Adds the ability to use .fpk file extensions while updating GPX GNSS receivers.
Fixes bug with checksum where 0 length data would cause an invalid checksum.