### PR TITLE
SN-5030 fix evaltool windows build

### DIFF
--- a/python/logInspector/logInspector.py
+++ b/python/logInspector/logInspector.py
@@ -85,18 +85,21 @@ def setDataInformationDirectory(path, startMode=START_MODE_HOT):
         data['dataInfo']['dataDirectory'] = os.path.dirname(path).replace('\\','/')
         data['dataInfo']['subDirectories'] = [os.path.basename(path)]
         serialnumbers = []
+        logtype = 'DAT'
         for root, dirs, files in os.walk(path):
             for filename in files:
                 if "LOG_SN" in filename:
-                    serialnum = filename[4:11]
+                    serialnum = re.search(r'\d+', filename).group()
                     if serialnum not in serialnumbers:
                         serialnumbers += [serialnum]
+                if ".raw" in filename.lower():
+                    logtype = "RAW"
 
         data['processData'] = {}
         data['processData']['datasets'] = [{}]
-        data['processData']['datasets'][0]['SerialNumbers'] = serialnumbers         # TODO (whj 4/4) We need to make sure the list of serial numbers allows for enough digits
+        data['processData']['datasets'][0]['SerialNumbers'] = serialnumbers
         data['processData']['datasets'][0]['folder'] = os.path.basename(path)
-        data['processData']['datasets'][0]['logType'] = 'DAT'                       # TODO (whj 4/4) We need to set this based on the log type
+        data['processData']['datasets'][0]['logType'] = logtype
         if startMode == START_MODE_HOT:
             data['processData']['datasets'][0]['startMode'] = 'HOT'
         elif startMode == START_MODE_COLD:

--- a/python/logInspector/logInspector.py
+++ b/python/logInspector/logInspector.py
@@ -94,9 +94,9 @@ def setDataInformationDirectory(path, startMode=START_MODE_HOT):
 
         data['processData'] = {}
         data['processData']['datasets'] = [{}]
-        data['processData']['datasets'][0]['SerialNumbers'] = serialnumbers
+        data['processData']['datasets'][0]['SerialNumbers'] = serialnumbers         # TODO (whj 4/4) We need to make sure the list of serial numbers allows for enough digits
         data['processData']['datasets'][0]['folder'] = os.path.basename(path)
-        data['processData']['datasets'][0]['logType'] = 'DAT'
+        data['processData']['datasets'][0]['logType'] = 'DAT'                       # TODO (whj 4/4) We need to set this based on the log type
         if startMode == START_MODE_HOT:
             data['processData']['datasets'][0]['startMode'] = 'HOT'
         elif startMode == START_MODE_COLD:

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -937,7 +937,12 @@ protocol_type_t is_comm_parse_timeout(is_comm_instance_t* c, uint32_t timeMs)
 			case RTCM3_START_BYTE:          if (c->config.enabledMask & ENABLE_PROTOCOL_RTCM3)  { setParserStart(c, processRtcm3Pkt); }    break;
 			case SPARTN_START_BYTE:         if (c->config.enabledMask & ENABLE_PROTOCOL_SPARTN) { setParserStart(c, processSpartnByte); }  break;
 			case SONY_START_BYTE:           if (c->config.enabledMask & ENABLE_PROTOCOL_SONY)   { setParserStart(c, processSonyByte); }    break;
-			default:                        if (reportParseError(c)) { return _PTYPE_PARSE_ERROR; }                                       break;
+			default:                        
+				if (reportParseError(c)) 
+				{ 
+					return _PTYPE_PARSE_ERROR; 
+				}                                       
+				break;
 			}
 		}
 		else

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -375,8 +375,11 @@ bool cISLogger::LoadFromDirectory(const string& directory, eLogType logType, vec
 			// check for unique serial numbers
 			if (serialNumbers.find(serialNumber) == serialNumbers.end())
 			{
-				if (serials.size() == 0 || ((find(serials.begin(), serials.end(), "SN" + serialNumber) != serials.end() ||
-					find(serials.begin(), serials.end(), "ALL") != serials.end()))) // and that it is a serial number we want to use
+				bool emptySerialsList = serials.size() == 0;
+				bool inSerialsList = find(serials.begin(), serials.end(), "SN" + serialNumber) != serials.end();
+				bool useAll = find(serials.begin(), serials.end(), "ALL") != serials.end();
+
+				if (emptySerialsList || inSerialsList || useAll) // and that it is a serial number we want to use
 				{
 					serialNumbers.insert(serialNumber);
 

--- a/tests/test_data_utils.cpp
+++ b/tests/test_data_utils.cpp
@@ -316,6 +316,9 @@ void GenerateMessage(test_message_t &msg, protocol_type_t ptype)
     int i = dist(rng);
     float f = (float)i * 0.001;
 
+    static gps_pos_t gpsPos = {};
+    static gps_vel_t gpsVel = {};
+
     // Iterate through all ptypes
     if (ptype == _PTYPE_NONE)
     {
@@ -333,8 +336,6 @@ void GenerateMessage(test_message_t &msg, protocol_type_t ptype)
 
     case _PTYPE_NMEA:
         GenerateISB(msg, i, f);
-        static gps_pos_t gpsPos = {};
-        static gps_vel_t gpsVel = {};
         switch (msg.dataHdr.id)
         {
         case DID_PIMU:      msg.pktSize = nmea_ppimu((char*)msg.comm.rxBuf.start, msg.comm.rxBuf.size, msg.data.pImu); break;


### PR DESCRIPTION
- Fix test_data_utils.cpp build in Windows caused by variables defined within a switch statement.
- Fix LogInspector's ability to queue dataInformation.json used for the NavProcess post processing project for logs with serial numbers oflength different than 5 digits and .raw logs.