### PR TITLE
SN-4901 ISDevice + UpTime to SYS_PARAMS & GPX_STATUS

### DIFF
--- a/python/pylib/ISToolsData.py
+++ b/python/pylib/ISToolsData.py
@@ -204,6 +204,7 @@ class sSysParams(ct.Structure):
                 ('magInclination',  ct.c_float),
                 ('magDeclination',  ct.c_float),
                 ('genFaultCode',    ct.c_uint32),
+                ('upTime',          ct.c_double),
                 ]
 
 class sInsParams(ct.Structure):

--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -843,7 +843,7 @@ typedef struct
     int64_t time;
 
     /** fraction of second under 1 s */
-    double sec;         
+    double sec;
 } gtime_t;
 
 POP_PACK

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -409,6 +409,7 @@ static void PopulateSysParamsMappings(map_name_to_info_t mappings[DID_COUNT])
     ADD_MAP(m, totalSize, "flashCfgChecksum", flashCfgChecksum, 0, DataTypeUInt32, uint32_t, 0);
     ADD_MAP(m, totalSize, "navUpdatePeriodMs", navUpdatePeriodMs, 0, DataTypeUInt32, uint32_t, 0);
     ADD_MAP(m, totalSize, "genFaultCode", genFaultCode, 0, DataTypeUInt32, uint32_t, DataFlagsDisplayHex);
+    ADD_MAP(m, totalSize, "upTime", upTime, 0, DataTypeDouble, double, 0);
 
     ASSERT_SIZE(totalSize);
 }
@@ -1079,7 +1080,7 @@ static void PopulateISEventMappings(map_name_to_info_t mappings[DID_COUNT])
     uint32_t totalSize = 0;
 
 
-    ADD_MAP(m, totalSize, "Time stamp of message", timeMs, 0, DataTypeUInt32, uint32_t, 0);
+    ADD_MAP(m, totalSize, "Time stamp of message (System Up seconds)", time, 0, DataTypeDouble, double, 0);
     ADD_MAP(m, totalSize, "Senders serial number", senderSN, 0, DataTypeUInt32, uint32_t, 0);
     ADD_MAP(m, totalSize, "Sender hardware type", senderHdwId, 0, DataTypeUInt16, uint16_t, 0);
 
@@ -1142,6 +1143,8 @@ static void PopulateGpxStatusMappings(map_name_to_info_t mappings[DID_COUNT])
     ADD_MAP(m, totalSize, "rtkMode", rtkMode, 0, DataTypeUInt32, uint32_t, 0);
     ADD_MAP(m, totalSize, "gnss1RunState", gnss1RunState, 0, DataTypeUInt32, uint32_t, 0);
     ADD_MAP(m, totalSize, "gnss2RunState", gnss2RunState, 0, DataTypeUInt32, uint32_t, 0);
