### PR TITLE
Feature/cltool gpx status and debug array

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -136,10 +136,13 @@ static void display_logger_status(InertialSense* i, bool refreshDisplay=false)
 // [C++ COMM INSTRUCTION] STEP 5: Handle received data 
 static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
 {
-    if (data->hdr.id != g_commandLineOptions.outputOnceDid && g_commandLineOptions.outputOnceDid)
-    {
-        return;
+    if (g_commandLineOptions.outputOnceDid) {
+        if (data->hdr.id != g_commandLineOptions.outputOnceDid)
+            return;
+        g_inertialSenseDisplay.showRawData(true);
     }
+
+
     (void)i;
     (void)pHandle;
 

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1582,6 +1582,12 @@ string cInertialSenseDisplay::DataToStringWheelEncoder(const wheel_encoder_t &wh
 	return buf;
 }
 
+/**
+ * Formats the specified DID (of type gpx_statys_t) into primary components
+ * @param gpxStatus the parsed DID struct to display
+ * @param hdr the DID header
+ * @return returns a fully formatted string
+ */
 string cInertialSenseDisplay::DataToStringGPXStatus(const gpx_status_t &gpxStatus, const p_data_hdr_t& hdr)
 {
     (void)hdr;
@@ -1606,6 +1612,13 @@ string cInertialSenseDisplay::DataToStringGPXStatus(const gpx_status_t &gpxStatu
     return buf;
 }
 
+/**
+ * Formats the specified DID (of type debug_array_t) into its array components of
+ * 9 integers, 9 floats, and 3 doubles.
+ * @param debug the parsed DID struct to display
+ * @param hdr the DID header
+ * @return returns a fully formatted string
+ */
 string cInertialSenseDisplay::DataToStringDebugArray(const debug_array_t &debug, const p_data_hdr_t& hdr)
 {
     (void)hdr;
@@ -1641,6 +1654,14 @@ string cInertialSenseDisplay::DataToStringDebugArray(const debug_array_t &debug,
     return buf;
 }
 
+/**
+ * Formats the specified DID's raw data as a "hexidecimal view". This can be used with any DID that is not
+ * otherwise supported.
+ * @param raw_data a pointer to the raw DID byte stream
+ * @param hdr the DID header
+ * @param bytesPerLine the number of hexadecimal bytes to print per line.
+ * @return returns a fully formatted string
+ */
 string cInertialSenseDisplay::DataToStringRawHex(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine)
 {
     (void)hdr;

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1639,6 +1639,35 @@ string cInertialSenseDisplay::DataToStringDebugArray(const debug_array_t &debug,
     return buf;
 }
 
+string cInertialSenseDisplay::DataToStringRawHex(const p_data_hdr_t& hdr)
+{
+    (void)hdr;
+    char buf[BUF_SIZE];
+    char* ptr = buf;
+    char* ptrEnd = buf + BUF_SIZE;
+
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, "(%d) %s:", hdr.id, cISDataMappings::GetDataSetName(hdr.id));
+
+#if DISPLAY_DELTA_TIME==1
+    static double lastTime[2] = { 0 };
+	double dtMs = 1000.0*(wheel.timeOfWeek - lastTime[i]);
+	lastTime[i] = wheel.timeOfWeek;
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, " %4.1lfms", dtMs);
+#else
+#endif
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n    ");
+    int lines = hdr.size / 16;
+    for (int j = 0; j < lines; j++) {
+        for (int i = 0; i < 16; i++) {
+            ptr += SNPRINTF(ptr, ptrEnd - ptr, "\t%10d", debug.i[i]);
+        }
+        ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n");
+    }
+
+
+    return buf;
+}
+
 #define DISPLAY_SNPRINTF(f_, ...)	{ptr += SNPRINTF(ptr, ptrEnd - ptr, (f_), ##__VA_ARGS__);}
 #define DTS_VALUE_FORMAT	"%22s "
 

--- a/src/ISDisplay.h
+++ b/src/ISDisplay.h
@@ -117,6 +117,8 @@ public:
 	static std::string DataToStringDevInfo(const dev_info_t &info, bool full=false);
 	std::string DataToStringSensorsADC(const sys_sensors_adc_t &sensorsADC, const p_data_hdr_t& hdr);
 	std::string DataToStringWheelEncoder(const wheel_encoder_t &enc, const p_data_hdr_t& hdr);
+    std::string DataToStringGPXStatus(const gpx_status_t &gpxStatus, const p_data_hdr_t& hdr);
+    std::string DataToStringDebugArray(const debug_array_t &debug, const p_data_hdr_t& hdr);
 	std::string DataToStringGeneric(const p_data_t* data);
 	static void AddCommaToString(bool &comma, char* &ptr, char* &ptrEnd){ if (comma) { ptr += SNPRINTF(ptr, ptrEnd - ptr, ", "); } comma = true; };
 

--- a/src/ISDisplay.h
+++ b/src/ISDisplay.h
@@ -66,7 +66,8 @@ public:
 	~cInertialSenseDisplay();
 
 	void SetDisplayMode(eDisplayMode mode) { m_displayMode = mode; };
-	eDisplayMode GetDisplayMode() { return m_displayMode; }
+	eDisplayMode GetDisplayMode() { return m_displayMode; };
+    void showRawData(bool enable) { m_showRawHex = enable; };
 	void ShowCursor(bool visible);
 	void ShutDown();
 	void Clear(void);
@@ -119,6 +120,7 @@ public:
 	std::string DataToStringWheelEncoder(const wheel_encoder_t &enc, const p_data_hdr_t& hdr);
     std::string DataToStringGPXStatus(const gpx_status_t &gpxStatus, const p_data_hdr_t& hdr);
     std::string DataToStringDebugArray(const debug_array_t &debug, const p_data_hdr_t& hdr);
+    std::string DataToStringRawHex(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine);
 	std::string DataToStringGeneric(const p_data_t* data);
 	static void AddCommaToString(bool &comma, char* &ptr, char* &ptrEnd){ if (comma) { ptr += SNPRINTF(ptr, ptrEnd - ptr, ", "); } comma = true; };
 
@@ -148,6 +150,7 @@ private:
 	edit_data_t m_editData = {};
 	uint32_t m_outputOnceDid = 0;			// Set to DID to display then exit cltool.  0 = disabled
 	bool m_interactiveMode = true;
+    bool m_showRawHex = false;
 
 	struct sDidStats
 	{

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -5025,6 +5025,9 @@ typedef union PACKED
     rmc_t					rmc;
     evb_status_t			evbStatus;
     infield_cal_t			infieldCal;
+    gpx_status_t            gpxStatus;
+    debug_array_t           imxDebugArray;
+    debug_array_t           gpxDebugArray;
 
 #if defined(INCLUDE_LUNA_DATA_SETS)
     evb_luna_velocity_control_t     wheelController;


### PR DESCRIPTION
Adds the GPX_STATUS and DEBUG_ARRAY to cltool/ISDisplay.
```
$ Inertial Sense.  Connected.  Press CTRL-C to terminate.  Rx 0
(123) DID_GPX_STATUS: 427997.000s, status: 0x00000002, hdwStatus: 0x00000000, gnss1RunState: 2, gnss2RunState: 2, mcuTemp: 46.058
(124) DID_GPX_DEBUG_ARRAY:
    i[]:              2000            1000            6861           27002            7100             348              18               0               2
    f[]:            0.0000          0.0000          0.0000          0.0000        559.0000        117.0000         18.0000          0.0000          0.0000
   lf[]:            0.0000          0.0000          0.0000
```
And also adds a "Raw Hex" view for DIDs which aren't supported, but have the "outputOnceDid" (ie -did <did>=0).

```
$ Inertial Sense.  Connected.  Press CTRL-C to terminate.  Rx 0
(15) DID_GPS1_SAT (RAW):
        b8 c1 80 19 0e 00 00 00 01 05 34 a0 00 2c 1f 00 01 06 0a 39 00 18 1f 00 01 0b 2d 31 00 27 15 00 
        01 0c 38 b8 00 2b 1f 00 01 14 3e 59 00 29 1f 00 03 02 44 f4 00 24 03 00 03 0b 21 33 00 23 15 00 
        03 19 22 a7 00 27 15 00 01 19 3f fe 00 21 1f 00 01 1c 0b 27 01 16 1f 00
```