### PR TITLE
More complete fix to prevent serial write() from blocking indefinitely.

### DIFF
--- a/src/cltool.cpp
+++ b/src/cltool.cpp
@@ -63,7 +63,7 @@ static bool matches(const char* str, const char* pre)
 
 #define CL_DEFAULT_BAUD_RATE				IS_BAUDRATE_DEFAULT 
 #define CL_DEFAULT_COM_PORT					"*"
-#define CL_DEFAULT_DISPLAY_MODE				cInertialSenseDisplay::DMODE_QUIET 
+#define CL_DEFAULT_DISPLAY_MODE				cInertialSenseDisplay::DMODE_SCROLL
 #define CL_DEFAULT_LOG_TYPE					"dat"
 #define CL_DEFAULT_LOGS_DIRECTORY			DEFAULT_LOGS_DIRECTORY
 #define CL_DEFAULT_ENABLE_LOGGING			false 

--- a/src/serialPort.h
+++ b/src/serialPort.h
@@ -69,7 +69,10 @@ struct serial_port_t
 	// the port name (do not modify directly)
 	char port[MAX_SERIAL_PORT_NAME_LENGTH + 1];
 
-	// optional error buffer to store errors
+    // latest errno that was reported from an operation on this port
+    int errorCode;
+
+    // optional error buffer to store errors
 	char* error;
 
 	// length of error


### PR DESCRIPTION
Additional checking, validation and reporting on serialPortPlatform.c.
Invalid or errant devices which fail a basic read() test will be closed immediately (inside call to serialPortPlatformOpen).
Additional check in InertialSense.cpp will remove discovered devices if they also fail a write() test.
Note, this is purely an SDK improvement, but still need an IMX PR for the SDK bump to be ran through CI-HDW checks.