### PR TITLE
Wait until flash config is received before printing.

### DIFF
--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1452,7 +1452,7 @@ string cInertialSenseDisplay::DataToStringDevInfo(const dev_info_t &info, bool f
 	case DEV_INFO_HARDWARE_UINS:	ptr += SNPRINTF(ptr, ptrEnd - ptr, " uINS"); 	break;
 	case DEV_INFO_HARDWARE_EVB:		ptr += SNPRINTF(ptr, ptrEnd - ptr, " EVB");  	break;
 	case DEV_INFO_HARDWARE_IMX:		ptr += SNPRINTF(ptr, ptrEnd - ptr, " IMX");  	break;
-	case DEV_INFO_HARDWARE_GPX:		ptr += SNPRINTF(ptr, ptrEnd - ptr, " IMX");  	break;
+	case DEV_INFO_HARDWARE_GPX:		ptr += SNPRINTF(ptr, ptrEnd - ptr, " GPX");  	break;
 	}
 
 	ptr += SNPRINTF(ptr, ptrEnd - ptr, "-%d.%d.%d",

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -816,35 +816,6 @@ int InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
     return comManagerSendData(pHandle, &device.flashCfg, DID_FLASH_CONFIG, sizeof(nvm_flash_cfg_t), 0);
 }
 
-bool InertialSense::EvbFlashConfig(evb_flash_cfg_t &evbFlashCfg, int pHandle)
-{
-    if ((size_t)pHandle >= m_comManagerState.devices.size())
-    {
-        pHandle = 0;
-    }
-
-    evbFlashCfg = m_comManagerState.devices[pHandle].evbFlashCfg;
-
-    return true;
-}
-
-int InertialSense::SetEvbFlashConfig(evb_flash_cfg_t &evbFlashCfg, int pHandle)
-{
-    if ((size_t)pHandle >= m_comManagerState.devices.size())
-    {
-        return 0;
-    }
-    is_device_t &device = m_comManagerState.devices[pHandle];
-
-    // Update checksum
-    evbFlashCfg.checksum = flashChecksum32(&evbFlashCfg, sizeof(evb_flash_cfg_t));
-
-    device.evbFlashCfg = evbFlashCfg;
-
-    // [C COMM INSTRUCTION]  Update the entire DID_FLASH_CONFIG data set in the uINS.
-    return comManagerSendData(pHandle, &device.evbFlashCfg, DID_EVB_FLASH_CFG, sizeof(evb_flash_cfg_t), 0);
-}
-
 void InertialSense::ProcessRxData(int pHandle, p_data_t* data)
 {
     if (data->hdr.size==0 || data->ptr==NULL)
@@ -858,7 +829,6 @@ void InertialSense::ProcessRxData(int pHandle, p_data_t* data)
     {
         case DID_DEV_INFO:          device.devInfo = *(dev_info_t*)data->ptr;                               break;
         case DID_SYS_CMD:           device.sysCmd = *(system_command_t*)data->ptr;                          break;
-        case DID_EVB_FLASH_CFG:     device.evbFlashCfg = *(evb_flash_cfg_t*)data->ptr;                      break;
         case DID_SYS_PARAMS:        copyDataPToStructP(&device.sysParams, data, sizeof(sys_params_t));      break;
         case DID_FLASH_CONFIG:
             copyDataPToStructP(&device.flashCfg, data, sizeof(nvm_flash_cfg_t));

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -69,7 +69,6 @@ public:
         system_command_t sysCmd;
         nvm_flash_cfg_t flashCfg;
         unsigned int flashCfgUploadTimeMs;		// (ms) non-zero time indicates an upload is in progress and local flashCfg should not be overwritten
-        evb_flash_cfg_t evbFlashCfg;
         sys_params_t sysParams;
         ISFirmwareUpdater *fwUpdater;
         fwUpdate::update_status_e closeStatus;
@@ -320,22 +319,6 @@ public:
     * @return int number bytes sent
     */
     int SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle = 0);
-
-    /**
-    * Get the EVB flash config, returns the latest flash config read from the uINS flash memory
-    * @param flashCfg the flash config value
-    * @param pHandle the port pHandle to get flash config for
-    * @return bool whether the EVB flash config is valid, currently synchronized
-    */
-    bool EvbFlashConfig(evb_flash_cfg_t &evbFlashCfg, int pHandle = 0);
-
-    /**
-    * Set the EVB flash config and update flash config on the EVB-2 flash memory
-    * @param evbFlashCfg the flash config
-    * @param pHandle the pHandle to set flash config for
-    * @return int number bytes sent
-    */
-    int SetEvbFlashConfig(evb_flash_cfg_t &evbFlashCfg, int pHandle = 0);
 
     void ProcessRxData(int pHandle, p_data_t* data);
     void ProcessRxNmea(int pHandle, const uint8_t* msg, int msgSize);

--- a/src/cltool.h
+++ b/src/cltool.h
@@ -60,7 +60,6 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
 	bool bootloaderVerify; 					// -bv
 	bool replayDataLog;
 	bool softwareResetImx;
-	bool softwareResetEvb;
 	bool magRecal;
 	uint32_t magRecalMode;
 	survey_in_t surveyIn;
@@ -86,13 +85,11 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
 	std::string baseConnection; 			// -base=IP:port    (client)	
 	
 	std::string flashCfg;
-	std::string evbFlashCfg;	
 	uint32_t timeoutFlushLoggerSeconds;
 	uint32_t outputOnceDid;	
 	
 	uint32_t sysCommand;
 	int32_t platformType;
-	bool chipEraseEvb2;
     fwUpdate::target_t updateFirmwareTarget = fwUpdate::TARGET_HOST;
     uint32_t updateFirmwareSlot = 0;
 	uint32_t runDuration = 0;				// Run for this many millis before exiting (0 = indefinitely)
@@ -116,7 +113,6 @@ void cltool_firmwareUpdateWaiter();
 void cltool_bootloadUpdateInfo(void* obj, ISBootloader::eLogLevel level, const char* str, ...);
 void cltool_firmwareUpdateInfo(void* obj, ISBootloader::eLogLevel level, const char* str, ...);
 bool cltool_updateFlashCfg(InertialSense& inertialSenseInterface, std::string flashCfg); // true if should continue
-bool cltool_updateEvbFlashCfg(InertialSense& inertialSenseInterface, std::string evbFlashCfg); // true if should continue
 
 #endif // __CLTOOL_H__
 

--- a/src/cltool_main.cpp
+++ b/src/cltool_main.cpp
@@ -231,21 +231,6 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         cout << "Sending software reset." << endl;
         inertialSenseInterface.SendRaw((uint8_t*)NMEA_CMD_SOFTWARE_RESET, NMEA_CMD_SIZE);
     }
