### PR TITLE
SN-4962 remove nmea msg id zero

### DIFF
--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -364,6 +364,7 @@ extern void vPortFree(void* pv);
 
 #ifndef STRINGIFY
 #define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
 #endif
 
 #ifndef M_PI

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1418,10 +1418,10 @@ enum eSerialPortBridge
 
 typedef struct nmeaBroadcastMsgPair
 {
-    /** Message ID to be set up to 20 at a time using msgCount to indicate which indexes are valid. 
-     *  See eNmeaAsciiMsgId for msg IDs
-    */
+    /** Message ID. (see eNmeaAsciiMsgId) */
     uint8_t msgID;
+
+	/** Message period multiple. */
     uint8_t msgPeriod;
 }nmeaBroadcastMsgPair_t;
 
@@ -1433,19 +1433,13 @@ typedef struct PACKED
     /** Options: Port selection[0x0=current, 0x1=ser0, 0x2=ser1, 0x4=ser2, 0x8=USB, 0x100=preserve, 0x200=Persistant] (see RMC_OPTIONS_...) */
     uint32_t				options;
 
-    /** The number of messages being set in this message */
-    uint8_t                 msgCount;
-    
-    /** NMEA message to be set. (up to 20 at a time using msgCount to indicate which indexes are valid). 
-     *  See eNmeaAsciiMsgId for msg IDs
-    */
+    /** NMEA message to be set.  Up to 20 to indicate which indexes are valid. (see eNmeaAsciiMsgId) */
     nmeaBroadcastMsgPair_t nmeaBroadcastMsgs[MAX_nmeaBroadcastMsgPairs];   
 
     /*  Example usage:
-     *  If you are setting message GGA (0x06) at 1Hz and GGL (0x07) at 5Hz. 
-     *  msgCount = 2
-     *  nmeaBroadcastMsgs[0].msgID = 0x06, nmeaBroadcastMsgs[1].msgID = 0x07 
-     *  nmeaBroadcastMsgs[0].msgPeriod = 0x05, nmeaBroadcastMsgs[1].msgPeriod = 0x01 */           
+     *  If you are setting message GGA (6) at 1Hz and GGL (7) at 5Hz with the default DID_FLASH_CONFIG.startupGpsDtMs = 200 (5Hz) 
+     *  nmeaBroadcastMsgs[0].msgID = 6, nmeaBroadcastMsgs[0].msgPeriod = 5  
+     *  nmeaBroadcastMsgs[1].msgID = 7, nmeaBroadcastMsgs[1].msgPeriod = 1 */           
 
 } nmea_msgs_t;
 
