### PR TITLE
Refactor sdk cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ x64
 Release/
 Debug/
 IS_logs/
+CMakeFiles/
 
 *.autosave
 *.elf
@@ -21,5 +22,9 @@ IS_logs/
 .vs
 .vscode
 
-cmake-build-debug
 .idea
+cmake-build-debug
+Makefile
+CMakeCache.txt
+cmake_install.cmake
+libInertialSenseSDK.a

--- a/CMakeCommon.txt
+++ b/CMakeCommon.txt
@@ -42,7 +42,7 @@ if(BUILD_INERTIAL_SENSE_SDK AND NOT BUILD_LIB)
 	add_executable(${PROJECT_NAME} ${SOURCES_PROJECT})
 	
 	# Link the sdk lib
-	target_link_libraries(${PROJECT_NAME} InertialSense)
+	target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
 	
 	if(PROJECT_LIBS)
 		target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 # Other settings
 if(WIN32)
+	# yamlcpp needs to know it's a static lib
+	add_definitions(-DYAML_CPP_STATIC_DEFINE)
+
 	# Windows specific include dir
 	target_include_directories(${PROJECT_NAME} PUBLIC
 		${CMAKE_CURRENT_LIST_DIR}/src/libusb/msvc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,40 +1,82 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
-project(InertialSense)
+project(InertialSenseSDK)
 
-# Required: set PROJECT_NAME to the same name as project in case of a multi-file build
-set(PROJECT_NAME "InertialSense")
+file(GLOB SOURCES_SDK
+	"src/*.c"
+	"src/*.cpp"
+	"src/*.h"
+    "src/protocol/*.cpp"
+    "src/protocol/*.h"
+    "src/util/*.cpp"
+    "src/util/*.h"
+	"hw-libs/bootloader/bootloaderShared.c"
+	"src/yaml-cpp/*.cpp"
+	"src/yaml-cpp/*.h"
+	"src/yaml-cpp/contrib/*.cpp"
+	"src/yaml-cpp/contrib/*.h"
+	"src/yaml-cpp/node/*.cpp"
+	"src/yaml-cpp/node/*.h"
+)
 
-# Required: set the PROJECT_DIR to let the common cmake file know where this project lives
-set(PROJECT_DIR "${CMAKE_CURRENT_LIST_DIR}")
+# Compile libusb from source
+if(WIN32)
+	file(GLOB SOURCES_LIB_USB
+		"src/libusb/libusb/*.h"
+		"src/libusb/libusb/*.c"
+		"src/libusb/libusb/os/*windows*"
+	)
+else()
+	file(GLOB SOURCES_LIB_USB
+		"src/libusb/libusb/*.h"
+		"src/libusb/libusb/*.c"
+		"src/libusb/libusb/os/*linux*"
+		"src/libusb/libusb/os/*posix*"
+	)
+endif()
 
-# We will be building the SDK as a static library
-set(BUILD_LIB 1)
+# Ignore bootloader files
+# list(FILTER SOURCES_SDK EXCLUDE REGEX "ISBootloader.*")
+list(FILTER SOURCES_SDK EXCLUDE REGEX "ISBootloaderSony.*")
+list(FILTER SOURCES_SDK EXCLUDE REGEX "ISBootloaderSTM32.*")
 
-# Custom definitions
-add_definitions(-DRTK_EMBEDDED)
+list(APPEND SOURCES_SDK ${SOURCES_LIB_USB})
 
-# Required: set SOURCES_PROJECT, since we are the SDK, we don't need any files, but we add one to keep cmake happy
-set(SOURCES_PROJECT "${PROJECT_DIR}/src/InertialSense.h")
+add_library(${PROJECT_NAME} STATIC ${SOURCES_SDK})
 
-# Optional: add any libraries this project needs
-#set(PROJECT_LIBS "")
+# Include paths
+target_include_directories(${PROJECT_NAME} PUBLIC
+	src
+	src/util
+	src/protocol
+	src/libusb
+	src/libusb/libusb
+	src/yaml-cpp
+	external
+)
 
-# Get this project built (the static lib of the sdk)
-include(${PROJECT_DIR}/CMakeCommon.txt)
-
-# Go back to building executables
-set(BUILD_LIB 0)
-
-# Build example projects if not ignored
-if(NOT IGNORE_EXAMPLE_PROJECTS)
-
-	# Denote that all executables will be linking the sdk static library and not the sources directly
-	set(BUILD_INERTIAL_SENSE_SDK 1)
-
-	# Build the other projects
-	add_subdirectory(cltool)
-	add_subdirectory(ExampleProjects)
-
+# Other settings
+if(WIN32)
+	# Windows specific include dir
+	target_include_directories(${PROJECT_NAME} PUBLIC
+		${CMAKE_CURRENT_LIST_DIR}/src/libusb/msvc
+	)	
+	
+	# We need to ensure windows static libs are found
+	target_link_libraries(${PROJECT_NAME} Ws2_32.lib)
+else()
+	# Linux specific include dir 
+	target_include_directories(${PROJECT_NAME} PUBLIC
+		${CMAKE_CURRENT_LIST_DIR}/src/libusb/linux
+	)
+	
+	# Linux compiler flags
+	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers")
+		
+	# Set Linux compiler linker flag
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+	
+	# Link in Linux specific packages
+	target_link_libraries(${PROJECT_NAME} udev m)
 endif()

--- a/ExampleProjects/Ascii/CMakeLists.txt
+++ b/ExampleProjects/Ascii/CMakeLists.txt
@@ -1,13 +1,25 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
-# Required: set the project
+
 project(ISAsciiExample)
 
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT	"${CMAKE_CURRENT_LIST_DIR}/ISAsciiExample.c")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-# Optional: add any libraries this project needs
-#set(PROJECT_LIBS "")
+if(NOT USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
 
-# Everything is setup, use common template to build
-include(../../CMakeCommon.txt)
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
 
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} ISAsciiExample.c)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)

