### PR TITLE
Fix/SN-5028 Cltool FlashCfg errors

### DIFF
--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -264,6 +264,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         else if (startsWith(a, "-flashCfg="))
         {
             g_commandLineOptions.flashCfg = &a[10];
+            g_commandLineOptions.displayMode = cInertialSenseDisplay::eDisplayMode::DMODE_QUIET;
         }
         else if (startsWith(a, "-flashCfg"))
         {
@@ -647,7 +648,17 @@ bool cltool_updateFlashCfg(InertialSense& inertialSenseInterface, string flashCf
         {
             vector<string> keyAndValue;
             splitString(keyValues[i], '=', keyAndValue);
-            if (keyAndValue.size() == 2)
+            if (keyAndValue.size() == 1) {
+                // read flash config and display only the selected values
+                data_mapping_string_t stringBuffer;
+                for (map_name_to_info_t::const_iterator i = flashMap.begin(); i != flashMap.end(); i++)
+                {
+                    if ((i->second.name == keyAndValue[0]) && (cISDataMappings::DataToString(i->second, NULL, (const uint8_t*)&flashCfg, stringBuffer)))
+                    {
+                        cout << i->second.name << " = " << stringBuffer << endl;
+                    }
+                }
+            } else if (keyAndValue.size() == 2)
             {
                 if (flashMap.find(keyAndValue[0]) == flashMap.end())
                 {

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2824,49 +2824,36 @@ bool cISDataMappings::StringToData(const char* stringBuffer, int stringLength, c
     return StringToVariable(stringBuffer, stringLength, ptr, info.dataType, info.dataSize, radix, json);
 }
 
-
 bool cISDataMappings::StringToVariable(const char* stringBuffer, int stringLength, const uint8_t* dataBuffer, eDataType dataType, uint32_t dataSize, int radix, bool json)
 {
     switch (dataType)
     {
     case DataTypeInt8:
-        *(int8_t*)dataBuffer = (int8_t)strtol(stringBuffer, NULL, radix);
-        break;
-
-    case DataTypeUInt8:
-        *(uint8_t*)dataBuffer = (uint8_t)strtoul(stringBuffer, NULL, radix);
-        break;
-
     case DataTypeInt16:
-        *(int16_t*)dataBuffer = (int16_t)strtol(stringBuffer, NULL, radix);
-        break;
-
-    case DataTypeUInt16:
-        *(uint16_t*)dataBuffer = (uint16_t)strtoul(stringBuffer, NULL, radix);
-        break;
-
     case DataTypeInt32:
-        *(int32_t*)dataBuffer = (int32_t)strtol(stringBuffer, NULL, radix);
+        protectUnalignedAssign<int32_t>((void*)dataBuffer, strtol(stringBuffer, NULL, radix));
         break;
 
+        case DataTypeUInt8:
+    case DataTypeUInt16:
     case DataTypeUInt32:
-        *(uint32_t*)dataBuffer = (uint32_t)strtoul(stringBuffer, NULL, radix);
+        protectUnalignedAssign<uint32_t>((void*)dataBuffer, strtoul(stringBuffer, NULL, radix));
         break;
 
     case DataTypeInt64:
-        *(int64_t*)dataBuffer = (int64_t)strtoll(stringBuffer, NULL, radix);
+        protectUnalignedAssign<int64_t>((void*)dataBuffer, strtoll(stringBuffer, NULL, radix));
         break;
 
     case DataTypeUInt64:
-        *(uint64_t*)dataBuffer = (uint64_t)strtoull(stringBuffer, NULL, radix);
+        protectUnalignedAssign<uint64_t>((void*)dataBuffer, strtoull(stringBuffer, NULL, radix));
         break;
 
     case DataTypeFloat:
-        *(float*)dataBuffer = strtof(stringBuffer, NULL);
+        protectUnalignedAssign<float>((void*)dataBuffer, strtod(stringBuffer, NULL));
         break;
 
     case DataTypeDouble:
-        *(double*)dataBuffer = strtod(stringBuffer, NULL);
+        protectUnalignedAssign<double>((void*)dataBuffer, strtod(stringBuffer, NULL));
         break;
 
     case DataTypeString:
@@ -3131,8 +3118,7 @@ double cISDataMappings::GetTimestamp(const p_data_hdr_t* hdr, const uint8_t* buf
             if (timeStampField->dataType == DataTypeDouble)
             {
                 // field is seconds, use as is
-                double secVal = (*(double*)ptr);  // This seems a little weird, but this is necessary to work around compiler/pointer alignment issues on armv7
-                return secVal;
+                return protectUnalignedAssign<double>((void *)ptr);
             }
             else if (timeStampField->dataType == DataTypeUInt32)
             {

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -246,6 +246,28 @@ private:
 	const data_info_t* m_timestampFields[DID_COUNT];
 	map_name_to_info_t m_lookupInfo[DID_COUNT];
 
+    #define PROTECT_UNALIGNED_ASSIGNS
+    template<typename T>
+    static inline void protectUnalignedAssign(void* out, T in) {
+    #ifdef PROTECT_UNALIGNED_ASSIGNS
+        memcpy((void*)out, (void*)&in, sizeof(T));
+    #else
+        *(T*)out = in;
+    #endif
+    }
+
+    template<typename T>
+    static inline T protectUnalignedAssign(void* in) {
+    #ifdef PROTECT_UNALIGNED_ASSIGNS
+        T out;
+        memcpy((void*)&out, in, sizeof(T));
+        return out;
+    #else
+        return *(T*)in;
+    #endif
+    }
+
+
 #if PLATFORM_IS_EMBEDDED
 
 	// on embedded we cannot new up C++ runtime until after free rtos has started


### PR DESCRIPTION
Tries to protect against unaligned-variable assignments on Armv7.
Added support to query/print single flashCfg parameters.