@@ -1663,23 +1657,24 @@ typedef struct PACKED
 
 enum eNmeaAsciiMsgId
 {
-    NMEA_MSG_ID_PIMU      = 0,
-    NMEA_MSG_ID_PPIMU     = 1,
-    NMEA_MSG_ID_PRIMU     = 2,
-    NMEA_MSG_ID_PINS1     = 3,
-    NMEA_MSG_ID_PINS2     = 4,
-    NMEA_MSG_ID_PGPSP     = 5,
-    NMEA_MSG_ID_GxGGA     = 6,
-    NMEA_MSG_ID_GxGLL     = 7,
-    NMEA_MSG_ID_GxGSA     = 8,
-    NMEA_MSG_ID_GxRMC     = 9,
-    NMEA_MSG_ID_GxZDA     = 10,
-    NMEA_MSG_ID_PASHR     = 11, 
-    NMEA_MSG_ID_PSTRB     = 12,
-    NMEA_MSG_ID_INFO      = 13,
-    NMEA_MSG_ID_GxGSV     = 14,
-    NMEA_MSG_ID_GxVTG     = 15,
-    NMEA_MSG_ID_INTEL     = 16,
+    NMEA_MSG_ID_INVALID   = 0,
+    NMEA_MSG_ID_PIMU      = 1,
+    NMEA_MSG_ID_PPIMU     = 2,
+    NMEA_MSG_ID_PRIMU     = 3,
+    NMEA_MSG_ID_PINS1     = 4,
+    NMEA_MSG_ID_PINS2     = 5,
+    NMEA_MSG_ID_PGPSP     = 6,
+    NMEA_MSG_ID_GxGGA     = 7,
+    NMEA_MSG_ID_GxGLL     = 8,
+    NMEA_MSG_ID_GxGSA     = 9,
+    NMEA_MSG_ID_GxRMC     = 10,
+    NMEA_MSG_ID_GxZDA     = 11,
+    NMEA_MSG_ID_PASHR     = 12,
+    NMEA_MSG_ID_PSTRB     = 13,
+    NMEA_MSG_ID_INFO      = 14,
+    NMEA_MSG_ID_GxGSV     = 15,
+    NMEA_MSG_ID_GxVTG     = 16,
+    NMEA_MSG_ID_INTEL     = 17,
     NMEA_MSG_ID_COUNT,
 
 	// IMX/GPX Input Commands

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1423,18 +1423,18 @@ typedef struct nmeaBroadcastMsgPair
 
 	/** Message period multiple. */
     uint8_t msgPeriod;
-}nmeaBroadcastMsgPair_t;
+} nmeaBroadcastMsgPair_t;
 
 #define MAX_nmeaBroadcastMsgPairs 20
 
 /** (DID_NMEA_BCAST_PERIOD) Set NMEA message broadcast periods. This data structure is zeroed out on stop_all_broadcasts */
 typedef struct PACKED
 {
-    /** Options: Port selection[0x0=current, 0x1=ser0, 0x2=ser1, 0x4=ser2, 0x8=USB, 0x100=preserve, 0x200=Persistant] (see RMC_OPTIONS_...) */
+    /** Options: Port selection[0x0=current, 0x1=ser0, 0x2=ser1, 0x4=ser2, 0x8=USB, 0x100=preserve, 0x200=Persistent] (see RMC_OPTIONS_...) */
     uint32_t				options;
 
-    /** NMEA message to be set.  Up to 20 to indicate which indexes are valid. (see eNmeaAsciiMsgId) */
-    nmeaBroadcastMsgPair_t nmeaBroadcastMsgs[MAX_nmeaBroadcastMsgPairs];   
+    /** NMEA message to be set.  Up to 20 message ID/period pairs.  Message ID of zero indicates the remaining pairs are not used. (see eNmeaAsciiMsgId) */
+    nmeaBroadcastMsgPair_t	nmeaBroadcastMsgs[MAX_nmeaBroadcastMsgPairs];   
 
     /*  Example usage:
      *  If you are setting message GGA (6) at 1Hz and GGL (7) at 5Hz with the default DID_FLASH_CONFIG.startupGpsDtMs = 200 (5Hz) 

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -394,7 +394,7 @@ void nmea_enable_stream(uint32_t& bits, uint8_t* period, uint32_t nmeaId, uint8_
 
 void nmea_set_rmc_period_multiple(uint32_t& bits, uint8_t* period, uint16_t* tmp)
 {
-	for(int i = 0; i < NMEA_MSG_ID_COUNT; i++)
+	for(int i = 1; i < NMEA_MSG_ID_COUNT; i++)
 		nmea_enable_stream(bits, period, i,  tmp[i]);
 }
 
@@ -1517,7 +1517,6 @@ int nmeaMsgIdToTalker(int msgId, void *str, int strSize)
 	case NMEA_MSG_ID_GxGSV:	memcpy(str, "GxGSV", 5);	return 0;
 	case NMEA_MSG_ID_GxVTG:	memcpy(str, "GxVTG", 5);	return 0;
 	case NMEA_MSG_ID_INTEL:	memcpy(str, "INTEL", 5);	return 0;
-	case NMEA_MSG_ID_COUNT:	memcpy(str, "COUNT", 5);	return 0;
 	case NMEA_MSG_ID_ASCB:	memcpy(str, "ASCB", 4);		return 0;
 	case NMEA_MSG_ID_ASCE:	memcpy(str, "ASCE", 4);		return 0;
 	case NMEA_MSG_ID_BLEN:	memcpy(str, "BLEN", 4);		return 0;

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -29,7 +29,7 @@ PYBIND11_NUMPY_DTYPE(ins_2_t, week, timeOfWeek, insStatus, hdwStatus, qn2b, uvw,
 PYBIND11_NUMPY_DTYPE(ins_3_t, week, timeOfWeek, insStatus, hdwStatus, qn2b, uvw, lla, msl);
 PYBIND11_NUMPY_DTYPE(ins_4_t, week, timeOfWeek, insStatus, hdwStatus, qe2b, ve, ecef);
 PYBIND11_NUMPY_DTYPE(system_command_t, command, invCommand);
-PYBIND11_NUMPY_DTYPE(nmea_msgs_t, options, msgCount, nmeaBroadcastMsgs);
+PYBIND11_NUMPY_DTYPE(nmea_msgs_t, options, nmeaBroadcastMsgs);
 PYBIND11_NUMPY_DTYPE(rmc_t, bits, options);
 PYBIND11_NUMPY_DTYPE(sys_params_t, timeOfWeekMs, insStatus, hdwStatus, imuTemp, baroTemp, mcuTemp, sysStatus, imuSamplePeriodMs, navOutputPeriodMs, sensorTruePeriod, flashCfgChecksum, navUpdatePeriodMs, genFaultCode);
 PYBIND11_NUMPY_DTYPE(sys_sensors_t, time, temp, pqr, acc, mag, bar, barTemp, mslBar, humidity, vin, ana1, ana3, ana4);

--- a/src/test/test_protocol_nmea.cpp
+++ b/src/test/test_protocol_nmea.cpp
@@ -57,7 +57,7 @@ TEST(protocol_nmea, nmea_parse_ascb)
         ASSERT_EQ( a.rmcNmea.nmeaBits, b.rmcNmea.nmeaBits );
         
         //cout << "I: " << i << " a: " << a.rmcNmea.nmeaBits << " b: " <<  b.rmcNmea.nmeaBits << "\n"; 
-        for (int j=0; j<NMEA_MSG_ID_COUNT; j++)
+        for (int j=1; j<NMEA_MSG_ID_COUNT; j++)
         {
             //cout << "J: " << j << " a: " << a.rmcNmea.nmeaPeriod[j] << " b: " <<  b.rmcNmea.nmeaPeriod[j] << "\n"; 
             ASSERT_EQ( a.rmcNmea.nmeaPeriod[j], b.rmcNmea.nmeaPeriod[j] );
@@ -101,7 +101,7 @@ TEST(protocol_nmea, nmea_parse_asce)
          
         // cout << "I: " << i << " a: " << a.rmcNmea.nmeaBits << " b: " <<  b.rmcNmea.nmeaBits << "\n"; 
         ASSERT_EQ( a.rmcNmea.nmeaBits, b.rmcNmea.nmeaBits );
-        for (int j=0; j < NMEA_MSG_ID_COUNT; j++)
+        for (int j=1; j < NMEA_MSG_ID_COUNT; j++)
         {
             // cout << "J: " << j << " a: " << a.rmcNmea.nmeaPeriod[j] << " b: " <<  b.rmcNmea.nmeaPeriod[j] << "\n";  
             ASSERT_EQ( a.rmcNmea.nmeaPeriod[j], b.rmcNmea.nmeaPeriod[j] );

--- a/src/test/test_protocol_nmea.cpp
+++ b/src/test/test_protocol_nmea.cpp
@@ -72,22 +72,29 @@ TEST(protocol_nmea, nmea_parse_asce)
     rmci_t rmci[NUM_COM_PORTS] = {};
     int port = 1;
     rmci_t &r = rmci[port];
-    r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PINS2] = '2';
-    r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PIMU] = '1';
-    r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_GxGGA] = '0';
+    r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PINS1] = 2;
+    r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PPIMU] = 1;
+    r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_GxGGA] = 1;
+    r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PINS2] = 10;
+    r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_GxGSV] = 7;
     r.rmcNmea.nmeaBits = 
+        NMEA_RMC_BITS_PINS1 |
+        NMEA_RMC_BITS_PPIMU |
+        NMEA_RMC_BITS_GxGGA |
         NMEA_RMC_BITS_PINS2 |
-        NMEA_RMC_BITS_PIMU |
-        NMEA_RMC_BITS_GxGGA;
+        NMEA_RMC_BITS_GxGSV;
     uint32_t options = RMC_OPTIONS_PRESERVE_CTRL | RMC_OPTIONS_PERSISTENT;
 
     char a[ASCII_BUF_LEN] = {};
     int n=0;
 	nmea_sprint(a, ASCII_BUF_LEN, n, "$ASCE,%u", options);
+    nmea_sprint(a, ASCII_BUF_LEN, n, ",PINS1,%u", r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PINS1]);
+    nmea_sprint(a, ASCII_BUF_LEN, n, ",PPIMU,%u", r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PPIMU]);
+    nmea_sprint(a, ASCII_BUF_LEN, n, ",GxGGA,%u", r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_GxGGA]);
     nmea_sprint(a, ASCII_BUF_LEN, n, ",%u,%u", NMEA_MSG_ID_PINS2, r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PINS2]);
-    nmea_sprint(a, ASCII_BUF_LEN, n, ",%u,%u", NMEA_MSG_ID_PIMU,  r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_PIMU]);
-    nmea_sprint(a, ASCII_BUF_LEN, n, ",%u,%u", NMEA_MSG_ID_GxGGA, r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_GxGGA]);
+    nmea_sprint(a, ASCII_BUF_LEN, n, ",%u,%u", NMEA_MSG_ID_GxGSV, r.rmcNmea.nmeaPeriod[NMEA_MSG_ID_GxGSV]);
 	nmea_sprint_footer(a, ASCII_BUF_LEN, n);
+    cout << a << endl;
 
     rmci_t outRmci[NUM_COM_PORTS] = {};
     uint32_t outOptions = nmea_parse_asce(port, a, n, outRmci);


### PR DESCRIPTION
Address complications of having zero as a valid NMEA message ID.  Shift all NMEA message IDs up and make ID zero an invalid ID.  

Allows $ASCE to accept NMEA identifier name instead of the NMEA message ID.  The following two statements enable the same NMEA messages:

```
$ASCE,0,PPIMU,1,PINS2,10,GxGGA,1*10\r\n
$ASCE,0,2,1,5,10,7,1*39\r\n
```