--- a/ExampleProjects/Ascii/CMakeLists.txt
+++ b/ExampleProjects/Ascii/CMakeLists.txt
@@ -5,8 +5,8 @@ project(ISAsciiExample)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/Ascii/CMakeLists.txt
+++ b/ExampleProjects/Ascii/CMakeLists.txt
@@ -4,8 +4,9 @@ project(ISAsciiExample)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-if(NOT USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/Bootloader/CMakeLists.txt
+++ b/ExampleProjects/Bootloader/CMakeLists.txt
@@ -4,8 +4,9 @@ project(ISBootloaderExample)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-if(NOT USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/Bootloader/CMakeLists.txt
+++ b/ExampleProjects/Bootloader/CMakeLists.txt
@@ -1,10 +1,25 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
 project(ISBootloaderExample)
 
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT	"${CMAKE_CURRENT_LIST_DIR}/ISBootloaderExample.cpp")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-include(../../CMakeCommon.txt)
+if(NOT USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
 
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
+
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} ISBootloaderExample.cpp)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)

--- a/ExampleProjects/Bootloader/CMakeLists.txt
+++ b/ExampleProjects/Bootloader/CMakeLists.txt
@@ -22,5 +22,8 @@ link_directories(${IS_SDK_DIR})
 # Define the executable
 add_executable(${PROJECT_NAME} ISBootloaderExample.cpp)
 
+# Find pthread package
+find_package(Threads REQUIRED)
+
 # Link InertialSenseSDK static library to the executable
-target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK Threads::Threads)

--- a/ExampleProjects/Bootloader/CMakeLists.txt
+++ b/ExampleProjects/Bootloader/CMakeLists.txt
@@ -5,8 +5,8 @@ project(ISBootloaderExample)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/CMakeLists.txt
+++ b/ExampleProjects/CMakeLists.txt
@@ -1,5 +1,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
+project(ExampleProjects)
+
 if (MSVC_VERSION GREATER_EQUAL "1900")
     include(CheckCXXCompilerFlag)
     CHECK_CXX_COMPILER_FLAG("/std:c++latest" _cpp_latest_flag_supported)