-    if (g_commandLineOptions.softwareResetEvb)
-    {   // Issue software reset to EVB
-        cout << "Sending EVB software reset." << endl;
-        uint32_t sysCommand = SYS_CMD_SOFTWARE_RESET;
-        inertialSenseInterface.SendRawData(DID_EVB_STATUS, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
-    }
-    if (g_commandLineOptions.chipEraseEvb2)
-    {   // Chip erase EVB
-        cout << "Sending EVB chip erase." << endl;
-        uint32_t sysCommand;
-        sysCommand = SYS_CMD_MANF_UNLOCK;
-        inertialSenseInterface.SendRawData(DID_EVB_STATUS, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
-        sysCommand = SYS_CMD_MANF_CHIP_ERASE;
-        inertialSenseInterface.SendRawData(DID_EVB_STATUS, (uint8_t*)&sysCommand, sizeof(uint32_t), offsetof(evb_status_t, sysCommand));
-    }
     if (g_commandLineOptions.sysCommand != 0)
     {   // Send system command to IMX
         cout << "Sending system command: " << g_commandLineOptions.sysCommand;
@@ -314,11 +299,20 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     }
     if (g_commandLineOptions.flashCfg.length() != 0)
     {
+        unsigned int startMs = current_timeMs();
+        while(!inertialSenseInterface.FlashConfigSynced())
+        {   // Request and wait for flash config
+            inertialSenseInterface.Update();
+            SLEEP_MS(100);
+
+            if (current_timeMs() - startMs > 3000)
+            {   // Timeout waiting for flash config
+                cout << "Failed to read flash config!" << endl;
+                return false;
+            }
+        }
+
         return cltool_updateFlashCfg(inertialSenseInterface, g_commandLineOptions.flashCfg);
-    }
-    if (g_commandLineOptions.evbFlashCfg.length() != 0)
-    {
-        return cltool_updateEvbFlashCfg(inertialSenseInterface, g_commandLineOptions.evbFlashCfg);
     }
     return true;
 }
@@ -524,11 +518,6 @@ static int cltool_createHost()
     else if (g_commandLineOptions.flashCfg.length() != 0 && !cltool_updateFlashCfg(inertialSenseInterface, g_commandLineOptions.flashCfg))
     {
         cout << "Failed to update flash config" << endl;
-        return -1;
-    }
-    else if (g_commandLineOptions.evbFlashCfg.length() != 0 && !cltool_updateFlashCfg(inertialSenseInterface, g_commandLineOptions.evbFlashCfg))
-    {
-        cout << "Failed to update EVB flash config" << endl;
         return -1;
     }
     else if (!inertialSenseInterface.CreateHost(g_commandLineOptions.baseConnection))


### PR DESCRIPTION
This fixes a problem where the cltool -flashCfg would return zero.  This was cause by recent changes to handshaking when the serial port is opened in the inertialsense class and not requesting and waiting for DID_FLASH_CONFIG to be received.  This also removes some EVB code from cltool.