+    ADD_MAP(m, totalSize, "SourcePort", gpxSourcePort, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "upTime", upTime, 0, DataTypeDouble, double, 0);
 }
 
 static void PopulateEvbStatusMappings(map_name_to_info_t mappings[DID_COUNT])

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file ISDevice.cpp 
+ * @brief ${BRIEF_DESC}
+ *
+ * @author Kyle Mallory on 2/24/24.
+ * @copyright Copyright (c) 2024 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "ISDevice.h"
+#include "ISFirmwareUpdater.h"
+
+bool ISDeviceUpdater::inProgress() { return (fwUpdater && !fwUpdater->fwUpdate_isDone()); }
+
+void ISDeviceUpdater::update() {
+    if (fwUpdater) {
+        if ("upload" == fwUpdater->getActiveCommand()) {
+            if (fwUpdater->fwUpdate_getSessionTarget() != lastTarget) {
+                hasError = false;
+                lastStatus = fwUpdate::NOT_STARTED;
+                lastMessage.clear();
+                lastTarget = fwUpdater->fwUpdate_getSessionTarget();
+            }
+            lastSlot = fwUpdater->fwUpdate_getSessionImageSlot();
+
+            if ((fwUpdater->fwUpdate_getSessionStatus() == fwUpdate::NOT_STARTED) && fwUpdater->isWaitingResponse()) {
+                // We're just starting (no error yet, but no response either)
+                lastStatus = fwUpdate::INITIALIZING;
+                lastMessage = ISFirmwareUpdater::fwUpdate_getNiceStatusName(lastStatus);
+            } else if ((fwUpdater->fwUpdate_getSessionStatus() != fwUpdate::NOT_STARTED) && (lastStatus != fwUpdater->fwUpdate_getSessionStatus())) {
+                // We're got a valid status update (error or otherwise)
+                lastStatus = fwUpdater->fwUpdate_getSessionStatus();
+                lastMessage = ISFirmwareUpdater::fwUpdate_getNiceStatusName(lastStatus);
+
+                // check for error
+                if (!hasError && fwUpdater && fwUpdater->fwUpdate_getSessionStatus() < fwUpdate::NOT_STARTED) {
+                    hasError = true;
+                }
+            }
+
+            // update our upload progress
+            if ((lastStatus == fwUpdate::IN_PROGRESS)) {
+                percent = ((float) fwUpdater->fwUpdate_getNextChunkID() / (float) fwUpdater->fwUpdate_getTotalChunks()) * 100.f;
+            } else {
+                percent = lastStatus <= fwUpdate::READY ? 0.f : 100.f;
+            }
+        } else if ("waitfor" == fwUpdater->getActiveCommand()) {
+            lastMessage = "Waiting for response from device.";
+        } else if ("reset" == fwUpdater->getActiveCommand()) {
+            lastMessage = "Resetting device.";
+        } else if ("delay" == fwUpdater->getActiveCommand()) {
+            lastMessage = "Waiting...";
+        }
+
+        if (!fwUpdater->hasPendingCommands()) {
+            if (!hasError) {
+                lastMessage = "Completed successfully.";
+            } else {
+                lastMessage = "Error: ";
+                lastMessage += ISFirmwareUpdater::fwUpdate_getNiceStatusName(lastStatus);
+            }
+        }
+
+        // cleanup if we're done.
+        if (fwUpdater->fwUpdate_isDone()) {
+            delete fwUpdater;
+            fwUpdater = nullptr;
+        }
+    } else {
+        percent = 0.0;
+    }
+}
+

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -1,0 +1,66 @@
+/**
+ * @file ISDevice.h 
+ * @brief ${BRIEF_DESC}
+ *
+ * @author Kyle Mallory on 2/24/24.
+ * @copyright Copyright (c) 2024 Inertial Sense, Inc. All rights reserved.
+ */
+
+#ifndef INERTIALSENSESDK_ISDEVICE_H
+#define INERTIALSENSESDK_ISDEVICE_H
+
+#include "protocol/FirmwareUpdate.h"
+// #include "ISFirmwareUpdater.h"
+
+extern "C"
+{
+    // [C COMM INSTRUCTION]  Include data_sets.h and com_manager.h
+    #include "data_sets.h"
+    #include "com_manager.h"
+    #include "serialPortPlatform.h"
+}
+
+class ISFirmwareUpdater;
+
+class ISDeviceUpdater {
+public:
+    ISFirmwareUpdater* fwUpdater;
+    float percent;
+    bool hasError;
+    uint16_t lastSlot;
+    fwUpdate::target_t lastTarget;
+    fwUpdate::update_status_e lastStatus;
+    std::string lastMessage;
+
+    std::vector<std::string> target_idents;
+    std::vector<std::string> target_messages;
+
+    bool inProgress();
+    void update();
+};
+
+class ISDevice {
+public:
+    int portHandle;
+    serial_port_t serialPort;
+    // libusb_device* usbDevice; // reference to the USB device (if using a USB connection), otherwise should be nullptr.
+    dev_info_t devInfo;
+    system_command_t sysCmd;
+    nvm_flash_cfg_t flashCfg;
+    unsigned int flashCfgUploadTimeMs;		// (ms) non-zero time indicates an upload is in progress and local flashCfg should not be overwritten
+    uint32_t flashCfgUploadChecksum;
+    evb_flash_cfg_t evbFlashCfg;
+    sys_params_t sysParams;
+    fwUpdate::update_status_e closeStatus;
+    ISDeviceUpdater fwUpdate;
+
+    static ISDevice invalidRef;
+
+    ISDevice() { };
+
+
+};
+
+
+
+#endif //INERTIALSENSESDK_ISDEVICE_H

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -42,17 +42,17 @@ public:
 class ISDevice {
 public:
     int portHandle;
-    serial_port_t serialPort;
+    serial_port_t serialPort = { };
     // libusb_device* usbDevice; // reference to the USB device (if using a USB connection), otherwise should be nullptr.
-    dev_info_t devInfo;
-    system_command_t sysCmd;
-    nvm_flash_cfg_t flashCfg;
-    unsigned int flashCfgUploadTimeMs;		// (ms) non-zero time indicates an upload is in progress and local flashCfg should not be overwritten
-    uint32_t flashCfgUploadChecksum;
-    evb_flash_cfg_t evbFlashCfg;
-    sys_params_t sysParams;
-    fwUpdate::update_status_e closeStatus;
-    ISDeviceUpdater fwUpdate;
+    dev_info_t devInfo = { };
+    system_command_t sysCmd = { };
+    nvm_flash_cfg_t flashCfg = { };
+    unsigned int flashCfgUploadTimeMs = 0;		// (ms) non-zero time indicates an upload is in progress and local flashCfg should not be overwritten
+    uint32_t flashCfgUploadChecksum = 0;
+    evb_flash_cfg_t evbFlashCfg = { };
+    sys_params_t sysParams = { };
+    fwUpdate::update_status_e closeStatus = { };
+    ISDeviceUpdater fwUpdate = { };
 
     static ISDevice invalidRef;
 

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1374,7 +1374,7 @@ string cInertialSenseDisplay::DataToStringSysParams(const sys_params_t& sys, con
 	if (m_displayMode == DMODE_PRETTY)
 	{
 		ptr = StatusToString(ptr, ptrEnd, sys.insStatus, sys.hdwStatus);
-		ptr += SNPRINTF(ptr, ptrEnd - ptr, "\tTemp:  IMU %4.1f C\tBaro %4.1f C\tMCU %4.1f C\n", sys.imuTemp, sys.baroTemp, sys.mcuTemp);
+		ptr += SNPRINTF(ptr, ptrEnd - ptr, "\tTemp:  IMU %4.1f C\tBaro %4.1f C\tMCU %4.1f C\tUpTime %4.1lf s\n", sys.imuTemp, sys.baroTemp, sys.mcuTemp, sys.upTime);
 	}
 
 	return buf;
@@ -1605,8 +1605,8 @@ string cInertialSenseDisplay::DataToStringGPXStatus(const gpx_status_t &gpxStatu
     ptr += SNPRINTF(ptr, ptrEnd - ptr, " %.3lfs", gpxStatus.timeOfWeekMs / 1000.0);
 #endif
 
-    ptr += SNPRINTF(ptr, ptrEnd - ptr, ", status: 0x%08x, hdwStatus: 0x%08x, gnss1RunState: %d, gnss2RunState: %d, mcuTemp: %0.3lf\n",
-                    gpxStatus.status, gpxStatus.hdwStatus, gpxStatus.gnss1RunState, gpxStatus.gnss2RunState, gpxStatus.mcuTemp
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, ", status: 0x%08x, hdwStatus: 0x%08x, gnss1RunState: %d, gnss2RunState: %d, mcuTemp: %0.3lf, upTime: %lf\n",
+                    gpxStatus.status, gpxStatus.hdwStatus, gpxStatus.gnss1RunState, gpxStatus.gnss2RunState, gpxStatus.mcuTemp, gpxStatus.upTime
     );
 
     return buf;

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -10,6 +10,8 @@
 
 #include <protocol/FirmwareUpdate.h>
 
+#include "ISDevice.h"
+// #include "InertialSense.h"
 #include "ISFileManager.h"
 #include "ISUtilities.h"
 #include "util/md5.h"
@@ -101,6 +103,9 @@ public:
      * @param portName a named reference to the connected port handle (ie, COM1 or /dev/ttyACM0)
      */
     ISFirmwareUpdater(int portHandle, const char *portName, const dev_info_t *devInfo) : FirmwareUpdateHost(), pHandle(portHandle), portName(portName), devInfo(devInfo) { };
+
+    ISFirmwareUpdater(ISDevice device) : FirmwareUpdateHost(), pHandle(device.portHandle), portName(device.serialPort.port), devInfo(&device.devInfo) { };
+
     ~ISFirmwareUpdater() override {};
 
     void setTarget(fwUpdate::target_t _target);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1354,6 +1354,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
         else
         {
             ISDevice device;
+            device.portHandle = i;
             device.serialPort = serial;
             device.sysParams.flashCfgChecksum = 0xFFFFFFFF;		// Invalidate flash config checksum to trigger sync event
             m_comManagerState.devices.push_back(device);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -398,11 +398,11 @@ size_t InertialSense::DeviceCount()
  * Returns a vector of available, connected devices
  * @return
  */
-std::vector<InertialSense::is_device_t>& InertialSense::getDevices() {
+std::vector<ISDevice>& InertialSense::getDevices() {
     return m_comManagerState.devices;
 }
 
-InertialSense::is_device_t& InertialSense::getDevice(uint32_t deviceIndex) {
+ISDevice& InertialSense::getDevice(uint32_t deviceIndex) {
     return m_comManagerState.devices[deviceIndex];
 }
 
@@ -782,7 +782,7 @@ void InertialSense::SyncFlashConfig(unsigned int timeMs)
 
     for (size_t i=0; i<m_comManagerState.devices.size(); i++)
     {
-        is_device_t &device = m_comManagerState.devices[i];
+        ISDevice& device = m_comManagerState.devices[i];
 
         if (device.flashCfgUploadTimeMs)
         {	// Upload in progress
@@ -827,7 +827,7 @@ bool InertialSense::FlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
         pHandle = 0;
     }
 
-    is_device_t &device = m_comManagerState.devices[pHandle];
+    ISDevice& device = m_comManagerState.devices[pHandle];
 
     // Copy flash config
     flashCfg = device.flashCfg;
@@ -842,7 +842,7 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
     {
         return 0;
     }
-    is_device_t &device = m_comManagerState.devices[pHandle];
+    ISDevice& device = m_comManagerState.devices[pHandle];
     
     // Iterate over and upload flash config in 4 byte segments.  Upload only contiguous segments of mismatched data starting at `key` (i = 2).  Don't upload size or checksum.
     static_assert(sizeof(nvm_flash_cfg_t) % 4 == 0, "Size of nvm_flash_cfg_t must be a 4 bytes in size!!!");
@@ -929,7 +929,7 @@ void InertialSense::ProcessRxData(int pHandle, p_data_t* data)
         return;
     }
 
-    is_device_t &device = m_comManagerState.devices[pHandle];
+    ISDevice& device = m_comManagerState.devices[pHandle];
 
     switch (data->hdr.id)
     {
@@ -965,7 +965,7 @@ void InertialSense::ProcessRxNmea(int pHandle, const uint8_t* msg, int msgSize)
         m_handlerNmea(pHandle, msg, msgSize);
     }
 
-    is_device_t &device = m_comManagerState.devices[pHandle];
+    ISDevice& device = m_comManagerState.devices[pHandle];
 
     switch (getNmeaMsgId(msg, msgSize))
     {
@@ -1032,7 +1032,7 @@ is_operation_result InertialSense::updateFirmware(
     EnableDeviceValidation(true);
     if (OpenSerialPorts(comPort.c_str(), baudRate)) {
         for (int i = 0; i < (int) m_comManagerState.devices.size(); i++) {
-            is_device_t& device = m_comManagerState.devices[i];
+            ISDevice& device = m_comManagerState.devices[i];
             device.fwUpdate.fwUpdater = new ISFirmwareUpdater(i, m_comManagerState.devices[i].serialPort.port, &m_comManagerState.devices[i].devInfo);
             device.fwUpdate.fwUpdater->setTarget(targetDevice);
 
@@ -1044,6 +1044,36 @@ is_operation_result InertialSense::updateFirmware(
             device.fwUpdate.fwUpdater->setCommands(cmds);
         }
     }
+
+    printf("\n\r");
+
+#if !PLATFORM_IS_WINDOWS
+    fputs("\e[?25h", stdout);	// Turn cursor back on
+#endif
+
+    return IS_OP_OK;
+}
+
+is_operation_result InertialSense::updateFirmware(
+        ISDevice& device,
+        fwUpdate::target_t targetDevice,
+        std::vector<std::string> cmds,
+        ISBootloader::pfnBootloadProgress uploadProgress,
+        ISBootloader::pfnBootloadProgress verifyProgress,
+        ISBootloader::pfnBootloadStatus infoProgress,
+        void (*waitAction)()
+)
+{
+    EnableDeviceValidation(true);
+    device.fwUpdate.fwUpdater = new ISFirmwareUpdater(device);
+    device.fwUpdate.fwUpdater->setTarget(targetDevice);
+
+    // TODO: Implement maybe
+    device.fwUpdate.fwUpdater->setUploadProgressCb(uploadProgress);
+    device.fwUpdate.fwUpdater->setVerifyProgressCb(verifyProgress);
+    device.fwUpdate.fwUpdater->setInfoProgressCb(infoProgress);
+
+    device.fwUpdate.fwUpdater->setCommands(cmds);
 
     printf("\n\r");
 
@@ -1322,7 +1352,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
         }
         else
         {
-            is_device_t device = {};
+            ISDevice device;
             device.serialPort = serial;
             device.sysParams.flashCfgChecksum = 0xFFFFFFFF;		// Invalidate flash config checksum to trigger sync event
             m_comManagerState.devices.push_back(device);
@@ -1645,4 +1675,32 @@ int InertialSense::LoadFlashConfig(std::string path, int pHandle)
     }
 
     return 0;
+}
+
+/**
+* Get the device info
+* @param pHandle the pHandle to get device info for
+* @return the device info
+*/
+const dev_info_t InertialSense::DeviceInfo(int pHandle)
+{
+    if ((size_t)pHandle >= m_comManagerState.devices.size())
+    {
+        pHandle = 0;
+    }
+    return m_comManagerState.devices[pHandle].devInfo;
+}
+
+/**
+* Get current device system command
+* @param pHandle the pHandle to get sysCmd for
+* @return current device system command
+*/
+system_command_t InertialSense::GetSysCmd(int pHandle)
+{
+    if ((size_t)pHandle >= m_comManagerState.devices.size())
+    {
+        pHandle = 0;
+    }
+    return m_comManagerState.devices[pHandle].sysCmd;
 }

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -13,10 +13,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #ifndef __INERTIALSENSE_H
 #define __INERTIALSENSE_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stddef.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstddef>
+#include <cstring>
 #include <string>
+#include <functional>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -31,11 +33,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISSerialPort.h"
 #include "ISDataMappings.h"
 #include "ISStream.h"
+#include "ISDevice.h"
 #include "ISClient.h"
 #include "message_stats.h"
 #include "ISBootloaderThread.h"
 #include "ISFirmwareUpdater.h"
-#include "string.h"
 
 extern "C"
 {
@@ -45,8 +47,6 @@ extern "C"
 
 #include "serialPortPlatform.h"
 }
-
-#include <functional>
 
 #define SYNC_FLASH_CFG_CHECK_PERIOD_MS      200
 
@@ -62,95 +62,10 @@ typedef void(*pfnStepLogFunction)(InertialSense* i, const p_data_t* data, int pH
 class InertialSense : public iISTcpServerDelegate
 {
 public:
-    typedef struct is_fwUpdate_info_s {
-        ISFirmwareUpdater* fwUpdater;
-        float percent;
-        bool hasError;
-        uint16_t lastSlot;
-        fwUpdate::target_t lastTarget;
-        fwUpdate::update_status_e lastStatus;
-        std::string lastMessage;
-
-        std::vector<std::string> target_idents;
-        std::vector<std::string> target_messages;
-
-        bool inProgress() { return (fwUpdater && !fwUpdater->fwUpdate_isDone()); }
-        void update() {
-            if (fwUpdater) {
-                if ("upload" == fwUpdater->getActiveCommand()) {
-                    if (fwUpdater->fwUpdate_getSessionTarget() != lastTarget) {
-                        hasError = false;
-                        lastStatus = fwUpdate::NOT_STARTED;
-                        lastMessage.clear();
-                        lastTarget = fwUpdater->fwUpdate_getSessionTarget();
-                    }
-                    lastSlot = fwUpdater->fwUpdate_getSessionImageSlot();
-
-                    if ((fwUpdater->fwUpdate_getSessionStatus() == fwUpdate::NOT_STARTED) && fwUpdater->isWaitingResponse()) {
-                        // We're just starting (no error yet, but no response either)
-                        lastStatus = fwUpdate::INITIALIZING;
-                        lastMessage = ISFirmwareUpdater::fwUpdate_getNiceStatusName(lastStatus);
-                    } else if ((fwUpdater->fwUpdate_getSessionStatus() != fwUpdate::NOT_STARTED) && (lastStatus != fwUpdater->fwUpdate_getSessionStatus())) {
-                        // We're got a valid status update (error or otherwise)
-                        lastStatus = fwUpdater->fwUpdate_getSessionStatus();
-                        lastMessage = ISFirmwareUpdater::fwUpdate_getNiceStatusName(lastStatus);
-
-                        // check for error
-                        if (!hasError && fwUpdater && fwUpdater->fwUpdate_getSessionStatus() < fwUpdate::NOT_STARTED) {
-                            hasError = true;
-                        }
-                    }
-
-                    // update our upload progress
-                    if ((lastStatus == fwUpdate::IN_PROGRESS)) {
-                        percent = ((float) fwUpdater->fwUpdate_getNextChunkID() / (float) fwUpdater->fwUpdate_getTotalChunks()) * 100.f;
-                    } else {
-                        percent = lastStatus <= fwUpdate::READY ? 0.f : 100.f;
-                    }
-                } else if ("waitfor" == fwUpdater->getActiveCommand()) {
-                        lastMessage = "Waiting for response from device.";
-                } else if ("reset" == fwUpdater->getActiveCommand()) {
-                    lastMessage = "Resetting device.";
-                } else if ("delay" == fwUpdater->getActiveCommand()) {
-                    lastMessage = "Waiting...";
-                }
-
-                if (!fwUpdater->hasPendingCommands()) {
-                    if (!hasError) {
-                        lastMessage = "Completed successfully.";
-                    } else {
-                        lastMessage = "Error: ";
-                        lastMessage += ISFirmwareUpdater::fwUpdate_getNiceStatusName(lastStatus);
-                    }
-                }
-
-                // cleanup if we're done.
-                if (fwUpdater->fwUpdate_isDone()) {
-                    delete fwUpdater;
-                    fwUpdater = nullptr;
-                }
-            } else {
-                percent = 0.0;
-            }
-        }
-    } is_fwUpdate_info_t;
-
-    typedef struct
-    {
-        serial_port_t serialPort;
-        dev_info_t devInfo;
-        system_command_t sysCmd;
-        nvm_flash_cfg_t flashCfg;
-        unsigned int flashCfgUploadTimeMs;		// (ms) non-zero time indicates an upload is in progress and local flashCfg should not be overwritten
-        uint32_t flashCfgUploadChecksum;
-        sys_params_t sysParams;
-        is_fwUpdate_info_t fwUpdate;
-    } is_device_t;
-
     struct com_manager_cpp_state_t
     {
         // per device vars
-        std::vector<is_device_t> devices;
+        std::vector<ISDevice> devices;
 
         // common vars
         pfnHandleBinaryData binaryCallbackGlobal;
@@ -226,14 +141,14 @@ public:
      * Returns a vector of available, connected devices
      * @return
      */
-    std::vector<is_device_t>& getDevices();
+    std::vector<ISDevice>& getDevices();
 
 
     /**
      * Returns a reference to an is_device_t struct that contains information about the specified device
      * @return
      */
-    is_device_t& getDevice(uint32_t index);
+    ISDevice& getDevice(uint32_t index);
 
     /**
     * Call in a loop to send and receive data.  Call at regular intervals as frequently as want to receive data.
@@ -364,28 +279,14 @@ public:
     * @param pHandle the pHandle to get device info for
     * @return the device info
     */
-    const dev_info_t DeviceInfo(int pHandle = 0)
-    {
-        if ((size_t)pHandle >= m_comManagerState.devices.size())
-        {
-            pHandle = 0;
-        }
-        return m_comManagerState.devices[pHandle].devInfo;
-    }
+    const dev_info_t DeviceInfo(int pHandle = 0);
 
     /**
     * Get current device system command
     * @param pHandle the pHandle to get sysCmd for
     * @return current device system command
     */
-    system_command_t GetSysCmd(int pHandle = 0)
-    {
-        if ((size_t)pHandle >= m_comManagerState.devices.size())
-        {
-            pHandle = 0;
-        }
-        return m_comManagerState.devices[pHandle].sysCmd;
-    }
+    system_command_t GetSysCmd(int pHandle = 0);
 
     /**
     * Set device configuration
@@ -409,7 +310,7 @@ public:
     */
     bool FlashConfigSynced(int pHandle = 0) 
     { 
-        is_device_t &device = m_comManagerState.devices[pHandle]; 
+        ISDevice& device = m_comManagerState.devices[pHandle];
         return  (device.flashCfg.checksum == device.sysParams.flashCfgChecksum) && 
                 (device.flashCfgUploadTimeMs==0) && !FlashConfigUploadFailure(pHandle); 
     }
@@ -422,8 +323,8 @@ public:
      */
     bool FlashConfigUploadFailure(int pHandle = 0)
     { 
-        is_device_t &device = m_comManagerState.devices[pHandle]; 
-        return device.flashCfgUploadChecksum && (device.flashCfgUploadChecksum != device.sysParams.flashCfgChecksum); 
+        ISDevice& device = m_comManagerState.devices[pHandle];
+        return device.flashCfgUploadChecksum && (device.flashCfgUploadChecksum != device.sysParams.flashCfgChecksum);
     } 
 
     /**
@@ -581,6 +482,16 @@ public:
             void (*waitAction)()
     );
 
+    is_operation_result updateFirmware(
+            ISDevice& device,
+            fwUpdate::target_t targetDevice,
+            std::vector<std::string> cmds,
+            ISBootloader::pfnBootloadProgress uploadProgress,
+            ISBootloader::pfnBootloadProgress verifyProgress,
+            ISBootloader::pfnBootloadStatus infoProgress,
+            void (*waitAction)()
+    );
+
     /**
      * @return true if all devices have finished all firmware update steps
      */
@@ -637,7 +548,7 @@ public:
 
     // Used for testing
     InertialSense::com_manager_cpp_state_t* ComManagerState() { return &m_comManagerState; }
-    InertialSense::is_device_t* ComManagerDevice(int pHandle=0) { if (pHandle >= (int)m_comManagerState.devices.size()) return NULLPTR; return &(m_comManagerState.devices[pHandle]); }
+    ISDevice* ComManagerDevice(int pHandle=0) { if (pHandle >= (int)m_comManagerState.devices.size()) return NULLPTR; return &(m_comManagerState.devices[pHandle]); }
 
 protected:
     bool OnClientPacketReceived(const uint8_t* data, uint32_t dataLength);

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -638,7 +638,7 @@ typedef struct PACKED
     /** Manufacturer name */
     char            manufacturer[DEVINFO_MANUFACTURER_STRLEN];
 
-	/** Build type (Release: 'a'=ALPHA, 'b'=BETA, 'c'=RELEASE CANDIDATE, 'r'=PRODUCTION RELEASE, 'd'=debug) */
+	/** Build type (Release: 'a'=ALPHA, 'b'=BETA, 'c'=RELEASE CANDIDATE, 'r'=PRODUCTION RELEASE, 'd'=developer/debug) */
 	uint8_t         buildType;
     
     /** Build date year - 2000 */
@@ -1412,34 +1412,38 @@ typedef struct PACKED
     uint32_t                hdwStatus;
 
     /** IMU temperature */
-    float					imuTemp;
+    float                   imuTemp;
 
     /** Baro temperature */
-    float					baroTemp;
+    float                   baroTemp;
 
     /** MCU temperature (not available yet) */
-    float					mcuTemp;
+    float                   mcuTemp;
 
     /** System status flags (eSysStatusFlags) */
-    uint32_t				sysStatus;
+    uint32_t                sysStatus;
 
 	/** IMU sample period (ms). Zero disables sampling. */
-	uint32_t				imuSamplePeriodMs;
+	uint32_t                imuSamplePeriodMs;
 
 	/** Preintegrated IMU (PIMU) integration period and navigation/AHRS filter output period (ms). */
-	uint32_t				navOutputPeriodMs;
+	uint32_t                navOutputPeriodMs;
 	
     /** Actual sample period relative to GPS PPS (sec) */
-    double					sensorTruePeriod;
+    double                  sensorTruePeriod;
 
 	/** Flash config checksum used with host SDK synchronization */
-	uint32_t				flashCfgChecksum;
+	uint32_t                flashCfgChecksum;
 
 	/** Navigation/AHRS filter update period (ms) */
-	uint32_t				navUpdatePeriodMs;
+	uint32_t                navUpdatePeriodMs;
 
     /** General fault code descriptor (eGenFaultCodes).  Set to zero to reset fault code. */
-    uint32_t				genFaultCode;
+    uint32_t                genFaultCode;
+
+    /** System up time in seconds (with double precision) */
+    double                  upTime;
+
 } sys_params_t;
 
 /*! General Fault Code descriptor */
@@ -4312,6 +4316,8 @@ typedef struct
 
     /** port */
     uint8_t                 gpxSourcePort;
+
+    double                  upTime;     //! Time in seconds, since system was started
 } gpx_status_t;
 
 
@@ -4677,8 +4683,8 @@ enum DID_EventPriority
 
 typedef struct DID_Event
 {
-    /** Time */
-    uint32_t        timeMs;
+    /** Time (uptime in seconds) */
+    double          time;
 
     /** Serial number */
     uint32_t        senderSN;

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -30,7 +30,7 @@ PYBIND11_NUMPY_DTYPE(ins_4_t, week, timeOfWeek, insStatus, hdwStatus, qe2b, ve, 
 PYBIND11_NUMPY_DTYPE(system_command_t, command, invCommand);
 PYBIND11_NUMPY_DTYPE(nmea_msgs_t, options, nmeaBroadcastMsgs);
 PYBIND11_NUMPY_DTYPE(rmc_t, bits, options);
-PYBIND11_NUMPY_DTYPE(sys_params_t, timeOfWeekMs, insStatus, hdwStatus, imuTemp, baroTemp, mcuTemp, sysStatus, imuSamplePeriodMs, navOutputPeriodMs, sensorTruePeriod, flashCfgChecksum, navUpdatePeriodMs, genFaultCode);
+PYBIND11_NUMPY_DTYPE(sys_params_t, timeOfWeekMs, insStatus, hdwStatus, imuTemp, baroTemp, mcuTemp, sysStatus, imuSamplePeriodMs, navOutputPeriodMs, sensorTruePeriod, flashCfgChecksum, navUpdatePeriodMs, genFaultCode, upTime);
 PYBIND11_NUMPY_DTYPE(sys_sensors_t, time, temp, pqr, acc, mag, bar, barTemp, mslBar, humidity, vin, ana1, ana3, ana4);
 PYBIND11_NUMPY_DTYPE(nvm_flash_cfg_t, size, checksum, key, startupImuDtMs, startupNavDtMs, ser0BaudRate, ser1BaudRate, insRotation, insOffset, gps1AntOffset, dynamicModel, debug, gnssSatSigConst, sysCfgBits, refLla, lastLla, lastLlaTimeOfWeekMs, lastLlaWeek, lastLlaUpdateDistance, ioConfig, platformConfig, gps2AntOffset, zeroVelRotation, zeroVelOffset, gpsTimeUserDelay, magDeclination, gpsTimeSyncPeriodMs, startupGPSDtMs, RTKCfgBits, sensorConfig, gpsMinimumElevation, ser2BaudRate, wheelConfig, magInterferenceThreshold, magCalibrationQualityThreshold);
 PYBIND11_NUMPY_DTYPE(gps_pos_t, week, timeOfWeekMs, status, ecef, lla, hMSL, hAcc, vAcc, pDop, cnoMean, towOffset, leapS, reserved);


### PR DESCRIPTION
This is kind of a superficial change on the ISDevice side, which basically moves `is_device_t` into proper class called `ISDevice`. It also moves `is_firmUpdate_info_t` into a class called `ISDeviceUpdater`.

ISDevice consolidates all information associated with an Inertial Sense device, outside of the InertialSense class (though, that is where its still primarily used).  Specifically, it makes a hard association between the devInfo, flashConfig, serialPort and portHandle, and also the device update status (through ISDeviceUpdater) available through the ISDevice class.

Because ISDevice is not an internal class of the InertialSense class, you can now request from the InertialSense class, a pointer to the ISDevice, and have access to all necessary data, handles, etc to be able to directly communicate with any specific device.

Additionally, ISDeviceUpdater provides a way for the InertialSense class, and more specifically the ISDevice instance, with per-device specific status of the update process.

This PR also include a small number of other fixes/improvements (notably Uptime reporting), which may need to be pulled out into a seperate PR if the root PR is problematic.

This PR is a **_HARD PREREQUISITE_** of the subsequent Telemetry PR.  This should not be merged unless that PR is also ready to be merged.