### PR TITLE
SN-4676 Addresses device discover of v2 protocol devices, particularly for cltool.

### DIFF
--- a/ExampleProjects/IS_firmwareUpdate_v2/ISFirmwareUpdateExample_v2.cpp
+++ b/ExampleProjects/IS_firmwareUpdate_v2/ISFirmwareUpdateExample_v2.cpp
@@ -247,9 +247,6 @@ int main(int argc, char* argv[])
     // Create InertialSense object, passing in data callback function pointer.
     InertialSense inertialSenseInterface(NULL);
 
-    // Disable device response requirement to validate open port
-    inertialSenseInterface.EnableDeviceValidation(false);
-
     // [C++ COMM INSTRUCTION] STEP 2: Open serial port
     if (!inertialSenseInterface.Open(COMNum.c_str(), baudRate, true))
     {

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -899,7 +899,7 @@ bool InertialSense::BroadcastBinaryData(uint32_t dataId, int periodMultiple, pfn
         {
             // [C COMM INSTRUCTION]  3.) Request a specific data set from the uINS.  "periodMultiple" specifies the interval
             // between broadcasts and "periodMultiple=0" will disable broadcasts and transmit one single message.
-            if (m_comManagerState.devices[i].devInfo.protocolVer[0] == 2) {
+            if (m_comManagerState.devices[i].devInfo.protocolVer[0] == PROTOCOL_VERSION_CHAR0) {
                 comManagerGetData(i, dataId, 0, 0, periodMultiple);
             }
         }

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -173,7 +173,7 @@ void InertialSense::DisableLogging()
     m_logger.CloseAllFiles();
 }
 
-bool InertialSense::HasReceivedResponseFromDevice(size_t index)
+bool InertialSense::HasReceivedDeviceInfo(size_t index)
 {
     if (index >= m_comManagerState.devices.size())
     {
@@ -181,12 +181,11 @@ bool InertialSense::HasReceivedResponseFromDevice(size_t index)
     }
 
     return (
-            m_comManagerState.devices[index].flashCfg.size != 0 &&
             m_comManagerState.devices[index].devInfo.serialNumber != 0 &&
             m_comManagerState.devices[index].devInfo.manufacturer[0] != 0);
 }
 
-bool InertialSense::HasReceivedResponseFromAllDevices()
+bool InertialSense::HasReceivedDeviceInfoFromAllDevices()
 {
     if (m_comManagerState.devices.size() == 0)
     {
@@ -195,7 +194,7 @@ bool InertialSense::HasReceivedResponseFromAllDevices()
 
     for (size_t i = 0; i < m_comManagerState.devices.size(); i++)
     {
-        if (!HasReceivedResponseFromDevice(i))
+        if (!HasReceivedDeviceInfo(i))
         {
             return false;
         }
@@ -900,7 +899,9 @@ bool InertialSense::BroadcastBinaryData(uint32_t dataId, int periodMultiple, pfn
         {
             // [C COMM INSTRUCTION]  3.) Request a specific data set from the uINS.  "periodMultiple" specifies the interval
             // between broadcasts and "periodMultiple=0" will disable broadcasts and transmit one single message.
-            comManagerGetData(i, dataId, 0, 0, periodMultiple);
+            if (m_comManagerState.devices[i].devInfo.protocolVer[0] == 2) {
+                comManagerGetData(i, dataId, 0, 0, periodMultiple);
+            }
         }
     }
     return true;
@@ -1278,6 +1279,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
     // handle wildcard, auto-detect serial ports
     if (port[0] == '*')
     {
+        m_enableDeviceValidation = true; // always use device-validation when given the 'all ports' wildcard.
         cISSerialPort::GetComPorts(ports);
         if (port[1] != '\0')
         {
@@ -1332,7 +1334,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
         bool removedSerials = false;
 
 		// Query devices with 10 second timeout
-		while (!HasReceivedResponseFromAllDevices() && (time(0) - startTime < 10))
+		while (!HasReceivedDeviceInfoFromAllDevices() && (time(0) - startTime < 10))
 		{
 			for (size_t i = 0; i < m_comManagerState.devices.size(); i++)
 			{
@@ -1343,13 +1345,6 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
                     RemoveDevice(i);
                     removedSerials = true, i--;
                 }
-                else
-                {
-                    // comManagerGetData((int)i, DID_DEV_INFO,         0, 0, 0);
-                    comManagerGetData((int) i, DID_SYS_CMD, 0, 0, 0);
-                    comManagerGetData((int) i, DID_FLASH_CONFIG, 0, 0, 0);
-                    comManagerGetData((int) i, DID_EVB_FLASH_CFG, 0, 0, 0);
-                }
 			}
 
 			SLEEP_MS(100);
@@ -1359,10 +1354,10 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
 		// remove each failed device where communications were not received
 		for (int i = ((int)m_comManagerState.devices.size() - 1); i >= 0; i--)
 		{
-			if (!HasReceivedResponseFromDevice(i))
+			if (!HasReceivedDeviceInfo(i))
 			{
 				RemoveDevice(i);
-				removedSerials = true, i--;
+				removedSerials = true;
 			}
 		}
 
@@ -1387,6 +1382,16 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
 			comManagerSetCallbacks(m_handlerRmc, staticProcessRxNmea, m_handlerUblox, m_handlerRtcm3, m_handlerSpartn);
 		}
 	}
+
+    // request extended device info for remaining connected devices...
+    for (int i = ((int)m_comManagerState.devices.size() - 1); i >= 0; i--) {
+        // but only if they are of a compatible protocol version
+        if (m_comManagerState.devices[i].devInfo.protocolVer[0] == PROTOCOL_VERSION_CHAR0) {
+            comManagerGetData((int) i, DID_SYS_CMD, 0, 0, 0);
+            comManagerGetData((int) i, DID_FLASH_CONFIG, 0, 0, 0);
+            comManagerGetData((int) i, DID_EVB_FLASH_CFG, 0, 0, 0);
+        }
+    }
 
     return m_comManagerState.devices.size() != 0;
 }

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -564,8 +564,8 @@ private:
     bool UpdateClient();
     bool EnableLogging(const std::string& path, cISLogger::eLogType logType, float maxDiskSpacePercent, uint32_t maxFileSize, const std::string& subFolder);
     void DisableLogging();
-    bool HasReceivedResponseFromDevice(size_t index);
-    bool HasReceivedResponseFromAllDevices();
+    bool HasReceivedDeviceInfo(size_t index);
+    bool HasReceivedDeviceInfoFromAllDevices();
     void RemoveDevice(size_t index);
     bool OpenSerialPorts(const char* port, int baudRate);
     void CloseSerialPorts();

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -147,6 +147,19 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         return true;
     }
 
+    // check for any compatible (procotol version 2) devices
+    for (int i = inertialSenseInterface.DeviceCount() - 1; i >= 0; i--) {
+        if (inertialSenseInterface.DeviceInfo(i).protocolVer[0] != PROTOCOL_VERSION_CHAR0) {
+            printf("ERROR: One or more connected devices are using an incompatible protocol version (requires %d.x.x.x).\n", PROTOCOL_VERSION_CHAR0);
+            // let's print the dev info for all connected devices (so the user can identify the errant device)
+            for (int i = inertialSenseInterface.DeviceCount() - 1; i >= 0; i--) {
+                std::string devInfo = g_inertialSenseDisplay.DataToStringDevInfo(inertialSenseInterface.DeviceInfo(i), true);
+                printf("%s\n", devInfo.c_str());
+            }
+            return false;
+        }
+    }
+
     // ask for device info every 2 seconds
     inertialSenseInterface.BroadcastBinaryData(DID_DEV_INFO, 2000);
 
@@ -561,11 +574,6 @@ static int inertialSenseMain()
         // [C++ COMM INSTRUCTION] STEP 1: Instantiate InertialSense Class
         // Create InertialSense object, passing in data callback function pointer.
         InertialSense inertialSenseInterface(cltool_dataCallback);
-
-        // Disable device response requirement to validate open port and flash config sync IF flash config is not needed
-        inertialSenseInterface.EnableDeviceValidation(
-            g_commandLineOptions.flashCfg.size() ||
-            g_commandLineOptions.evbFlashCfg.size() );
 
         // [C++ COMM INSTRUCTION] STEP 2: Open serial port
         if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose))

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -569,8 +569,9 @@ static int serialPortReadTimeoutPlatformLinux(serialPortHandle* handle, unsigned
             int pollrc = poll(fds, 1, timeoutMilliseconds);
             if (pollrc <= 0 || !(fds[0].revents & POLLIN))
             {
-                if ((pollrc < 0) && (fds[0].revents & POLLERR))
+                if (fds[0].revents & POLLERR) {
                     return -1; // more than a timeout occurred.
+                }
                 break;
             }
         }
@@ -586,6 +587,7 @@ static int serialPortReadTimeoutPlatformLinux(serialPortHandle* handle, unsigned
         {
             totalRead += n;
         }
+
         if (timeoutMilliseconds > 0 && totalRead < readCount)
         {
             gettimeofday(&curr, NULL);


### PR DESCRIPTION
Identified an issue, primarily in the cltool, in which it would require a binary response from connected devices, before sending the $info query for device info. This would prevent the device from initializing correctly, and thus identifying the device. 

I modified the requirements for “device validation”, which ONLY relies on dev_info_t being populated (requested via $info).  Once validated, additional requests are made for the flash config, etc.  In addition, extra validation is performed, with improved reporting from the cltool if discovered devices are not COMPATIBLE with the current protocol version (2).  In this instance, cltool will report the error and the DEVINFO for all discovered devices (so the user can see which devices are compatible).

Note that the way devices are currently handled by the InertialSense class, there is an assumption that if one devices supports protocol X, then all devices support protocol X.  We will need to address this in the future, but not today.