@@ -8,8 +10,11 @@ if (MSVC_VERSION GREATER_EQUAL "1900")
     endif()
 endif()
 
-project(ExampleProjects)
-SET(PROJECT_NAME "ExampleProjects")
+set(USE_PREBUILT_SDK 1)
+
+# Add InertialSenseSDK static library subdirectory
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
+add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 
 # Add all the other sub projects
 add_subdirectory(Ascii)

--- a/ExampleProjects/CMakeLists.txt
+++ b/ExampleProjects/CMakeLists.txt
@@ -14,8 +14,8 @@ endif()
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/CMakeLists.txt
+++ b/ExampleProjects/CMakeLists.txt
@@ -10,11 +10,14 @@ if (MSVC_VERSION GREATER_EQUAL "1900")
     endif()
 endif()
 
-set(USE_PREBUILT_SDK 1)
-
 # Add InertialSenseSDK static library subdirectory
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
-add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
 
 # Add all the other sub projects
 add_subdirectory(Ascii)

--- a/ExampleProjects/CMakeLists.txt
+++ b/ExampleProjects/CMakeLists.txt
@@ -19,6 +19,11 @@ if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 
+if(WIN32)
+    # yamlcpp needs to know it's a static lib
+    add_definitions(-DYAML_CPP_STATIC_DEFINE)
+endif()
+
 # Add all the other sub projects
 add_subdirectory(Ascii)
 add_subdirectory(Bootloader)

--- a/ExampleProjects/Communications/CMakeLists.txt
+++ b/ExampleProjects/Communications/CMakeLists.txt
@@ -23,4 +23,8 @@ link_directories(${IS_SDK_DIR})
 add_executable(${PROJECT_NAME} ISCommunicationsExample.c)
 
 # Link InertialSenseSDK static library to the executable
-target_link_libraries(${PROJECT_NAME} InertialSenseSDK m)
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+
+if(NOT WIN32)
+    target_link_libraries(${PROJECT_NAME} m)
+endif()

--- a/ExampleProjects/Communications/CMakeLists.txt
+++ b/ExampleProjects/Communications/CMakeLists.txt
@@ -1,37 +1,25 @@
-# This example project does not use the CMakeCommon.txt file in the SDK/src folder
-# If you don't want to follow that pattern, you can create your own cmake file
-# The one define BUILD_INERTIAL_SENSE_SDK needs to be checked, and if on,
-#  link the InertialSense library only
-
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
 project(ISCommunicationsExample)
 
