### PR TITLE
SN-5124 - Implements "-list-devices" in cltool

### DIFF
--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -457,6 +457,11 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             g_commandLineOptions.updateFirmwareTarget = fwUpdate::TARGET_HOST;      // use legacy firmware update mechanism
             g_commandLineOptions.bootloaderVerify = true;
         }
+        else if (startsWith(a, "-list-devices"))
+        {
+            g_commandLineOptions.list_devices = true;
+            g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_QUIET;
+        }
 		else if (startsWith(a, "-v") || startsWith(a, "--version"))
 		{
 			cout << cltool_version() << endl;
@@ -552,6 +557,7 @@ void cltool_outputUsage()
 	cout << endlbOn;
 	cout << "OPTIONS (General)" << endl;
 	cout << "    -h --help" << boldOff << "       Display this help menu." << endlbOn;
+    cout << "    -list-devices" << boldOff << "   Discovers and prints a list of discovered Inertial Sense devices and connected ports." << endlbOn;
 	cout << "    -c " << boldOff << "DEVICE_PORT  Select the serial port. Set DEVICE_PORT to \"*\" for all ports or \"*4\" for only first four available." << endlbOn;
 	cout << "    -baud=" << boldOff << "BAUDRATE  Set serial port baudrate.  Options: " << IS_BAUDRATE_115200 << ", " << IS_BAUDRATE_230400 << ", " << IS_BAUDRATE_460800 << ", " << IS_BAUDRATE_921600 << " (default)" << endlbOn;
 	cout << "    -magRecal[n]" << boldOff << "    Recalibrate magnetometers: 0=multi-axis, 1=single-axis" << endlbOn;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -24,6 +24,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISDisplay.h"
 #include "ISUtilities.h"
 #include "ISBootloaderBase.h"
+#include "util/util.h"
 
 #define APP_NAME                "cltool"
 #if PLATFORM_IS_WINDOWS
@@ -93,6 +94,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     fwUpdate::target_t updateFirmwareTarget = fwUpdate::TARGET_HOST;
     uint32_t updateFirmwareSlot = 0;
 	uint32_t runDuration = 0;				// Run for this many millis before exiting (0 = indefinitely)
+	bool list_devices = false;				// if true, dumps results of findDevices() including port name.
 } cmd_options_t;
 
 extern cmd_options_t g_commandLineOptions;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -582,7 +582,7 @@ static int cltool_dataStreaming()
                                                                           d.devInfo.firmwareVer[0], d.devInfo.firmwareVer[1], d.devInfo.firmwareVer[2], d.devInfo.firmwareVer[3],
                                                                           d.devInfo.buildNumber, d.devInfo.buildType);
                 }
