### PR TITLE
Quick fix for Cltool segfault

### DIFF
--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -463,30 +463,30 @@ void cltool_firmwareUpdateInfo(void* obj, ISBootloader::eLogLevel level, const c
     print_mutex.lock();
     static char buffer[256];
 
-    va_list ap;
-    va_start(ap, str);
-    vsnprintf(buffer, sizeof(buffer) - 1, str, ap);
-    va_end(ap);
-
-    if(obj == NULL)
-    {
-        cout << buffer << endl;
-        print_mutex.unlock();
-        return;
+    memset(buffer, 0, sizeof(buffer));
+    if (str) {
+        va_list ap;
+        va_start(ap, str);
+        vsnprintf(buffer, sizeof(buffer) - 1, str, ap);
+        va_end(ap);
     }
 
-    ISFirmwareUpdater* fwCtx = (ISFirmwareUpdater*)obj;
-    if (buffer[0] || (fwCtx->fwUpdate_getSessionStatus() == fwUpdate::IN_PROGRESS)) {
-        printf("[%5.2f] [%s:SN%07d > %s]", current_timeMs() / 1000.0f, fwCtx->portName, fwCtx->devInfo->serialNumber, fwCtx->fwUpdate_getSessionTargetName());
-        if (fwCtx->fwUpdate_getSessionStatus() == fwUpdate::IN_PROGRESS) {
-            int tot = fwCtx->fwUpdate_getTotalChunks();
-            int num = fwCtx->fwUpdate_getNextChunkID();
-            float percent = num / (float) (tot) * 100.f;
-            printf(" :: Progress %d/%d (%0.1f%%)", num, tot, percent);
+    if(obj == NULL) {
+        cout << buffer << endl;
+    } else {
+        ISFirmwareUpdater *fwCtx = (ISFirmwareUpdater *) obj;
+        if (buffer[0] || (fwCtx->fwUpdate_getSessionStatus() == fwUpdate::IN_PROGRESS)) {
+            printf("[%5.2f] [%s:SN%07d > %s]", current_timeMs() / 1000.0f, fwCtx->portName, fwCtx->devInfo->serialNumber, fwCtx->fwUpdate_getSessionTargetName());
+            if (fwCtx->fwUpdate_getSessionStatus() == fwUpdate::IN_PROGRESS) {
+                int tot = fwCtx->fwUpdate_getTotalChunks();
+                int num = fwCtx->fwUpdate_getNextChunkID();
+                float percent = num / (float) (tot) * 100.f;
+                printf(" :: Progress %d/%d (%0.1f%%)", num, tot, percent);
+            }
+            if (buffer[0])
+                printf(" :: %s", buffer);
+            printf("\n");
         }
-        if (buffer[0])
-            printf(" :: %s", buffer);
-        printf("\n");
     }
 
     print_mutex.unlock();


### PR DESCRIPTION
... when cltool_firmwareUpdateInfo() has no or null message string.