-if(NOT WIN32)
-	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
+
+if(NOT USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 
-if(BUILD_INERTIAL_SENSE_SDK)	# Build w/ SDK
-
-add_executable(ISCommunicationsExample ISCommunicationsExample.c)
-target_link_libraries(ISCommunicationsExample InertialSense)
-
-else()	# Build only this project
-
-add_executable(ISCommunicationsExample
-    ISCommunicationsExample.c
-    ../../src/data_sets.c
-    ../../src/ISComm.c
-    ../../src/ISMatrix.c
-    ../../src/ISPose.c
-    ../../src/serialPort.c
-    ../../src/serialPortPlatform.c
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-if(NOT WIN32)
-	# Link in Linux specific packages
-	target_link_libraries(ISCommunicationsExample udev m)
-endif()
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
 
-endif()
+# Define the executable
+add_executable(${PROJECT_NAME} ISCommunicationsExample.c)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK m)

--- a/ExampleProjects/Communications/CMakeLists.txt
+++ b/ExampleProjects/Communications/CMakeLists.txt
@@ -4,8 +4,9 @@ project(ISCommunicationsExample)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-if(NOT USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/Communications/CMakeLists.txt
+++ b/ExampleProjects/Communications/CMakeLists.txt
@@ -5,8 +5,8 @@ project(ISCommunicationsExample)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/IS_NMEAProtocolCheckSum/CMakeLists.txt
+++ b/ExampleProjects/IS_NMEAProtocolCheckSum/CMakeLists.txt
@@ -4,8 +4,9 @@ project(IS_NMEAProtocolCheckSum)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-if(NOT USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/IS_NMEAProtocolCheckSum/CMakeLists.txt
+++ b/ExampleProjects/IS_NMEAProtocolCheckSum/CMakeLists.txt
@@ -5,8 +5,8 @@ project(IS_NMEAProtocolCheckSum)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/IS_NMEAProtocolCheckSum/CMakeLists.txt
+++ b/ExampleProjects/IS_NMEAProtocolCheckSum/CMakeLists.txt
@@ -1,10 +1,27 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
 project(IS_NMEAProtocolCheckSum)
 
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT	"${CMAKE_CURRENT_LIST_DIR}/IS_NMEAProtocolCheckSum.cpp")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-include(../../CMakeCommon.txt)
+if(NOT USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
+
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
+
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} IS_NMEAProtocolCheckSum.cpp)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+
 

--- a/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
+++ b/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
@@ -1,10 +1,26 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
 project(ISFirmwareUpdateExample_v2)
 
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT	"${CMAKE_CURRENT_LIST_DIR}/ISFirmwareUpdateExample_v2.cpp")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-include(../../CMakeCommon.txt)
+if(NOT USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
+
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
+
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} ISFirmwareUpdateExample_v2.cpp)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
 

--- a/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
+++ b/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
@@ -22,6 +22,9 @@ link_directories(${IS_SDK_DIR})
 # Define the executable
 add_executable(${PROJECT_NAME} ISFirmwareUpdateExample_v2.cpp)
 
+# Find pthread package
+find_package(Threads REQUIRED)
+
 # Link InertialSenseSDK static library to the executable
-target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK Threads::Threads)
 

--- a/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
+++ b/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
@@ -4,8 +4,9 @@ project(ISFirmwareUpdateExample_v2)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-if(NOT USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
+++ b/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
@@ -5,8 +5,8 @@ project(ISFirmwareUpdateExample_v2)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/LogReader/CMakeLists.txt
+++ b/ExampleProjects/LogReader/CMakeLists.txt
@@ -4,8 +4,9 @@ project(ISLogReaderExample)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-if(NOT USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/LogReader/CMakeLists.txt
+++ b/ExampleProjects/LogReader/CMakeLists.txt
@@ -22,5 +22,8 @@ link_directories(${IS_SDK_DIR})
 # Define the executable
 add_executable(${PROJECT_NAME} ISLogReaderExample.cpp)
 
+# Find pthread package
+find_package(Threads REQUIRED)
+
 # Link InertialSenseSDK static library to the executable
-target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK Threads::Threads)

--- a/ExampleProjects/LogReader/CMakeLists.txt
+++ b/ExampleProjects/LogReader/CMakeLists.txt
@@ -5,8 +5,8 @@ project(ISLogReaderExample)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/LogReader/CMakeLists.txt
+++ b/ExampleProjects/LogReader/CMakeLists.txt
@@ -1,13 +1,25 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
 project(ISLogReaderExample)
 
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT	"${CMAKE_CURRENT_LIST_DIR}/ISLogReaderExample.cpp")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-# Optional: add any libraries this project needs
-#set(PROJECT_LIBS "")
+if(NOT USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
 
-# Everything is setup, use common template to build
-include(../../CMakeCommon.txt)
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
+
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} ISLogReaderExample.cpp)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)