-                maxPortLen = std::max(maxPortLen, (int)strlen(d.serialPort.port));
+                maxPortLen = std::max<int>(maxPortLen, (int)strlen(d.serialPort.port));
             }
         }
         for (auto i : portDevices) {

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -37,7 +37,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 // Contains command line parsing and utility functions.  Include this in your project to use these utility functions.
 #include "cltool.h"
 #include "protocol_nmea.h"
-#include "natsort.h"
+#include "util/natsort.h"
 
 using namespace std;
 

--- a/scripts/windows/build_sdk_examples.bat
+++ b/scripts/windows/build_sdk_examples.bat
@@ -13,12 +13,12 @@ REM MSBUILD_EXECUTABLE, MSBUILD_OPTIONS and NMAKE_EXECUTABLE are set in init_bui
 ::###############################################################################
 
 call :build_header "SDK Example Projects"
-cd %~dp0..\ExampleProjects
+cd %SDK_DIR%\ExampleProjects
 cmake -S . -B ./build "-DCMAKE_BUILD_TYPE=Release" && cmake --build ./build --config Release -j 7
 call :build_footer
 
 @REM cd to imx/scripts/windows directory
-cd %~dp0    
+cd %SDK_DIR%\scripts\windows
 
 :finish
 

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISConstants.h"
 #include "ISDataMappings.h"
 #include "ISLogFileFactory.h"
+#include "util/util.h"
 
 using namespace std;
 
@@ -244,29 +245,15 @@ bool cDeviceLog::OpenNextReadFile()
 
 string cDeviceLog::GetNewFileName(uint32_t serialNumber, uint32_t fileCount, const char* suffix)
 {
-	// file name 
-#if 1
-    char filename[200];
-    SNPRINTF(filename, sizeof(filename), "%s/%s%d_%s_%04d%s%s", 
-        m_directory.c_str(), 
+    return utils::string_format("%s/%s%d_%s_%04d%s%s",
+        m_directory.c_str(),
         IS_LOG_FILE_PREFIX, 
         (int)serialNumber, 
         m_timeStamp.c_str(), 
         (int)(fileCount % 10000), 
         (suffix == NULL || *suffix == 0 ? "" : (string("_") + suffix).c_str()), 
-        LogFileExtention().c_str());
-    return filename;
-#else
-    // This code is not working on the embedded platform
-	ostringstream filename;
-	filename << m_directory << "/" << IS_LOG_FILE_PREFIX <<
-		serialNumber << "_" <<
-		m_timeStamp << "_" <<
-		setfill('0') << setw(4) << (fileCount % 10000) <<
-		(suffix == NULL || *suffix == 0 ? "" : string("_") + suffix) <<
-		LogFileExtention();
-	return filename.str();
-#endif
+        LogFileExtention().c_str()
+    );
 }
 
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -271,12 +271,13 @@ void InertialSense::LoggerThread(void* info)
             // log the packets
             for (map<int, vector<p_data_buf_t>>::iterator i = packets.begin(); i != packets.end(); i++)
             {
-                for (size_t j = 0; j < i->second.size(); j++)
-                {
-                    if (!inertialSense->m_logger.LogData(i->first, &i->second[j].hdr, i->second[j].buf))
-                    {
-                        // Failed to write to log
-                        SLEEP_MS(20);
+                if (inertialSense->m_logger.GetType() != cISLogger::LOGTYPE_RAW) {
+                    size_t numPackets = i->second.size();
+                    for (size_t j = 0; j < numPackets; j++) {
+                        if (!inertialSense->m_logger.LogData(i->first, &i->second[j].hdr, i->second[j].buf)) {
+                            // Failed to write to log
+                            SLEEP_MS(20); // FIXME:  This maybe problematic, as it may unnecessarily delay the thread, leading run-away memory usage.
+                        }
                     }
                 }
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -610,11 +610,11 @@ typedef struct PACKED
 	/** Reserved bits */
 	uint16_t        reserved;
 
-	/** Unused */
-	uint8_t         reserved2;
-
 	/** Hardware Type: 1=uINS, 2=EVB, 3=IMX, 4=GPX (see eIsHardwareType) */
 	uint8_t         hardwareType;
+
+    /** Unused */
+    uint8_t         reserved2;
 
     /** Serial number */
     uint32_t        serialNumber;

--- a/src/util/natsort.cpp
+++ b/src/util/natsort.cpp
@@ -1,0 +1,168 @@
+/**
+ * @file natsort.cpp 
+ * @brief ${BRIEF_DESC}
+ *
+ * @author Kyle Mallory on 4/27/24.
+ * @copyright Copyright (c) 2024 Inertial Sense, Inc. All rights reserved.
+ */
+
+/* -*- mode: c; c-file-style: "k&r" -*-
+
+  strnatcmp.c -- Perform 'natural order' comparisons of strings in C.
+  Copyright (C) 2000, 2004 by Martin Pool <mbp sourcefrog net>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "util/natsort.h"
+#include <stddef.h>     /* size_t */
+#include <ctype.h>
+
+namespace utils {
+
+    /* These are defined as macros to make it easier to adapt this code to
+     * different characters types or comparison functions. */
+    static inline int nat_isdigit(nat_char a) {
+        return isdigit((unsigned char) a);
+    }
+
+    static inline int nat_isspace(nat_char a) {
+        return isspace((unsigned char) a);
+    }
+
+    static inline nat_char nat_toupper(nat_char a) {
+        return toupper((unsigned char) a);
+    }
+
+    static int compare_right(nat_char const *a, nat_char const *b) {
+        int bias = 0;
+
+        /* The longest run of digits wins.  That aside, the greatest
+           value wins, but we can't know that it will until we've scanned
+           both numbers to know that they have the same magnitude, so we
+           remember it in BIAS. */
+        for (;; a++, b++) {
+            if (!nat_isdigit(*a)  &&  !nat_isdigit(*b))
+                return bias;
+            if (!nat_isdigit(*a))
+                return -1;
+            if (!nat_isdigit(*b))
+                return +1;
+            if (*a < *b) {
+                if (!bias)
+                    bias = -1;
+            } else if (*a > *b) {
+                if (!bias)
+                    bias = +1;
+            } else if (!*a  &&  !*b)
+                return bias;
+        }
+
+        return 0;
+    }
+
+
+    static int compare_left(nat_char const *a, nat_char const *b) {
+        /* Compare two left-aligned numbers: the first to have a
+           different value wins. */
+        for (;; a++, b++) {
+            if (!nat_isdigit(*a)  &&  !nat_isdigit(*b))
+                return 0;
+            if (!nat_isdigit(*a))
+                return -1;
+            if (!nat_isdigit(*b))
+                return +1;
+            if (*a < *b)
+                return -1;
+            if (*a > *b)
+                return +1;
+        }
+
+        return 0;
+    }
+
+
+    static int strnatcmp0(nat_char const *a, nat_char const *b, int fold_case) {
+        int ai, bi;
+        nat_char ca, cb;
+        int fractional, result;
+
+        ai = bi = 0;
+        while (1) {
+            ca = a[ai]; cb = b[bi];
+
+            /* skip over leading spaces or zeros */
+            while (nat_isspace(ca))
+                ca = a[++ai];
+
+            while (nat_isspace(cb))
+                cb = b[++bi];
+
+            /* process run of digits */
+            if (nat_isdigit(ca)  &&  nat_isdigit(cb)) {
+                fractional = (ca == '0' || cb == '0');
+
+                if (fractional) {
+                    if ((result = compare_left(a+ai, b+bi)) != 0)
+                        return result;
+                } else {
+                    if ((result = compare_right(a+ai, b+bi)) != 0)
+                        return result;
+                }
+            }
+
+            if (!ca && !cb) {
+                /* The strings compare the same.  Perhaps the caller
+                   will want to call strcmp to break the tie. */
+                return 0;
+            }
+
+            if (fold_case) {
+                ca = nat_toupper(ca);
+                cb = nat_toupper(cb);
+            }
+
+            if (ca < cb)
+                return -1;
+
+            if (ca > cb)
+                return +1;
+
+            ++ai; ++bi;
+        }
+    }
+
+
+    int strnatcmp(nat_char const *a, nat_char const *b) {
+        return strnatcmp0(a, b, 0);
+    }
+
+
+    /* Compare, recognizing numeric string and ignoring case. */
+    int strnatcasecmp(nat_char const *a, nat_char const *b) {
+        return strnatcmp0(a, b, 1);
+    }
+
+    int natcmp(const std::string& a, const std::string& b) {
+        return strnatcmp0(a.c_str(), b.c_str(), 0);
+    }
+
+    int natcasecmp(const std::string& a, const std::string& b) {
+        return strnatcmp0(a.c_str(), b.c_str(), 1);
+    }
+
+} // utils

--- a/src/util/natsort.h
+++ b/src/util/natsort.h
@@ -1,0 +1,59 @@
+/**
+ * @file natsort.h 
+ * @brief ${BRIEF_DESC}
+ *
+ * @author Kyle Mallory on 4/27/24.
+ * @copyright Copyright (c) 2024 Inertial Sense, Inc. All rights reserved.
+ */
+
+/* -*- mode: c; c-file-style: "k&r" -*-
+
+  strnatcmp.c -- Perform 'natural order' comparisons of strings in C.
+  Copyright (C) 2000, 2004 by Martin Pool <mbp sourcefrog net>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef INERTIALSENSE_SDK__NATSORT_H
+#define INERTIALSENSE_SDK__NATSORT_H
+
+#include <string>
+
+namespace utils {
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+    /* CUSTOMIZATION SECTION
+     *
+     * You can change this typedef, but must then also change the inline
+     * functions in strnatcmp.c */
+    typedef char nat_char;
+
+    int strnatcmp(nat_char const *a, nat_char const *b);
+    int strnatcasecmp(nat_char const *a, nat_char const *b);
+
+    int natcmp(const std::string& a, const std::string& b);
+    int natcasecmp(const std::string& a, const std::string& b);
+
+#ifdef __cplusplus
+    }
+#endif
+} // utils
+
+#endif //INERTIALSENSE_SDK__NATSORT_H

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -6,8 +6,8 @@
  * @copyright Copyright (c) 2024 Inertial Sense, Inc. All rights reserved.
  */
 
-#ifndef IS_GPX_UTIL_H
-#define IS_GPX_UTIL_H
+#ifndef INERTIALSENSE_SDK__UTIL_H
+#define INERTIALSENSE_SDK__UTIL_H
 
 #include <string>
 #include <memory>
@@ -30,4 +30,4 @@ namespace utils {
 };
 
 
-#endif //IS_GPX_UTIL_H
+#endif //INERTIALSENSE_SDK__UTIL_H


### PR DESCRIPTION
Implement "--list-devices" (or -list-devices) in clTool to discover all Inertial Sense devices, their hardware and firmware information, and print the results in a natual sorted order by port name:

```$ ./cltool --list-devices
/dev/ttyACM0 --> SN62842, IMX-5.0 (fw2.0.3 37c)
/dev/ttyACM1 --> SN62855, IMX-5.0 (fw2.0.3 37c)
/dev/ttyACM2 --> SN62850, IMX-5.0 (fw2.0.3 37c)
/dev/ttyACM3 --> SN62849, IMX-5.0 (fw2.0.3 37c)
/dev/ttyACM4 --> SN62806, IMX-5.0 (fw2.0.3 37c)
/dev/ttyACM5 --> SN62844, IMX-5.0 (fw2.0.3 37c)
/dev/ttyACM6 --> SN62833, IMX-5.0 (fw2.0.3 37c)
/dev/ttyACM7 --> SN62832, IMX-5.0 (fw2.0.3 37c)
/dev/ttyACM8 --> SN928398908, GPX-1.0 (fw2.0.6 233r)
/dev/ttyACM9 --> SN928396093, GPX-1.0 (fw2.0.6 233r)
/dev/ttyACM10 --> SN928399420, GPX-1.0 (fw2.0.6 233r)
/dev/ttyACM11 --> SN928405052, GPX-1.0 (fw2.0.6 233r)
/dev/ttyACM12 --> SN928393021, GPX-1.0 (fw2.0.6 233r)
/dev/ttyACM13 --> SN928392766, GPX-1.0 (fw2.0.6 233r)
/dev/ttyACM14 --> SN928402750, GPX-1.0 (fw2.0.6 233r)
/dev/ttyACM15 --> SN928400444, GPX-1.0 (fw2.0.6 233r)

Process finished with exit code 0
```