### PR TITLE
Remove reference to gauss for magnetometer units

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -770,7 +770,7 @@ typedef struct PACKED
     /** Time since boot up in seconds.  Convert to GPS time of week by adding gps.towOffset */
     double                  time;
     
-    /** Magnetometers in Gauss */
+    /** Magnetometers */
     float                   mag[3];
 } magnetometer_t;
 
@@ -1274,7 +1274,7 @@ typedef struct PACKED
     /** Accelerometers in meters / second squared */
     float                   acc[3];
 
-    /** Magnetometers in Gauss */
+    /** Magnetometers */
     float                   mag[3];
 
     /** Barometric pressure in kilopascals */


### PR DESCRIPTION
Our magnetometer units are not gauss.  They are normalized to 1 for the strength of the earths magnetic field in Utah.  This removes the "gauss" label which may confuse some customers.