--- a/ExampleProjects/Logger/CMakeLists.txt
+++ b/ExampleProjects/Logger/CMakeLists.txt
@@ -5,8 +5,8 @@ project(ISLoggerExample)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/Logger/CMakeLists.txt
+++ b/ExampleProjects/Logger/CMakeLists.txt
@@ -1,13 +1,25 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
 project(ISLoggerExample)
 
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT	"${CMAKE_CURRENT_LIST_DIR}/ISLoggerExample.cpp")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-# Optional: add any libraries this project needs
-#set(PROJECT_LIBS "")
+if(NOT USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
 
-# Everything is setup, use common template to build
-include(../../CMakeCommon.txt)
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
+
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} ISLoggerExample.cpp)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)

--- a/ExampleProjects/Logger/CMakeLists.txt
+++ b/ExampleProjects/Logger/CMakeLists.txt
@@ -4,8 +4,9 @@ project(ISLoggerExample)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-if(NOT USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/Logger/CMakeLists.txt
+++ b/ExampleProjects/Logger/CMakeLists.txt
@@ -22,5 +22,8 @@ link_directories(${IS_SDK_DIR})
 # Define the executable
 add_executable(${PROJECT_NAME} ISLoggerExample.cpp)
 
+# Find pthread package
+find_package(Threads REQUIRED)
+
 # Link InertialSenseSDK static library to the executable
-target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK Threads::Threads)

--- a/ExampleProjects/NTRIP_rover/CMakeLists.txt
+++ b/ExampleProjects/NTRIP_rover/CMakeLists.txt
@@ -1,13 +1,25 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
 project(ISNtripRoverExample)
 
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT	"${CMAKE_CURRENT_LIST_DIR}/ISNtripRoverExample.cpp")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-# Optional: add any libraries this project needs
-#set(PROJECT_LIBS "")
+if(NOT USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
 
-# Everything is setup, use common template to build
-include(../../CMakeCommon.txt)
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
+
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} ISNtripRoverExample.cpp)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)

--- a/ExampleProjects/NTRIP_rover/CMakeLists.txt
+++ b/ExampleProjects/NTRIP_rover/CMakeLists.txt
@@ -22,5 +22,8 @@ link_directories(${IS_SDK_DIR})
 # Define the executable
 add_executable(${PROJECT_NAME} ISNtripRoverExample.cpp)
 
+# Find pthread package
+find_package(Threads REQUIRED)
+
 # Link InertialSenseSDK static library to the executable
-target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK Threads::Threads)

--- a/ExampleProjects/NTRIP_rover/CMakeLists.txt
+++ b/ExampleProjects/NTRIP_rover/CMakeLists.txt
@@ -4,8 +4,9 @@ project(ISNtripRoverExample)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
-if(NOT USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ExampleProjects/NTRIP_rover/CMakeLists.txt
+++ b/ExampleProjects/NTRIP_rover/CMakeLists.txt
@@ -5,8 +5,8 @@ project(ISNtripRoverExample)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -4,10 +4,13 @@ project(cltool)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 
+# find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR} ${IS_SDK_DIR}/build ${IS_SDK_DIR}/build/Release)
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
 if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
     # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+# else()
+#     link_directories(${IS_SDK_DIR}/Build/Release)
 endif()
 
 # Include InertialSenseSDK header files
@@ -19,8 +22,10 @@ include_directories(
 # Link the InertialSenseSDK static library 
 link_directories(${IS_SDK_DIR})
 
-# yamlcpp needs to know it's a static lib
-add_definitions(-DYAML_CPP_STATIC_DEFINE)
+if(WIN32)
+    # yamlcpp needs to know it's a static lib
+    add_definitions(-DYAML_CPP_STATIC_DEFINE)
+endif()
 
 # Define the executable
 add_executable(${PROJECT_NAME} main.cpp)

--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -16,14 +16,18 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-find_package(Threads)
-
 # Link the InertialSenseSDK static library 
 link_directories(${IS_SDK_DIR})
+
+# yamlcpp needs to know it's a static lib
+add_definitions(-DYAML_CPP_STATIC_DEFINE)
 
 # Define the executable
 add_executable(${PROJECT_NAME} main.cpp)
 
+# Find pthread package
+find_package(Threads REQUIRED)
+
 # Link InertialSenseSDK static library to the executable
-target_link_libraries(${PROJECT_NAME} InertialSenseSDK pthread)
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK Threads::Threads)
 

--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -16,6 +16,8 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
+find_package(Threads)
+
 # Link the InertialSenseSDK static library 
 link_directories(${IS_SDK_DIR})
 
@@ -23,4 +25,5 @@ link_directories(${IS_SDK_DIR})
 add_executable(${PROJECT_NAME} main.cpp)
 
 # Link InertialSenseSDK static library to the executable
-target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK pthread)
+

