### PR TITLE
Bugfix/imx bootloader

### DIFF
--- a/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
+++ b/EVB-2/IS_EVB-2/IS_EVB-2.cppproj
@@ -505,7 +505,7 @@
       </framework-data>
     </AsfFrameworkConfig>
     <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
-    <avrtoolserialnumber>J41800082852</avrtoolserialnumber>
+    <avrtoolserialnumber>J41800098687</avrtoolserialnumber>
     <avrdeviceexpectedsignature>0xA1020C01</avrdeviceexpectedsignature>
     <avrtoolinterface>SWD</avrtoolinterface>
     <com_atmel_avrdbg_tool_edbg>
@@ -540,7 +540,7 @@
         <InterfaceName>SWD</InterfaceName>
       </ToolOptions>
       <ToolType>com.atmel.avrdbg.tool.atmelice</ToolType>
-      <ToolNumber>J41800082852</ToolNumber>
+      <ToolNumber>J41800098687</ToolNumber>
       <ToolName>Atmel-ICE</ToolName>
     </com_atmel_avrdbg_tool_atmelice>
     <com_atmel_avrdbg_tool_samice>

--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -632,13 +632,26 @@ void handle_data_from_host(is_comm_instance_t *comm, protocol_type_t ptype, uint
 				g_status.evbStatus |= EVB_STATUS_MANF_UNLOCKED;
 				break;
 
-			case SYS_CMD_MANF_CHIP_ERASE:			// chip erase and reboot - do NOT reset calibration!
+			case SYS_CMD_MANF_ENABLE_ROM_BOOTLOADER:	// reboot into ROM bootloader mode
+				if(manfUnlock)
+				{
+					// Set "stay_in_bootloader" signature to require app firmware update following bootloader update.
+					write_bootloader_signature_stay_in_bootloader_mode();   
+
+					BEGIN_CRITICAL_SECTION
+					flash_rom_bootloader();
+					while(1);
+					END_CRITICAL_SECTION
+				}
+				break;
+
+			case SYS_CMD_MANF_CHIP_ERASE:		            // chip erase and reboot
 				if(manfUnlock)
 				{
 					BEGIN_CRITICAL_SECTION
-					
-					// erase chip
 					flash_erase_chip();
+					while(1);
+					END_CRITICAL_SECTION
 				}
 				break;
 			}

--- a/hw-libs/bootloader/bootloaderApp.c
+++ b/hw-libs/bootloader/bootloaderApp.c
@@ -161,4 +161,3 @@ void enable_bootloader_assistant(void)
     soft_reset_backup_register(SYS_FAULT_STATUS_ENABLE_BOOTLOADER);
 }
 
-

--- a/hw-libs/bootloader/bootloaderApp.c
+++ b/hw-libs/bootloader/bootloaderApp.c
@@ -104,14 +104,12 @@ void set_reset_pin_enabled(int enabled)
 
 }
 
