### PR TITLE
Add a sys cmd to reset GPX through IMX

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1532,6 +1532,7 @@ enum eSystemCommand
     SYS_CMD_GPX_ENABLE_SERIAL_BRIDGE_CUR_PORT_LOOPBACK  = 35,           // (uint32 inv: 4294967260) // Enables serial bridge on IMX to GPX and loopback on GPX.
     SYS_CMD_GPX_HARD_RESET_GNSS1                        = 36,           // (uint32 inv: 4294967259)
     SYS_CMD_GPX_HARD_RESET_GNSS2                        = 37,           // (uint32 inv: 4294967258)
+    SYS_CMD_GPX_SOFT_RESET_GPX                          = 38,           // (uint32 inv: 4294967257)
 
     SYS_CMD_TEST_GPIO                                   = 64,           // (uint32 inv: 4294967231)
 


### PR DESCRIPTION
Create SYS_CMD_GPX_SOFT_RESET_GPX (similar to SYS_CMD_GPX_HARD_RESET_GNSS1) as a way to issue a GPX reset through the IMX.