--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -1,13 +1,25 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
 project(cltool)
 
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT "${CMAKE_CURRENT_LIST_DIR}/main.cpp")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 
-# Optional: add any libraries this project needs
-#set(PROJECT_LIBS "")
+if(USE_PREBUILT_SDK)
+    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
 
-# Everything is setup, use common template to build
-include(../CMakeCommon.txt)
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
+
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} main.cpp)
+
+# Link InertialSenseSDK static library to the executable
+target_link_libraries(${PROJECT_NAME} InertialSenseSDK)

--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -4,8 +4,9 @@ project(cltool)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 
-if(USE_PREBUILT_SDK)
-    # Add InertialSenseSDK static library subdirectory to build SDK with this project 
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -5,8 +5,8 @@ project(cltool)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -75,7 +75,7 @@ add_library(inertial_sense_ros
     src/inertial_sense_ros.cpp
 )
 
-target_link_libraries(inertial_sense_ros InertialSense ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} pthread)
+target_link_libraries(inertial_sense_ros InertialSenseSDK ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} pthread)
 target_include_directories(inertial_sense_ros PUBLIC include)
 add_dependencies(inertial_sense_ros inertial_sense_ros_generate_messages_cpp)
 

--- a/src/ISEarth.c
+++ b/src/ISEarth.c
@@ -854,7 +854,7 @@ static double leaps[MAXLEAPS + 1][7] = { /* leap seconds (y,m,d,h,m,s,utc-gpst) 
     {0}
 };
 
-gtime_t epoch2time(const double *ep)
+gtime_t ISepoch2time(const double *ep)
 {
     const int doy[] = { 1,32,60,91,121,152,182,213,244,274,305,335 };
     gtime_t time = { 0 };
@@ -871,7 +871,7 @@ gtime_t epoch2time(const double *ep)
     return time;
 }
 
-gtime_t timeadd(gtime_t t, double sec)
+gtime_t IStimeadd(gtime_t t, double sec)
 {
     double tt;
     t.sec += sec; 
@@ -881,26 +881,26 @@ gtime_t timeadd(gtime_t t, double sec)
     return t;
 }
 
-double timediff(gtime_t t1, gtime_t t2)
+double IStimediff(gtime_t t1, gtime_t t2)
 {
     return ((double)(t1.time - t2.time)) + (t1.sec - t2.sec);
 }
 
-gtime_t utc2gpst(gtime_t t)
+gtime_t ISutc2gpst(gtime_t t)
 {
     int i;
 
     for (i = 0; leaps[i][0] > 0; i++) {
-        if (timediff(t, epoch2time(leaps[i])) >= 0.0) {
-            return timeadd(t, -leaps[i][6]);
+        if (IStimediff(t, ISepoch2time(leaps[i])) >= 0.0) {
+            return IStimeadd(t, -leaps[i][6]);
         }
     }
     return t;
 }
 
-gtime_t gpst2time(int week, double sec)
+gtime_t ISgpst2time(int week, double sec)
 {
-    gtime_t t = epoch2time(gpst0);
+    gtime_t t = ISepoch2time(gpst0);
 
     if (sec < -1E9 || 1E9 < sec) 
         sec = 0.0;
@@ -909,9 +909,9 @@ gtime_t gpst2time(int week, double sec)
     return t;
 }
 
-double time2gpst(gtime_t t, int *week)
+double IStime2gpst(gtime_t t, int *week)
 {
-    gtime_t t0 = epoch2time(gpst0);
+    gtime_t t0 = ISepoch2time(gpst0);
     time_t sec = t.time - t0.time;
     time_t w = (time_t)(sec / (86400 * 7));
 

--- a/src/ISEarth.h
+++ b/src/ISEarth.h
@@ -17,8 +17,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 extern "C" {
 #endif
 
-#include <stdbool.h>
-
 #include "ISMatrix.h"
 #include "ISConstants.h"
 #include "ISPose.h"
@@ -225,7 +223,7 @@ void gndSpeedToVelEcef(const float gndSpeed, const float hdg, const float vertVe
  * @param sec                   time of week in gps time (s)
  * @return                      gtime_t struct
  */
-gtime_t gpst2time(int week, double sec);
+gtime_t ISgpst2time(int week, double sec);
 
 /**
  * @brief Convert gtime_t struct to week and tow in gps time
@@ -233,7 +231,7 @@ gtime_t gpst2time(int week, double sec);
  * @param week                  number in gps time (NULL: no output)
  * @return                      time of week in gps time (s)
  */
-double time2gpst(gtime_t t, int *week);
+double IStime2gpst(gtime_t t, int *week);
 
 /**
  * @brief Add time to gtime_t struct
@@ -241,28 +239,28 @@ double time2gpst(gtime_t t, int *week);
  * @param sec                   time to add (s)
  * @return                      gtime_t struct (t+sec)
  */
-gtime_t timeadd(gtime_t t, double sec);
+gtime_t IStimeadd(gtime_t t, double sec);
 
 /**
  * @brief Difference between gtime_t structs
  * @param t1, t2                gtime_t structs
  * @return                      time difference (t1-t2) (s)
  */
-double timediff(gtime_t t1, gtime_t t2);
+double IStimediff(gtime_t t1, gtime_t t2);
 
 /** 
  * @brief Convert calendar day/time to gtime_t struct
  * @param ep                    Pointer to day/time {year,month,day,hour,min,sec}
  * @return                      gtime_t struct
  */
-gtime_t epoch2time(const double *ep);
+gtime_t ISepoch2time(const double *ep);
 
 /**
  * @brief convert utc to gpstime considering leap seconds
  * @param args                  time expressed in utc
  * @return                      time expressed in gpstime
  */
-gtime_t utc2gpst(gtime_t t);
+gtime_t ISutc2gpst(gtime_t t);
 #endif
 
 #ifdef __cplusplus

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,13 +4,18 @@ project(IS-SDK_unit-tests)
 
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 
-# Add InertialSenseSDK static library subdirectory
-add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
+if(NOT SDK_LIBRARY_PATH)
+    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+endif()
 
 # Include InertialSenseSDK header files
 include_directories(
     ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/protocol
     ${IS_SDK_DIR}/src/libusb/libusb
+    ${IS_SDK_DIR}/src/util
 )
 
 find_package(GTest REQUIRED)
@@ -25,29 +30,4 @@ list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_com_manager_2.cpp")
 add_executable(${PROJECT_NAME} ${TESTS_SOURCES})
 
 # Link InertialSenseSDK static library to the executable
-# target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
 target_link_libraries(${PROJECT_NAME} gtest_main InertialSenseSDK ${GTEST_LIBRARIES} udev pthread m)
-
-
-
-
-
-
-
-# Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-# set(SOURCES_PROJECT ${TESTS_SOURCES})
-
-# include_directories(${GTEST_INCLUDE_DIRS}
-# 		${PROJECT_DIR}/src
-# 		${PROJECT_DIR}/src/libusb
-# 		${PROJECT_DIR}/src/libusb/linux
-# 		${PROJECT_DIR}/src/libusb/libusb
-# 		${PROJECT_DIR}/src/yaml-cpp
-# 		${PROJECT_DIR}/external
-# 		)
-
-
-# add_executable(${PROJECT_NAME} ${SOURCES_PROJECT})
-
-# SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -fms-extensions")
-# SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fms-extensions")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,8 +5,8 @@ project(IS-SDK_unit-tests)
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_DIR})
-if(NOT SDK_LIBRARY_PATH)
-    # InertialSenseSDK static library not built.  Build SDK along with this project. 
+if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
+    # InertialSenseSDK library not prebuilt and not already include in project.  Include in this project.
     add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,45 +1,53 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