-
-void enable_bootloader(int pHandle)
+void write_bootloader_signature_stay_in_bootloader_mode(void)
 {	
     // update the bootloader header jump signature to indicate we want to go to bootloader
     bootloader_header_t header;
     memcpy(&header, (void*)BOOTLOADER_FLASH_BOOTLOADER_HEADER_ADDRESS, BOOTLOADER_FLASH_BOOTLOADER_HEADER_SIZE);
     strncpy(header.data.jumpSignature, BOOTLOADER_JUMP_SIGNATURE_STAY_IN_BOOTLOADER, sizeof(header.data.jumpSignature));
-
 
 #ifndef IMX_5
     // unlock bootloader header 
@@ -125,7 +123,12 @@ void enable_bootloader(int pHandle)
 #else
 	flash_write(BOOTLOADER_FLASH_BOOTLOADER_HEADER_ADDRESS, &header, BOOTLOADER_FLASH_BOOTLOADER_HEADER_SIZE, 0);
 #endif
-    
+}
+
+void enable_bootloader(int pHandle)
+{	
+    write_bootloader_signature_stay_in_bootloader_mode();
+
 	// Let the bootloader know which port to use for the firmware update.  Set key and port number.
 #ifndef IMX_5
     GPBR->SYS_GPBR[3] = PORT_SEL_KEY_SYS_GPBR_3;

--- a/hw-libs/bootloader/bootloaderApp.h
+++ b/hw-libs/bootloader/bootloaderApp.h
@@ -22,6 +22,7 @@ void unlockUserFlash(void);
 void soft_reset_no_backup_register(void); // soft reset without setting backup register
 void soft_reset_backup_register(uint32_t key); // soft reset and set backup register to a value
 void set_reset_pin_enabled(int enabled); // enabled is 0 or 1
+void write_bootloader_signature_stay_in_bootloader_mode(void);
 void enable_bootloader(int pHandle);
 void enable_bootloader_assistant(void);
 

--- a/hw-libs/bootloader/bootloaderApp.h
+++ b/hw-libs/bootloader/bootloaderApp.h
@@ -26,7 +26,6 @@ void write_bootloader_signature_stay_in_bootloader_mode(void);
 void enable_bootloader(int pHandle);
 void enable_bootloader_assistant(void);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/hw-libs/drivers/SAMx70/d_flash.h
+++ b/hw-libs/drivers/SAMx70/d_flash.h
@@ -35,6 +35,9 @@ uint32_t flash_update_block(uint32_t address, const void* newData, int dataSize,
 // erase the flash block at the 8K aligned address
 uint32_t flash_erase_block(uint32_t address);
 
+// Reboot into SAM-BA (ROM bootloader) - Since it is a RAM function, it needs 'extern' declaration.
+extern void flash_rom_bootloader(void);
+
 // Erase chip - Since it is a RAM function, it needs 'extern' declaration.
 extern void flash_erase_chip(void);
 

--- a/src/ISBootloaderISB.cpp
+++ b/src/ISBootloaderISB.cpp
@@ -137,7 +137,7 @@ is_operation_result cISBootloaderISB::reboot_up()
     // send the "reboot to program mode" command and the device should start in program mode
     serialPortWrite(m_port, (unsigned char*)":020000040300F7", 15);
     serialPortFlush(m_port);
-    SLEEP_MS(1000);
+    SLEEP_MS(100);
     serialPortClose(m_port);
     return IS_OP_OK;
 }
@@ -165,7 +165,7 @@ is_operation_result cISBootloaderISB::reboot_down(uint8_t major, char minor, boo
 
     SNPRINTF(message+n, sizeof(message)-n, "Update needed...");
     m_info_callback(this, message, IS_LOG_LEVEL_INFO);
-    m_info_callback(this, "(ISB) Rebooting to DFU/SAM-BA mode...", IS_LOG_LEVEL_INFO);
+    m_info_callback(this, "(ISB) Rebooting to ROM bootloader mode...", IS_LOG_LEVEL_INFO);
 
     // USE WITH CAUTION! This will put in bootloader ROM mode allowing a new bootloader to be put on
     // In some cases, the device may become unrecoverable because of interference on its ports.

--- a/src/ISBootloaderThread.cpp
+++ b/src/ISBootloaderThread.cpp
@@ -708,7 +708,7 @@ is_operation_result cISBootloaderThread::update(
     m_timeStart = current_timeMs();
 
     ////////////////////////////////////////////////////////////////////////////
-    // Run `mode_thread_serial_isb` to put all ISB devices into DFU/SAM-BA mode
+    // Run `mode_thread_serial_isb` to put all ISB devices into ROM bootloader mode
     ////////////////////////////////////////////////////////////////////////////
 
     while(m_continue_update && !true_if_cancelled())

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1384,6 +1384,7 @@ enum eSystemCommand
     SYS_CMD_MANF_FACTORY_RESET                          = 1357924680,   // (uint32 inv: 2937042615) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
     SYS_CMD_MANF_CHIP_ERASE                             = 1357924681,   // (uint32 inv: 2937042614) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
     SYS_CMD_MANF_DOWNGRADE_CALIBRATION                  = 1357924682,   // (uint32 inv: 2937042613) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
+    SYS_CMD_MANF_REBOOT_DOWN_ROM_BOOTLOADER             = 1357924683,   // (uint32 inv: 2937042612) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
 };
 
 enum eSerialPortBridge

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1384,7 +1384,7 @@ enum eSystemCommand
     SYS_CMD_MANF_FACTORY_RESET                          = 1357924680,   // (uint32 inv: 2937042615) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
     SYS_CMD_MANF_CHIP_ERASE                             = 1357924681,   // (uint32 inv: 2937042614) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
     SYS_CMD_MANF_DOWNGRADE_CALIBRATION                  = 1357924682,   // (uint32 inv: 2937042613) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
-    SYS_CMD_MANF_REBOOT_DOWN_ROM_BOOTLOADER             = 1357924683,   // (uint32 inv: 2937042612) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
+    SYS_CMD_MANF_ENABLE_ROM_BOOTLOADER                  = 1357924683,   // (uint32 inv: 2937042612) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
 };
 
 enum eSerialPortBridge

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1382,9 +1382,9 @@ enum eSystemCommand
     SYS_CMD_SOFTWARE_RESET                              = 99,           // (uint32 inv: 4294967196)
     SYS_CMD_MANF_UNLOCK                                 = 1122334455,   // (uint32 inv: 3172632840)
     SYS_CMD_MANF_FACTORY_RESET                          = 1357924680,   // (uint32 inv: 2937042615) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
-    SYS_CMD_MANF_CHIP_ERASE                             = 1357924681,   // (uint32 inv: 2937042614) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
+    SYS_CMD_MANF_CHIP_ERASE                             = 1357924681,   // (uint32 inv: 2937042614) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.  A device power cycle may be necessary to complete this command.
     SYS_CMD_MANF_DOWNGRADE_CALIBRATION                  = 1357924682,   // (uint32 inv: 2937042613) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
-    SYS_CMD_MANF_ENABLE_ROM_BOOTLOADER                  = 1357924683,   // (uint32 inv: 2937042612) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
+    SYS_CMD_MANF_ENABLE_ROM_BOOTLOADER                  = 1357924683,   // (uint32 inv: 2937042612) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.  A device power cycle may be necessary to complete this command.
 };
 
 enum eSerialPortBridge

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -1461,6 +1461,10 @@ int getNmeaMsgId(const void *msg, int msgSize)
 		if      (UINT32_MATCH(talker,"BLEN"))       { return NMEA_MSG_ID_BLEN; }
 		break;
 
+	case 'E':
+		if      (UINT32_MATCH(talker,"EBLE"))       { return NMEA_MSG_ID_EBLE; }
+		break;
+
 	case 'G':
 		if      (UINT32_MATCH(talker+2,"GGA,"))     { return NMEA_MSG_ID_GxGGA; }
 		else if (UINT32_MATCH(talker+2,"GLL,"))     { return NMEA_MSG_ID_GxGLL; }


### PR DESCRIPTION
- Created SYS_CMD_MANF_ENABLE_ROM_BOOTLOADER as a separate command, keeping SYS_CMD_MANF_CHIP_ERASE.  
- Converts the chip erase pin to a boot mode pin. 