-# Required: set the project
 project(IS-SDK_unit-tests)
 
-# Optional: add any libraries this project needs
-#set(PROJECT_LIBS "")
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
+
+# Add InertialSenseSDK static library subdirectory
+add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
+
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
 
 find_package(GTest REQUIRED)
 
-file(GLOB TESTS_SRC "${CMAKE_CURRENT_LIST_DIR}/test_*.cpp")
-list(FILTER TESTS_SRC EXCLUDE REGEX "test_com_manager_2.cpp")
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+file(GLOB TESTS_SOURCES "${CMAKE_CURRENT_LIST_DIR}/test_*.cpp")
+list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_com_manager_2.cpp")
+
+# Define the executable
+add_executable(${PROJECT_NAME} ${TESTS_SOURCES})
+
+# Link InertialSenseSDK static library to the executable
+# target_link_libraries(${PROJECT_NAME} InertialSenseSDK)
+target_link_libraries(${PROJECT_NAME} gtest_main InertialSenseSDK ${GTEST_LIBRARIES} udev pthread m)
+
+
+
+
+
+
 
 # Required: set SOURCES_PROJECT to the code in this project, the files must go on their own lines
-set(SOURCES_PROJECT ${TESTS_SRC})
+# set(SOURCES_PROJECT ${TESTS_SOURCES})
 
-include_directories(${GTEST_INCLUDE_DIRS}
-		${PROJECT_DIR}/src
-		${PROJECT_DIR}/src/libusb
-		${PROJECT_DIR}/src/libusb/linux
-		${PROJECT_DIR}/src/libusb/libusb
-		${PROJECT_DIR}/src/yaml-cpp
-		${PROJECT_DIR}/external
-		)
+# include_directories(${GTEST_INCLUDE_DIRS}
+# 		${PROJECT_DIR}/src
+# 		${PROJECT_DIR}/src/libusb
+# 		${PROJECT_DIR}/src/libusb/linux
+# 		${PROJECT_DIR}/src/libusb/libusb
+# 		${PROJECT_DIR}/src/yaml-cpp
+# 		${PROJECT_DIR}/external
+# 		)
 
-# Everything is setup, use common template to build
-include(../CMakeCommon.txt)
-
-#add_library(${PROJECT_NAME}
-#		${TESTS_SRC}
-#		${SOURCES_SDK}
-#		)
 
 # add_executable(${PROJECT_NAME} ${SOURCES_PROJECT})
-# add_executable(${PROJECT_NAME} ${TESTS_SRC})
 
-# add_executable(${PROJECT_NAME} ${SOURCES_PROJECT})
-target_link_libraries(${PROJECT_NAME} gtest_main ${GTEST_LIBRARIES} udev pthread m)
-
-#    target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-#    add_test(NAME ${PROJECT_NAME}
-#             COMMAND ${PROJECT_NAME} --gtest_color=true)
-
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -fms-extensions")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fms-extensions")
+# SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -fms-extensions")
+# SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fms-extensions")


### PR DESCRIPTION
Optimize build time by building IS SDK as a static library and including in all projects.  The IS SDK will be automatically included in each project when the prebuilt IS SDK static library is not found (previously built).