### PR TITLE
Feature/sn 5173 is logger refactor

### DIFF
--- a/ExampleProjects/ISLoggerSimple/ISLoggerSimpleExample.cpp
+++ b/ExampleProjects/ISLoggerSimple/ISLoggerSimpleExample.cpp
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
 			// Log serial port data to file
 			logger.LogData(0, len, buf);
 
-			printf("Log file size: %.3f MB \r", logger.LogSizeMB());
+			printf("Log file size: %.3f MB \r", logger.LogSizeAllMB());
 		}
     }
 

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -512,13 +512,14 @@ bool cltool_replayDataLog()
 
     cout << "Replaying log files: " << g_commandLineOptions.logPath << endl;
     p_data_buf_t *data;
-    for (int d=0; d<logger.DeviceCount(); d++)
+    // for (int d=0; d<logger.DeviceCount(); d++)
+    for (auto dl : logger.DeviceLogs())
     {
         if (logger.DeviceCount() > 1)
         {
-            printf("Device(%d): SN%d\n", d, logger.DeviceInfo(d)->serialNumber);
+            printf("Device SN%d: \n", dl->SerialNumber());
         }
-        while ((data = logger.ReadData(d)) != NULL)
+        while (((data = logger.ReadData(dl)) != NULL) && !g_inertialSenseDisplay.ExitProgram())
         {
             p_data_t d = {data->hdr, data->buf};
             g_inertialSenseDisplay.ProcessData(&d, g_commandLineOptions.replayDataLog, g_commandLineOptions.replaySpeed);

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -368,6 +368,10 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         {
             g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_QUIET;
         }
+        else if (startsWith(a, "-raw-out"))
+        {
+            g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_RAW_PARSE;
+        }
         else if (startsWith(a, "-rp") && (i + 1) < argc)
         {
             g_commandLineOptions.replayDataLog = true;
@@ -462,11 +466,11 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             g_commandLineOptions.list_devices = true;
             g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_QUIET;
         }
-		else if (startsWith(a, "-v") || startsWith(a, "--version"))
-		{
-			cout << cltool_version() << endl;
-			return false;
-		}
+        else if (startsWith(a, "-v") || startsWith(a, "--version"))
+        {
+            cout << cltool_version() << endl;
+            return false;
+        }
         else
         {
             cout << "Unrecognized command line option: " << a << endl;
@@ -559,6 +563,7 @@ void cltool_outputUsage()
 	cout << "OPTIONS (General)" << endl;
 	cout << "    -h --help" << boldOff << "       Display this help menu." << endlbOn;
     cout << "    -list-devices" << boldOff << "   Discovers and prints a list of discovered Inertial Sense devices and connected ports." << endlbOn;
+    cout << "    -raw-out" << boldOff << "        Outputs all data in a human-readable raw format (used for debugging/learning the ISB protocol)." << endlbOn;
 	cout << "    -c " << boldOff << "DEVICE_PORT  Select the serial port. Set DEVICE_PORT to \"*\" for all ports or \"*4\" for only first four available." << endlbOn;
 	cout << "    -baud=" << boldOff << "BAUDRATE  Set serial port baudrate.  Options: " << IS_BAUDRATE_115200 << ", " << IS_BAUDRATE_230400 << ", " << IS_BAUDRATE_460800 << ", " << IS_BAUDRATE_921600 << " (default)" << endlbOn;
 	cout << "    -magRecal[n]" << boldOff << "    Recalibrate magnetometers: 0=multi-axis, 1=single-axis" << endlbOn;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -134,6 +134,100 @@ static void display_logger_status(InertialSense* i, bool refreshDisplay=false)
 	printf("\nLogging %.1f KB to: %s\n", logger.LogSize() * 0.001f, logger.LogDirectory().c_str());
 }
 
+static int cltool_errorCallback(int port, is_comm_instance_t* comm)
+{
+    #define BUF_SIZE    8192
+    #define BLACK   "\u001b[30m"
+    #define RED     "\u001b[31m"
+    #define GREEN   "\u001b[32m"
+    #define YELLOW  "\u001b[33m"
+    #define BLUE    "\u001b[34m"
+    #define MAGENTA "\u001b[35m"
+    #define CYAN    "\u001b[36m"
+    #define WHITE   "\u001b[37m"
+    #define RESET   "\u001b[0m"
+
+    if (g_commandLineOptions.displayMode != cInertialSenseDisplay::DMODE_RAW_PARSE)
+        return 0;
+
+    static const char* errorNames[] = {
+            "INVALID_PREAMBLE",
+            "INVALID_SIZE",
+            "INVALID_CHKSUM",
+            "INVALID_DATATYPE",
+            "MISSING_EOS_MARKER",
+            "INCOMPLETE_PACKET",
+            "INVALID_HEADER",
+            "INVALID_PAYLOAD",
+            "RXBUFFER_FLUSHED",
+            "STREAM_UNPARSEABLE",
+    };
+
+    typedef union
+    {
+        uint16_t ck;
+        struct
+        {
+            uint8_t a;	// Lower 8 bits
+            uint8_t b;	// Upper 8 bits
+        };
+    } checksum16_u;
+
+    char buf[BUF_SIZE];
+    char* ptr = buf;
+    char* ptrEnd = buf + BUF_SIZE;
+    int bytesPerLine = 32;
+
+    const packet_t* rxPkt = &(comm->rxPkt);
+    const uint8_t* raw_data = rxPkt->data.ptr;
+
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "ERROR:   " RED "%s\n", errorNames[comm->rxErrorType]);
+
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[PREAMB] " RED "%02x %02x ", ((rxPkt->preamble >> 8) & 0xFF), (rxPkt->preamble & 0xFF));
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[Flags: " YELLOW "%u" BLUE "] " RED "%02x ", rxPkt->flags, rxPkt->flags);
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[Id: " YELLOW "%s" BLUE "] " RED "%02x ", cISDataMappings::GetDataSetName(rxPkt->dataHdr.id), rxPkt->dataHdr.id);
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[Size: " YELLOW "%u" BLUE "] " RED "%02x %02x ", rxPkt->dataHdr.size, ((rxPkt->dataHdr.size >> 8) & 0xFF), (rxPkt->dataHdr.size & 0xFF));
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[Offset: " YELLOW "%u" BLUE "] " RED "%02x %02x", rxPkt->dataHdr.offset, ((rxPkt->dataHdr.offset >> 8) & 0xFF), (rxPkt->dataHdr.offset & 0xFF));
+
+#if DISPLAY_DELTA_TIME==1
+    static double lastTime[2] = { 0 };
+	double dtMs = 1000.0*(wheel.timeOfWeek - lastTime[i]);
+	lastTime[i] = wheel.timeOfWeek;
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, " %4.1lfms", dtMs);
+#else
+#endif
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n");
+    int lines = (rxPkt->dataHdr.size / bytesPerLine) + 1;
+    for (int j = 0; j < lines; j++) {
+        int linelen = (j == lines-1) ? rxPkt->dataHdr.size % bytesPerLine : bytesPerLine;
+        if (linelen > 0) {
+            if (j == 0)
+                ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "  [DATA] " RED);
+            else
+                ptr += SNPRINTF(ptr, ptrEnd - ptr, "         ");
+
+            for (int i = 0; i < linelen; i++) {
+                ptr += SNPRINTF(ptr, ptrEnd - ptr, "%02x ", (uint8_t) raw_data[(j * bytesPerLine) + i]);
+            }
+            ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n");
+        }
+    }
+
+    // recalculated actual checksum
+    packet_buf_t *isbPkt = (packet_buf_t*)(comm->rxBuf.head);
+    uint16_t payloadSize = isbPkt->hdr.payloadSize;
+    uint8_t *payload = comm->rxBuf.head + sizeof(packet_hdr_t);
+    checksum16_u *cksum = (checksum16_u*)(payload + payloadSize);
+    int bytes_cksum = rxPkt->size - 2;
+    uint16_t calcCksum = is_comm_isb_checksum16(0, comm->rxBuf.head, bytes_cksum);
+
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[CHKSUM] " RED "%02x %02x ", ((calcCksum >> 8) & 0xFF), (calcCksum & 0xFF));
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "  Expected: " RED "%02x %02x ", ((rxPkt->checksum >> 8) & 0xFF), (rxPkt->checksum & 0xFF));
+
+    cout << buf << RESET << endl;
+    return 0;
+}
+
 // [C++ COMM INSTRUCTION] STEP 5: Handle received data 
 static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
 {
@@ -142,7 +236,6 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
             return;
         g_inertialSenseDisplay.showRawData(true);
     }
-
 
     (void)i;
     (void)pHandle;
@@ -167,7 +260,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         return true;
     }
 
-    // check for any compatible (procotol version 2) devices
+    // check for any compatible (protocol version 2) devices
     for (int i = inertialSenseInterface.DeviceCount() - 1; i >= 0; i--) {
         if (inertialSenseInterface.DeviceInfo(i).protocolVer[0] != PROTOCOL_VERSION_CHAR0) {
             printf("ERROR: One or more connected devices are using an incompatible protocol version (requires %d.x.x.x).\n", PROTOCOL_VERSION_CHAR0);
@@ -550,6 +643,7 @@ static int cltool_dataStreaming()
     // [C++ COMM INSTRUCTION] STEP 1: Instantiate InertialSense Class
     // Create InertialSense object, passing in data callback function pointer.
     InertialSense inertialSenseInterface(cltool_dataCallback);
+    inertialSenseInterface.setErrorHandler(cltool_errorCallback);
 
     // [C++ COMM INSTRUCTION] STEP 2: Open serial port
     if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose))
@@ -596,6 +690,10 @@ static int cltool_dataStreaming()
     // [C++ COMM INSTRUCTION] STEP 3: Enable data broadcasting
     if (cltool_setupCommunications(inertialSenseInterface))
     {
+        if (g_commandLineOptions.displayMode == cInertialSenseDisplay::DMODE_RAW_PARSE) {
+            g_inertialSenseDisplay.showRawData(true);
+        }
+
         // [LOGGER INSTRUCTION] Setup and start data logger
         if (g_commandLineOptions.asciiMessages.size() == 0 && !cltool_setupLogger(inertialSenseInterface))
         {

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -131,7 +131,11 @@ static void display_logger_status(InertialSense* i, bool refreshDisplay=false)
 		return;
 	}
 
-	printf("\nLogging %.1f KB to: %s\n", logger.LogSize() * 0.001f, logger.LogDirectory().c_str());
+    float logSize = logger.LogSizeAll() * 0.001;
+    if (logSize < 5000.0)
+        printf("\nLogging %.1f MB to: %s\n", logSize, logger.LogDirectory().c_str());
+    else
+        printf("\nLogging %.2f KB to: %s\n", logSize * 0.001f, logger.LogDirectory().c_str());
 }
 
 static int cltool_errorCallback(int port, is_comm_instance_t* comm)

--- a/python/logInspector/include/log_reader.h
+++ b/python/logInspector/include/log_reader.h
@@ -146,7 +146,7 @@ public:
     }
 
 private:
-    void organizeData(int device_id);
+    void organizeData(std::shared_ptr<cDeviceLog>);
     void forwardData(int device_id);
 
     cISLogger logger_;

--- a/python/logInspector/logPlotter.py
+++ b/python/logInspector/logPlotter.py
@@ -506,11 +506,12 @@ class logPlot:
         
     def getGpsNedVel(self, d):
         velNed = None
-        status = self.getData(d, DID_GPS1_VEL, 'status')[0]
+        velDid = DID_GPS2_VEL if self.getData(d, DID_GPS1_VEL, 'status').size == 0 else DID_GPS1_VEL
+        status = self.getData(d, velDid, 'status')[0]
         if (status & 0x00008000):
-            velNed = self.getData(d, DID_GPS1_VEL, 'vel')    # NED velocity
+            velNed = self.getData(d, velDid, 'vel')    # NED velocity
         else:
-            velEcef = self.getData(d, DID_GPS1_VEL, 'vel')   # ECEF velocity
+            velEcef = self.getData(d, velDid, 'vel')   # ECEF velocity
             qe2n = quat_ecef2ned(refLla[0:2]*np.pi/180.0)
             if len(velEcef) > 0:
                 velNed = quatConjRot(qe2n, velEcef)

--- a/python/logInspector/setup.py
+++ b/python/logInspector/setup.py
@@ -102,12 +102,12 @@ def has_flag(compiler, flagname):
 
 
 def cpp_flag(compiler):
-    """Return the -std=c++[11/14] compiler flag.
+    """Return the -std=c++[11/17] compiler flag.
 
-    The c++14 is prefered over c++11 (when it is available).
+    The c++17 is prefered over c++11 (when it is available).
     """
-    if has_flag(compiler, '-std=c++14'):
-        return '-std=c++14'
+    if has_flag(compiler, '-std=c++17'):
+        return '-std=c++17'
     elif has_flag(compiler, '-std=c++11'):
         return '-std=c++11'
     else:

--- a/python/logInspector/src/log_reader.cpp
+++ b/python/logInspector/src/log_reader.cpp
@@ -116,10 +116,10 @@ bool LogReader::init(py::object python_class, std::string log_directory, py::lis
     return true;
 }
 
-void LogReader::organizeData(int device_id)
+void LogReader::organizeData(shared_ptr<cDeviceLog> devLog)
 {
     p_data_buf_t* data = NULL;
-    while ((data = logger_.ReadData(device_id)))
+    while ((data = logger_.ReadData(devLog)))
     {
         // if (data->hdr.id == DID_DEV_INFO)
         //     volatile int debug = 0;
@@ -319,7 +319,8 @@ void LogReader::forwardData(int device_id)
 
 bool LogReader::load()
 {
-    for (int i = 0; i < (int)logger_.DeviceCount(); i++)
+    std::vector<std::shared_ptr<cDeviceLog>> devices = logger_.DeviceLogs();
+    for (int i = 0; i < (int)devices.size(); i++)
     {
         if (dev_log_ != nullptr)
         {
@@ -327,7 +328,7 @@ bool LogReader::load()
         }
         dev_log_ = new DeviceLog();
 
-        organizeData(i);
+        organizeData(devices[i]);
         forwardData(i);
     }
 

--- a/python/logInspector/src/log_reader.cpp
+++ b/python/logInspector/src/log_reader.cpp
@@ -103,10 +103,10 @@ bool LogReader::init(py::object python_class, std::string log_directory, py::lis
 
     cout << logger_.DeviceCount() << " device(s):\n";
     vector<int> serialNumbers;
-    for (int i = 0; i < (int)logger_.DeviceCount(); i++)
+    for (auto dev : logger_.DeviceLogs())
     {
-        cout << (i==0 ? "  " : ", ") << logger_.DeviceInfo(i)->serialNumber;
-        serialNumbers.push_back(logger_.DeviceInfo(i)->serialNumber);
+        cout << (serialNumbers.empty() ? "  " : ", ") << dev->SerialNumber();
+        serialNumbers.push_back(dev->SerialNumber());
     }
     cout << endl;
     serialNumbers_ = py::cast(serialNumbers);

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -38,12 +38,12 @@ cDeviceLog::cDeviceLog() {
 cDeviceLog::cDeviceLog(const ISDevice* dev) : device(dev)  {
     if (dev == nullptr)
         throw std::invalid_argument("cDeviceLog() must be passed a valid ISDevice instance.");
-    devHdwId = ENCODE_DEV_INFO_TO_HDW_ID(dev->devInfo);
-    devSerialNo = dev->devInfo.serialNumber;
+    m_devHdwId = ENCODE_DEV_INFO_TO_HDW_ID(dev->devInfo);
+    m_devSerialNo = dev->devInfo.serialNumber;
     m_logStats.Clear();
 }
 
-cDeviceLog::cDeviceLog(uint16_t hdwId, uint32_t serial) : devHdwId(hdwId), devSerialNo(serial) {
+cDeviceLog::cDeviceLog(uint16_t hdwId, uint32_t serial) : m_devHdwId(hdwId), m_devSerialNo(serial) {
     m_logStats.Clear();
 }
 
@@ -56,7 +56,6 @@ cDeviceLog::~cDeviceLog()
 
 void cDeviceLog::InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize)
 {
-    // m_pHandle = pHandle;
 	m_timeStamp = timestamp;
 	m_directory = directory;
 	m_fileCount = 0;
@@ -189,9 +188,8 @@ bool cDeviceLog::OpenNewSaveFile()
 	m_fileCount++;
     uint32_t serNum = (device != nullptr ? device->devInfo.serialNumber : SerialNumber());
 	if (!serNum)
-	{
-		// serNum = device->portHandle; // FIXME: This really isn't okay... pHandle isn't guaranteed unique and we could run into collisions under some circumstances
-	}
+        return false;
+
 	string fileName = GetNewFileName(serNum, m_fileCount, NULL);
 	m_pFile = CreateISLogFile(fileName, "wb");
 	m_fileSize = 0;
@@ -262,19 +260,6 @@ ISDevice* cDeviceLog::Device() {
 const dev_info_t* cDeviceLog::DeviceInfo() {
     return (dev_info_t*)&(device->devInfo);
 }
-
-/*
-void cDeviceLog::SetDeviceInfo(const dev_info_t *info)
-{
-	if (info == NULL)
-	{
-		return;
-	}
-	// device->devInfo = *info;
-	SetSerialNumber(info->serialNumber);
-}
-*/
-
 
 void cDeviceLog::OnReadData(p_data_buf_t* data)
 {

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -16,81 +16,116 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <stdio.h>
 #include <string.h>
 #include <vector>
+// #include "ISDevice.h"
 #include "ISLogFileBase.h"
 #include "ISLogStats.h"
 
 extern "C"
 {
-	#include "com_manager.h"
+#include "com_manager.h"
 }
 
 // never change these!
 #define IS_LOG_FILE_PREFIX "LOG_SN"
 #define IS_LOG_TIMESTAMP_LENGTH 15
 
+class ISDevice;
 
-class cDeviceLog
-{
+class cDeviceLog {
 public:
     cDeviceLog();
+
+    cDeviceLog(const ISDevice *dev);
+
+    cDeviceLog(uint16_t hdwId, uint32_t serial);
+
     virtual ~cDeviceLog();
-	virtual void InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize);
-	virtual void InitDeviceForReading();
+
+    virtual void InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize);
+
+    virtual void InitDeviceForReading();
+
     virtual bool CloseAllFiles();
-	virtual bool FlushToFile() { return true; };
-	virtual bool OpenWithSystemApp();
-    virtual bool SaveData(p_data_hdr_t *dataHdr, const uint8_t* dataBuf, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA);
-	virtual bool SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &globalLogStats);
-    virtual p_data_buf_t* ReadData() = 0;
-	virtual void SetSerialNumber(uint32_t serialNumber) = 0;
-	virtual std::string LogFileExtention() = 0;
-	virtual void Flush() {}
-    bool SetupReadInfo(const std::string& directory, const std::string& deviceName, const std::string& timeStamp);
-    void SetDeviceInfo(const dev_info_t *info);
-    const dev_info_t* DeviceInfo() { return &m_devInfo; }
-	uint64_t FileSize() { return m_fileSize; }
-	uint64_t LogSize() { return m_logSize; }
-	uint32_t FileCount() { return m_fileCount; }
-	std::string GetNewFileName(uint32_t serialNumber, uint32_t fileCount, const char* suffix);
-	void SetKmlConfig(bool gpsData =true, bool showTracks =true, bool showPoints =true, bool showPointTimestamps =true, double pointUpdatePeriodSec=1.0, bool altClampToGround=true)
-	{ 
-		m_enableGpsLogging = gpsData;
-		m_showTracks = showTracks;
-		m_showPoints = showPoints;
-		m_showPointTimestamps = showPointTimestamps;
-		m_pointUpdatePeriodSec = pointUpdatePeriodSec;
-		m_altClampToGround = altClampToGround; 
-	}
-	void ShowParseErrors(bool show){ m_showParseErrors = show; }
+
+    virtual bool FlushToFile() { return true; };
+
+    virtual bool OpenWithSystemApp();
+
+    virtual bool SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf, protocol_type_t ptype = _PTYPE_INERTIAL_SENSE_DATA);
+
+    virtual bool SaveData(int dataSize, const uint8_t *dataBuf, cLogStats &globalLogStats);
+
+    virtual p_data_buf_t *ReadData() = 0;
+
+    virtual void SetSerialNumber(uint32_t serialNumber) = 0;
+
+
+    virtual std::string LogFileExtention() = 0;
+
+    virtual void Flush() {}
+
+    bool SetupReadInfo(const std::string &directory, const std::string &deviceName, const std::string &timeStamp);
+
+    ISDevice* Device();
+
+    const dev_info_t *DeviceInfo();
+
+    uint16_t HardwareId() { return devHdwId; }
+    uint32_t SerialNumber() { return devSerialNo; }
+
+    // void SetDeviceInfo(const dev_info_t *info);
+    uint64_t FileSize() { return m_fileSize; }
+
+    uint64_t LogSize() { return m_logSize; }
+
+    uint32_t FileCount() { return m_fileCount; }
+
+    std::string GetNewFileName(uint32_t serialNumber, uint32_t fileCount, const char *suffix);
+
+    void SetKmlConfig(bool gpsData = true, bool showTracks = true, bool showPoints = true, bool showPointTimestamps = true, double pointUpdatePeriodSec = 1.0, bool altClampToGround = true) {
+        m_enableGpsLogging = gpsData;
+        m_showTracks = showTracks;
+        m_showPoints = showPoints;
+        m_showPointTimestamps = showPointTimestamps;
+        m_pointUpdatePeriodSec = pointUpdatePeriodSec;
+        m_altClampToGround = altClampToGround;
+    }
+
+    void ShowParseErrors(bool show) { m_showParseErrors = show; }
 
 protected:
-	bool OpenNewSaveFile();
-	bool OpenNextReadFile();
-    void OnReadData(p_data_buf_t* data);
+    bool OpenNewSaveFile();
 
-	std::vector<std::string> m_fileNames;
-	cISLogFileBase*         m_pFile;
-	std::string             m_directory;
-	std::string             m_timeStamp;
-	std::string             m_fileName;
-	bool                    m_writeMode;	// Logger initialized for writing
-	bool					m_showParseErrors;
-	dev_info_t              m_devInfo;
-	int                     m_pHandle;
-	uint64_t                m_fileSize;
-	uint64_t                m_logSize;
-	uint32_t                m_fileCount;
-	uint64_t                m_maxDiskSpace;
-	uint32_t                m_maxFileSize;
-	bool                    m_altClampToGround;
-	bool                    m_enableGpsLogging;
-	bool                    m_showTracks;
-	bool                    m_showPoints;
-	bool                    m_showPointTimestamps;
-	double                  m_pointUpdatePeriodSec;
+    bool OpenNextReadFile();
+
+    void OnReadData(p_data_buf_t *data);
+
+    const ISDevice *device = nullptr;               //! ISDevice reference to source of data
+
+    uint16_t devHdwId = 0;                          //! used when reading a file and no ISDevice is available
+    uint32_t devSerialNo = -1;                      //! used when reading a file, and no ISDevice is available
+
+    std::vector<std::string> m_fileNames;
+    cISLogFileBase *m_pFile = NULL;
+    std::string m_directory;
+    std::string m_timeStamp;
+    std::string m_fileName;
+    bool m_writeMode = false;                       //! Logger initialized for writing
+    bool m_showParseErrors;
+    uint64_t m_fileSize = 0;
+    uint64_t m_logSize = 0;
+    uint32_t m_fileCount = 0;
+    uint64_t m_maxDiskSpace;
+    uint32_t m_maxFileSize;
+    bool m_altClampToGround = true;
+    bool m_enableGpsLogging = true;
+    bool m_showTracks = true;
+    bool m_showPoints;
+    bool m_showPointTimestamps = true;
+    double m_pointUpdatePeriodSec = 1.0f;
 
 private:
-    cLogStats               m_logStats;
+    cLogStats m_logStats;
 };
 
 #endif // DEVICE_LOG_H

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -16,7 +16,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <stdio.h>
 #include <string.h>
 #include <vector>
-// #include "ISDevice.h"
 #include "ISLogFileBase.h"
 #include "ISLogStats.h"
 
@@ -70,8 +69,8 @@ public:
 
     const dev_info_t *DeviceInfo();
 
-    uint16_t HardwareId() { return devHdwId; }
-    uint32_t SerialNumber() { return devSerialNo; }
+    uint16_t HardwareId() { return m_devHdwId; }
+    uint32_t SerialNumber() { return m_devSerialNo; }
 
     // void SetDeviceInfo(const dev_info_t *info);
     uint64_t FileSize() { return m_fileSize; }
@@ -102,8 +101,8 @@ protected:
 
     const ISDevice *device = nullptr;               //! ISDevice reference to source of data
 
-    uint16_t devHdwId = 0;                          //! used when reading a file and no ISDevice is available
-    uint32_t devSerialNo = -1;                      //! used when reading a file, and no ISDevice is available
+    uint16_t m_devHdwId = 0;                          //! used when reading a file and no ISDevice is available
+    uint32_t m_devSerialNo = -1;                      //! used when reading a file, and no ISDevice is available
 
     std::vector<std::string> m_fileNames;
     cISLogFileBase *m_pFile = NULL;

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -111,7 +111,7 @@ protected:
     std::string m_timeStamp;
     std::string m_fileName;
     bool m_writeMode = false;                       //! Logger initialized for writing
-    bool m_showParseErrors;
+    bool m_showParseErrors = false;
     uint64_t m_fileSize = 0;
     uint64_t m_logSize = 0;
     uint32_t m_fileCount = 0;

--- a/src/DeviceLogCSV.cpp
+++ b/src/DeviceLogCSV.cpp
@@ -52,9 +52,9 @@ void cDeviceLogCSV::InitDeviceForReading()
 		if (dataSet != NULL)
 		{
 			string dataSetRegex = string(dataSet) + "\\.csv$";
-			if (devSerialNo > 0 && devSerialNo < 4294967295)	// < 0xFFFFFFFF
+			if (m_devSerialNo > 0 && m_devSerialNo < 4294967295)	// < 0xFFFFFFFF
 			{	// Include serial number if valid
-				dataSetRegex = "LOG_SN" + to_string(devSerialNo) + ".*?" + dataSetRegex;
+				dataSetRegex = "LOG_SN" + to_string(m_devSerialNo) + ".*?" + dataSetRegex;
 			}
 			vector<ISFileManager::file_info_t> infos;
 			vector<string> files;
@@ -125,9 +125,7 @@ bool cDeviceLogCSV::OpenNewFile(cCsvLog& log, bool readonly)
 	// Open new file
 	uint32_t serNum = SerialNumber();
 	if (!serNum)
-	{
-		serNum = device->portHandle; // FIXME: This is a bad idea...
-	}
+        return false;
 
 	string fileName;
 	if (readonly)
@@ -316,7 +314,7 @@ p_data_buf_t* cDeviceLogCSV::ReadDataFromFile(cCsvLog& log)
 
 void cDeviceLogCSV::SetSerialNumber(uint32_t serialNumber)
 {
-    devSerialNo = serialNumber;
+    m_devSerialNo = serialNumber;
 }
 
 

--- a/src/DeviceLogCSV.h
+++ b/src/DeviceLogCSV.h
@@ -41,7 +41,11 @@ public:
 class cDeviceLogCSV : public cDeviceLog
 {
 public:
-	void InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
+    cDeviceLogCSV() : cDeviceLog() {};
+    cDeviceLogCSV(const ISDevice* dev) : cDeviceLog(dev) {};
+    cDeviceLogCSV(uint16_t hdwId, uint32_t serialNo) : cDeviceLog(hdwId, serialNo) {};
+
+    void InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
 	void InitDeviceForReading() OVERRIDE;
 	bool CloseAllFiles() OVERRIDE;
     bool SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA) OVERRIDE;

--- a/src/DeviceLogJSON.cpp
+++ b/src/DeviceLogJSON.cpp
@@ -102,7 +102,7 @@ bool cDeviceLogJSON::SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf, pro
 	}
 	else if (dataHdr->id == DID_DEV_INFO)
 	{
-		memcpy(&m_devInfo, dataBuf, sizeof(dev_info_t));
+		memcpy((void *)&(device->devInfo), dataBuf, sizeof(dev_info_t));
 	}
 
 	// Write date to file
@@ -154,17 +154,16 @@ p_data_buf_t* cDeviceLogJSON::ReadDataFromFile()
 	{
 		if (m_data.hdr.id == DID_DEV_INFO)
 		{
-			memcpy(&m_devInfo, m_data.buf, sizeof(dev_info_t));
+			memcpy((void *)&(device->devInfo), m_data.buf, sizeof(dev_info_t));
 		}
 		return &m_data;
 	}
     return NULLPTR;
 }
 
-
 void cDeviceLogJSON::SetSerialNumber(uint32_t serialNumber)
 {
-	m_devInfo.serialNumber = serialNumber;
+    devSerialNo = serialNumber;
 }
 
 

--- a/src/DeviceLogJSON.cpp
+++ b/src/DeviceLogJSON.cpp
@@ -163,7 +163,7 @@ p_data_buf_t* cDeviceLogJSON::ReadDataFromFile()
 
 void cDeviceLogJSON::SetSerialNumber(uint32_t serialNumber)
 {
-    devSerialNo = serialNumber;
+    m_devSerialNo = serialNumber;
 }
 
 

--- a/src/DeviceLogJSON.h
+++ b/src/DeviceLogJSON.h
@@ -25,6 +25,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 class cDeviceLogJSON : public cDeviceLog
 {
 public:
+    cDeviceLogJSON() : cDeviceLog() {};
+    cDeviceLogJSON(const ISDevice* dev) : cDeviceLog(dev) {};
+    cDeviceLogJSON(uint16_t hdwId, uint32_t serialNo) : cDeviceLog(hdwId, serialNo) {};
+
 	bool CloseAllFiles() OVERRIDE;
     bool SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA) OVERRIDE;
 	p_data_buf_t* ReadData() OVERRIDE;

--- a/src/DeviceLogKML.cpp
+++ b/src/DeviceLogKML.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace std;
 
-void cDeviceLogKML::InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize)
+void cDeviceLogKML::InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize)
 {
 	for (int kid=0; kid<cDataKML::MAX_NUM_KID; kid++ )
 	{
@@ -40,7 +40,7 @@ void cDeviceLogKML::InitDeviceForWriting(int pHandle, std::string timestamp, std
 	}
 	m_isRefIns = false;
 
-	cDeviceLog::InitDeviceForWriting(pHandle, timestamp, directory, maxDiskSpace, maxFileSize);
+	cDeviceLog::InitDeviceForWriting(timestamp, directory, maxDiskSpace, maxFileSize);
 }
 
 
@@ -98,10 +98,10 @@ bool cDeviceLogKML::CloseWriteFile(int kid, sKmlLog &log)
 
 	// Create filename
 	log.fileCount++;
-	int serNum = m_devInfo.serialNumber;
+	int serNum = device->devInfo.serialNumber;
 	if (!serNum)
 	{
-		serNum = m_pHandle;
+		serNum = device->portHandle;
 	}
 
 	log.fileName = GetNewFileName(serNum, log.fileCount, m_kml.GetDatasetName(kid).c_str());
@@ -576,10 +576,9 @@ bool cDeviceLogKML::ReadChunkFromFile()
 	return true;
 }
 
-
 void cDeviceLogKML::SetSerialNumber(uint32_t serialNumber)
 {
-	m_devInfo.serialNumber = serialNumber;
+    devSerialNo = serialNumber;
 }
 
 

--- a/src/DeviceLogKML.cpp
+++ b/src/DeviceLogKML.cpp
@@ -578,7 +578,7 @@ bool cDeviceLogKML::ReadChunkFromFile()
 
 void cDeviceLogKML::SetSerialNumber(uint32_t serialNumber)
 {
-    devSerialNo = serialNumber;
+    m_devSerialNo = serialNumber;
 }
 
 

--- a/src/DeviceLogKML.h
+++ b/src/DeviceLogKML.h
@@ -41,7 +41,11 @@ struct sKmlLog
 class cDeviceLogKML : public cDeviceLog
 {
 public:
-	void InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
+    cDeviceLogKML() : cDeviceLog() {};
+    cDeviceLogKML(const ISDevice* dev) : cDeviceLog(dev) {};
+    cDeviceLogKML(uint16_t hdwId, uint32_t serialNo) : cDeviceLog(hdwId, serialNo) {};
+
+    void InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
 	bool CloseAllFiles() OVERRIDE;
 	bool CloseWriteFile(int kid, sKmlLog& log);
 	bool OpenWithSystemApp(void) OVERRIDE;

--- a/src/DeviceLogRaw.cpp
+++ b/src/DeviceLogRaw.cpp
@@ -31,19 +31,27 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 using namespace std;
 
 
-cDeviceLogRaw::cDeviceLogRaw()
+cDeviceLogRaw::cDeviceLogRaw() : cDeviceLog()
 {
     is_comm_init(&m_comm, m_commBuf, sizeof(m_commBuf));
 }
 
+cDeviceLogRaw::cDeviceLogRaw(const ISDevice *dev) : cDeviceLog(dev) {
+    is_comm_init(&m_comm, m_commBuf, sizeof(m_commBuf));
+}
 
-void cDeviceLogRaw::InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize)
+cDeviceLogRaw::cDeviceLogRaw(uint16_t hdwId, uint32_t serialNo) : cDeviceLog(hdwId, serialNo) {
+    is_comm_init(&m_comm, m_commBuf, sizeof(m_commBuf));
+};
+
+
+void cDeviceLogRaw::InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize)
 {
 //     m_chunk.Init(chunkSize);
     m_chunk.Clear();
-    m_chunk.m_hdr.pHandle = pHandle;
+    m_chunk.m_hdr.pHandle = (device != nullptr ? device->portHandle : -1);
 
-    cDeviceLog::InitDeviceForWriting(pHandle, timestamp, directory, maxDiskSpace, maxFileSize);
+    cDeviceLog::InitDeviceForWriting(timestamp, directory, maxDiskSpace, maxFileSize);
 }
 
 
@@ -114,7 +122,7 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
 				{ 
 					if (m_comm.rxErrorCount>1) 
 					{ 
-						printf("SN%d SaveData() parse errors: %d\n", m_devInfo.serialNumber, m_comm.rxErrorCount); 
+						printf("SN%d SaveData() parse errors: %d\n", devSerialNo, m_comm.rxErrorCount);
 					}
 				}
 				break;
@@ -129,7 +137,7 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
                 cDeviceLog::SaveData(&m_comm.rxPkt.dataHdr, m_comm.rxPkt.data.ptr);
 
                 // Add serial number if available
-                if (m_comm.rxPkt.dataHdr.id == DID_DEV_INFO && !copyDataPToStructP2(&m_devInfo, &m_comm.rxPkt.dataHdr, m_comm.rxPkt.data.ptr, sizeof(dev_info_t)))
+                if (m_comm.rxPkt.dataHdr.id == DID_DEV_INFO && !copyDataPToStructP2((void*)&(device->devInfo), &m_comm.rxPkt.dataHdr, m_comm.rxPkt.data.ptr, sizeof(dev_info_t)))
                 {
                     int start = m_comm.rxPkt.dataHdr.offset;
                     int end = m_comm.rxPkt.dataHdr.offset + m_comm.rxPkt.dataHdr.size;
@@ -138,7 +146,7 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
                     // Did we really get the serial number?
                     if (start <= snOffset && (int)(snOffset + sizeof(uint32_t)) <= end)
                     {
-                        m_chunk.m_hdr.devSerialNum = m_devInfo.serialNumber;
+                        m_chunk.m_hdr.devSerialNum = device->devInfo.serialNumber;
                     }
                 }
                 }
@@ -264,7 +272,7 @@ p_data_buf_t* cDeviceLogRaw::ReadDataFromChunk()
 			case _PTYPE_PARSE_ERROR:
 				if (m_showParseErrors)
 				{
-					if (m_comm.rxErrorCount > 1) { printf("SN%d ReadDataFromChunk() parse errors: %d\n", m_devInfo.serialNumber, m_comm.rxErrorCount); }
+					if (m_comm.rxErrorCount > 1) { printf("SN%d ReadDataFromChunk() parse errors: %d\n", devSerialNo, m_comm.rxErrorCount); }
 				}
 				break;
 
@@ -295,10 +303,9 @@ bool cDeviceLogRaw::ReadChunkFromFile()
     return true;
 }
 
-
 void cDeviceLogRaw::SetSerialNumber(uint32_t serialNumber)
 {
-    m_devInfo.serialNumber = serialNumber;
+    devSerialNo = serialNumber;
     m_chunk.m_hdr.devSerialNum = serialNumber;
 }
 

--- a/src/DeviceLogRaw.cpp
+++ b/src/DeviceLogRaw.cpp
@@ -269,12 +269,12 @@ p_data_buf_t* cDeviceLogRaw::ReadDataFromChunk()
                 // Do nothing
                 break;
 
-			case _PTYPE_PARSE_ERROR:
-				if (m_showParseErrors)
-				{
-					if (m_comm.rxErrorCount > 1) { printf("SN%d ReadDataFromChunk() parse errors: %d\n", devSerialNo, m_comm.rxErrorCount); }
-				}
-				break;
+            case _PTYPE_PARSE_ERROR:
+                if (m_showParseErrors)
+                {
+                    if (m_comm.rxErrorCount > 1) { printf("SN%d ReadDataFromChunk() parse errors: %d\n", devSerialNo, m_comm.rxErrorCount); }
+                }
+                break;
 
             case _PTYPE_INERTIAL_SENSE_DATA:
             case _PTYPE_INERTIAL_SENSE_CMD:

--- a/src/DeviceLogRaw.cpp
+++ b/src/DeviceLogRaw.cpp
@@ -122,7 +122,7 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
 				{ 
 					if (m_comm.rxErrorCount>1) 
 					{ 
-						printf("SN%d SaveData() parse errors: %d\n", devSerialNo, m_comm.rxErrorCount);
+						printf("SN%d SaveData() parse errors: %d\n", m_devSerialNo, m_comm.rxErrorCount);
 					}
 				}
 				break;
@@ -272,7 +272,7 @@ p_data_buf_t* cDeviceLogRaw::ReadDataFromChunk()
             case _PTYPE_PARSE_ERROR:
                 if (m_showParseErrors)
                 {
-                    if (m_comm.rxErrorCount > 1) { printf("SN%d ReadDataFromChunk() parse errors: %d\n", devSerialNo, m_comm.rxErrorCount); }
+                    if (m_comm.rxErrorCount > 1) { printf("SN%d ReadDataFromChunk() parse errors: %d\n", m_devSerialNo, m_comm.rxErrorCount); }
                 }
                 break;
 
@@ -305,7 +305,7 @@ bool cDeviceLogRaw::ReadChunkFromFile()
 
 void cDeviceLogRaw::SetSerialNumber(uint32_t serialNumber)
 {
-    devSerialNo = serialNumber;
+    m_devSerialNo = serialNumber;
     m_chunk.m_hdr.devSerialNum = serialNumber;
 }
 

--- a/src/DeviceLogRaw.h
+++ b/src/DeviceLogRaw.h
@@ -19,6 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "DataChunk.h"
 #include "DeviceLog.h"
+#include "ISDevice.h"
 #include "com_manager.h"
 #include "ISLogStats.h"
 
@@ -27,8 +28,11 @@ class cDeviceLogRaw : public cDeviceLog
 {
 public:
     cDeviceLogRaw();
+    cDeviceLogRaw(const ISDevice* dev);
+    cDeviceLogRaw(uint16_t hdwId, uint32_t serialNo);
 
-	void InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFilesize) OVERRIDE;
+
+    void InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFilesize) OVERRIDE;
 	bool CloseAllFiles() OVERRIDE;
 	bool FlushToFile() OVERRIDE;
 	bool SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &globalLogStats) OVERRIDE;

--- a/src/DeviceLogSerial.cpp
+++ b/src/DeviceLogSerial.cpp
@@ -94,7 +94,7 @@ bool cDeviceLogSerial::SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf, p
             }
         }
     } else
-        m_chunk.m_hdr.devSerialNum = devSerialNo;
+        m_chunk.m_hdr.devSerialNum = m_devSerialNo;
 
     // Ensure data will fit in chunk.  If not, create new chunk
     int32_t dataBytes = sizeof(p_data_hdr_t) + dataHdr->size;
@@ -193,7 +193,7 @@ bool cDeviceLogSerial::ReadChunkFromFile() {
 
 
 void cDeviceLogSerial::SetSerialNumber(uint32_t serialNumber) {
-    devSerialNo = serialNumber;
+    m_devSerialNo = serialNumber;
     m_chunk.m_hdr.devSerialNum = serialNumber;
 }
 

--- a/src/DeviceLogSerial.h
+++ b/src/DeviceLogSerial.h
@@ -22,28 +22,38 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "com_manager.h"
 
 
-
-
-class cDeviceLogSerial : public cDeviceLog
-{
+class cDeviceLogSerial : public cDeviceLog {
 public:
-    cDeviceLogSerial(){}
+    cDeviceLogSerial();
 
-	void InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFilesize) OVERRIDE;
-	bool CloseAllFiles() OVERRIDE;
-	bool FlushToFile() OVERRIDE;
-    bool SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA) OVERRIDE;
-	p_data_buf_t* ReadData() OVERRIDE;
-	void SetSerialNumber(uint32_t serialNumber) OVERRIDE;
-	std::string LogFileExtention() OVERRIDE { return std::string(".dat"); }
-	void Flush() OVERRIDE;
+    cDeviceLogSerial(const ISDevice *dev);
 
-	cDataChunk m_chunk;
+    cDeviceLogSerial(uint16_t hdwId, uint32_t serialNo);
+
+    void InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFilesize) OVERRIDE;
+
+    bool CloseAllFiles() OVERRIDE;
+
+    bool FlushToFile() OVERRIDE;
+
+    bool SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf, protocol_type_t ptype = _PTYPE_INERTIAL_SENSE_DATA) OVERRIDE;
+
+    p_data_buf_t *ReadData() OVERRIDE;
+
+    void SetSerialNumber(uint32_t serialNumber) OVERRIDE;
+
+    std::string LogFileExtention() OVERRIDE { return std::string(".dat"); }
+
+    void Flush() OVERRIDE;
+
+    cDataChunk m_chunk;
 
 private:
-	p_data_buf_t* ReadDataFromChunk();
-	bool ReadChunkFromFile();
-	bool WriteChunkToFile();
+    p_data_buf_t *ReadDataFromChunk();
+
+    bool ReadChunkFromFile();
+
+    bool WriteChunkToFile();
 };
 
 #endif // DEVICE_LOG_SERIAL_H

--- a/src/DeviceLogSorted.cpp
+++ b/src/DeviceLogSorted.cpp
@@ -519,7 +519,7 @@ bool cDeviceLogSorted::ReadChunkFromFiles(cSortedDataChunk *chunk, uint32_t id)
 
 void cDeviceLogSorted::SetSerialNumber(uint32_t serialNumber)
 {
-    devSerialNo = serialNumber;
+    m_devSerialNo = serialNumber;
     if (m_chunks[DID_DEV_INFO] == NULLPTR)
 	{
         m_chunks[DID_DEV_INFO] = new cSortedDataChunk();

--- a/src/DeviceLogSorted.h
+++ b/src/DeviceLogSorted.h
@@ -26,8 +26,10 @@ class cDeviceLogSorted : public cDeviceLog
 {
 public:
     cDeviceLogSorted();
+    cDeviceLogSorted(const ISDevice* dev);
+    cDeviceLogSorted(uint16_t hdwId, uint32_t serialNo);
 
-	void InitDeviceForWriting(int pHandle, std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
+    void InitDeviceForWriting(std::string timestamp, std::string directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
 	void InitDeviceForReading() OVERRIDE;
 	bool OpenAllReadFiles();
 	bool CloseAllFiles() OVERRIDE;

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -196,21 +196,23 @@ void setParserStart(is_comm_instance_t* c, pFnProcessPkt processPkt)
     c->processPkt = processPkt;
 }
 
-static inline protocol_type_t reportParseError(is_comm_instance_t* c)
+static inline protocol_type_t reportParseError(is_comm_instance_t* c, eParseErrorType errorType)
 {
     if (!c->rxErrorState)
     {
         c->rxErrorState = 1;
         c->rxErrorCount++;
+        c->rxErrorType = errorType;
+        c->rxErrorTypeCount[errorType]++;
         return _PTYPE_PARSE_ERROR;
     }
     return _PTYPE_NONE;
 }
 
-static inline protocol_type_t parseErrorResetState(is_comm_instance_t* c)
+static inline protocol_type_t parseErrorResetState(is_comm_instance_t* c, eParseErrorType errorType)
 {
     is_comm_reset_parser(c);
-    return reportParseError(c);
+    return reportParseError(c, errorType);
 }
 
 
@@ -256,7 +258,7 @@ static protocol_type_t processIsbPkt(void* v)
             return _PTYPE_NONE;
         }
         // Invalid preamble - Reset state
-        return parseErrorResetState(c);
+        return parseErrorResetState(c, EPARSE_INVALID_PREAMBLE);
 
     case 2:		// Wait for packet header
         numBytes = (int)(c->rxBuf.scan - c->rxBuf.head);
@@ -271,7 +273,7 @@ static protocol_type_t processIsbPkt(void* v)
         p->size = sizeof(packet_hdr_t) + isbPkt->hdr.payloadSize + 2;		// Header + payload + footer (checksum)
         if (p->size > MAX_MSG_LENGTH_ISB)
         {	// Invalid size
-            return parseErrorResetState(c);
+            return parseErrorResetState(c, EPARSE_INVALID_SIZE);
         }
         return _PTYPE_NONE;
 
@@ -297,7 +299,7 @@ static protocol_type_t processIsbPkt(void* v)
     uint16_t calcCksum = is_comm_isb_checksum16(0, c->rxBuf.head, bytes_cksum);
     if (cksum->ck != calcCksum)
     {	// Invalid checksum
-        return parseErrorResetState(c);
+        return parseErrorResetState(c, EPARSE_INVALID_CHKSUM);
     }
 
     /////////////////////////////////////////////////////////
@@ -375,7 +377,7 @@ static protocol_type_t processIsbPkt(void* v)
     }
 
     // Invalid data type
-    return parseErrorResetState(c);
+    return parseErrorResetState(c, EPARSE_INVALID_DATATYPE);
 }
 
 static protocol_type_t processNmeaPkt(void* v)
@@ -403,7 +405,7 @@ static protocol_type_t processNmeaPkt(void* v)
             numBytes = (int)(c->rxBuf.scan - c->rxBuf.head);
             if (numBytes > MAX_MSG_LENGTH_NMEA)
             {	// Exceeds max length
-                return parseErrorResetState(c);
+                return parseErrorResetState(c, EPARSE_INVALID_SIZE);
             }
         }
         return _PTYPE_NONE;
@@ -411,7 +413,7 @@ static protocol_type_t processNmeaPkt(void* v)
     case 3:		// Wait for end of packet
         if (*(c->rxBuf.scan) != PSC_NMEA_END_BYTE)
         {	// Invalid end
-            return parseErrorResetState(c);
+            return parseErrorResetState(c, EPARSE_MISSING_EOS_MARKER);
         }
         // Found packet end
         break;
@@ -424,7 +426,7 @@ static protocol_type_t processNmeaPkt(void* v)
     numBytes = (int)(c->rxBuf.scan - c->rxBuf.head) + 1;
     if (numBytes < 8)
     {	// Packet length too short
-        return parseErrorResetState(c);
+        return parseErrorResetState(c, EPARSE_INCOMPLETE_PACKET);
     }
 
     // Validate checksum
@@ -439,7 +441,7 @@ static protocol_type_t processNmeaPkt(void* v)
     }
     if (msgChecksum != calChecksum)
     {	// Invalid checksum
-        return parseErrorResetState(c);
+        return parseErrorResetState(c, EPARSE_INVALID_CHKSUM);
     }
 
     /////////////////////////////////////////////////////////
@@ -480,7 +482,7 @@ static protocol_type_t processUbloxPkt(void* v)
         }
         else
         {	// Invalid preamble - Reset state
-            return parseErrorResetState(c);
+            return parseErrorResetState(c, EPARSE_INVALID_PREAMBLE);
         }
         return _PTYPE_NONE;
 
@@ -518,7 +520,7 @@ static protocol_type_t processUbloxPkt(void* v)
     cksum.ck = is_comm_fletcher16(0, cksum_start, cksum_size);
     if (pktChecksum != cksum.ck)
     {	// Invalid checksum
-        return parseErrorResetState(c);
+        return parseErrorResetState(c, EPARSE_INVALID_CHKSUM);
     }
 
     /////////////////////////////////////////////////////////
@@ -554,7 +556,7 @@ static protocol_type_t processRtcm3Pkt(void* v)
         // Validate packet length
         if (p->size > MAX_MSG_LENGTH_RTCM || p->size > c->rxBuf.size - 6)
         {	// Corrupt data
-            return parseErrorResetState(c);
+            return parseErrorResetState(c, EPARSE_INCOMPLETE_PACKET);
         }
         return _PTYPE_NONE;
 
@@ -579,7 +581,7 @@ static protocol_type_t processRtcm3Pkt(void* v)
 
     if (actualCRC != correctCRC)
     {	// Invalid checksum
-        return parseErrorResetState(c);
+        return parseErrorResetState(c, EPARSE_INVALID_CHKSUM);
     }
 
     /////////////////////////////////////////////////////////
@@ -672,7 +674,7 @@ static protocol_type_t processSonyByte(void* v)
         }
         if (checksum != hdr->fcsh || hdr->dataSize > MAX_MSG_LENGTH_SONY || hdr->dataSize > c->rxBuf.size)
         {	// Invalid header - Reset state
-            return parseErrorResetState(c);
+            return parseErrorResetState(c, EPARSE_INVALID_PREAMBLE);
         }
 
         // Valid header
@@ -703,7 +705,7 @@ static protocol_type_t processSonyByte(void* v)
     }
     if (checksum != c->rxBuf.scan[0])
     {	// Invalid data checksum
-        return parseErrorResetState(c);
+        return parseErrorResetState(c, EPARSE_INVALID_CHKSUM);
     }
 
     /////////////////////////////////////////////////////////
@@ -742,7 +744,7 @@ static protocol_type_t processSpartnByte(void* v)
         uint8_t calc = computeCrc4Ccitt(dbuf, 3);
         if((c->rxBuf.head[3] & 0x0F) != calc)
         {  	// Invalid header - Reset state
-            return parseErrorResetState(c);
+            return parseErrorResetState(c, EPARSE_INVALID_HEADER);
         }
 
         p->state++;
@@ -819,7 +821,7 @@ static protocol_type_t processSpartnByte(void* v)
         }
         else
         {	// Invalid data
-            return parseErrorResetState(c);
+            return parseErrorResetState(c, EPARSE_INVALID_PAYLOAD);
         }
 
         p->state = -((int32_t)payloadLen);
@@ -844,7 +846,7 @@ static protocol_type_t processSpartnByte(void* v)
         }
         else if(p->state > 0)
         {	// corrupt data or bad state
-            return parseErrorResetState(c);
+            return parseErrorResetState(c, EPARSE_INVALID_PAYLOAD);
         }
 
         break;
@@ -880,7 +882,7 @@ int is_comm_free(is_comm_instance_t* c)
         {	// If the buffer is mostly full and can only be shifted less than 1/3 of the buffer
             // we will be hung unless we flush the ring buffer, we have to drop bytes in this case and the caller
             // will need to resend the data
-            parseErrorResetState(c);
+            parseErrorResetState(c, EPARSE_RXBUFFER_FLUSHED);
             buf->head =
             buf->tail =
             buf->scan = buf->start;
@@ -941,7 +943,7 @@ protocol_type_t is_comm_parse_timeout(is_comm_instance_t* c, uint32_t timeMs)
             case SPARTN_START_BYTE:         if (c->config.enabledMask & ENABLE_PROTOCOL_SPARTN) { setParserStart(c, processSpartnByte); }  break;
             case SONY_START_BYTE:           if (c->config.enabledMask & ENABLE_PROTOCOL_SONY)   { setParserStart(c, processSonyByte); }    break;
             default:                        
-                if (reportParseError(c)) 
+                if (reportParseError(c, EPARSE_STREAM_UNPARSEABLE))
                 { 
                     return _PTYPE_PARSE_ERROR; 
                 }                                       

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -538,6 +538,20 @@ typedef enum
 	ENABLE_PROTOCOL_SONY        = 0x00000020,
 } eProtocolMask;
 
+typedef enum {
+    EPARSE_INVALID_PREAMBLE,
+    EPARSE_INVALID_SIZE,
+    EPARSE_INVALID_CHKSUM,
+    EPARSE_INVALID_DATATYPE,
+    EPARSE_MISSING_EOS_MARKER,      //! Invalid End-of-Stream/End-of-Sentence(NMEA) marker
+    EPARSE_INCOMPLETE_PACKET,       //! Stream/Sentence(NMEA) is too short/incomplete to identify as a packet
+    EPARSE_INVALID_HEADER,
+    EPARSE_INVALID_PAYLOAD,
+    EPARSE_RXBUFFER_FLUSHED,
+    EPARSE_STREAM_UNPARSEABLE,
+    NUM_EPARSE_ERRORS
+} eParseErrorType;
+
 typedef struct  
 {
 	/** See eProtocolMask */
@@ -571,7 +585,13 @@ typedef struct
 	/** Communications error counter */
 	uint32_t rxErrorCount;
 
-	/** Process packet function pointer.  Null pointer indicates no parsing is in progress. */
+    /** Communications error type (most recent) */
+    eParseErrorType rxErrorType;
+
+    /** Communications error counter, by type */
+    uint32_t rxErrorTypeCount[NUM_EPARSE_ERRORS];
+
+    /** Process packet function pointer.  Null pointer indicates no parsing is in progress. */
 	pFnProcessPkt processPkt;
 
 	/** Protocol parser state */

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -9,6 +9,9 @@
 #ifndef INERTIALSENSESDK_ISDEVICE_H
 #define INERTIALSENSESDK_ISDEVICE_H
 
+#include <memory>
+
+#include "DeviceLog.h"
 #include "protocol/FirmwareUpdate.h"
 // #include "ISFirmwareUpdater.h"
 
@@ -41,23 +44,25 @@ public:
 
 class ISDevice {
 public:
-    int portHandle;
+    int portHandle = 0;
     serial_port_t serialPort = { };
-    // libusb_device* usbDevice; // reference to the USB device (if using a USB connection), otherwise should be nullptr.
+    // libusb_device* usbDevice = nullptr; // reference to the USB device (if using a USB connection), otherwise should be nullptr.
+
     dev_info_t devInfo = { };
-    system_command_t sysCmd = { };
+    sys_params_t sysParams = { };
     nvm_flash_cfg_t flashCfg = { };
     unsigned int flashCfgUploadTimeMs = 0;		// (ms) non-zero time indicates an upload is in progress and local flashCfg should not be overwritten
     uint32_t flashCfgUploadChecksum = 0;
     evb_flash_cfg_t evbFlashCfg = { };
-    sys_params_t sysParams = { };
+    system_command_t sysCmd = { };
+
+    std::shared_ptr<cDeviceLog> devLogger;
     fwUpdate::update_status_e closeStatus = { };
     ISDeviceUpdater fwUpdate = { };
 
     static ISDevice invalidRef;
 
     ISDevice() { };
-
 
 };
 

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -441,7 +441,8 @@ void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 
 	static unsigned int timeSinceClearMs = 0;
 	static char idHist[DID_COUNT] = { 0 };
-	if (m_displayMode != DMODE_SCROLL)
+
+	if ((m_displayMode != DMODE_SCROLL) && (m_displayMode != DMODE_RAW_PARSE))
 	{
 		// Clear display every 2 seconds or if we start seeing new messages.
 		if (curTimeMs - timeSinceClearMs > 2000 || curTimeMs < timeSinceClearMs || idHist[data->hdr.id] == 0)
@@ -469,7 +470,7 @@ void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 		}
 		break;
 
-	case DMODE_EDIT:
+		case DMODE_EDIT:
 		if (m_editData.did == data->hdr.id)
 		{
 			m_editData.pData = *data;
@@ -480,7 +481,8 @@ void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 		DataToStats(data);
 		break;
 
-	case DMODE_SCROLL:	// Scroll display 
+	case DMODE_RAW_PARSE:	// fallthrough to DMODE_SCROLL
+	case DMODE_SCROLL:	// Scroll display
 		cout << DataToString(data) << endl;
 		break;
 	}
@@ -603,6 +605,12 @@ string cInertialSenseDisplay::DataToString(const p_data_t* data)
 	// Copy only new data
 	copyDataPToStructP(&d, data, sizeof(uDatasets));
 
+	if (m_displayMode == DMODE_RAW_PARSE)
+    {
+		return DataToStringPacket((const char *) data->ptr, data->hdr, 32, true);
+	}
+
+
 	string str;
 	switch (data->hdr.id)
 	{
@@ -642,13 +650,6 @@ string cInertialSenseDisplay::DataToString(const p_data_t* data)
 	default:
         if (m_showRawHex)
             str = DataToStringRawHex((const char *)data->ptr, data->hdr, 32);
-#if 0	// List all DIDs 
-		char buf[128];
-		SNPRINTF(buf, sizeof(buf), "(%d) %s \n", data->hdr.id, cISDataMappings::GetDataSetName(data->hdr.id));
-		str = buf;
-#elif 0
-		str = DataToStringGeneric(data);
-#endif
 		break;
 	}
 
@@ -1691,6 +1692,67 @@ string cInertialSenseDisplay::DataToStringRawHex(const char *raw_data, const p_d
 
     return buf;
 }
+
+
+/**
+ * Formats the specified DID's raw data as a "hexidecimal view". This can be used with any DID that is not
+ * otherwise supported.
+ * @param raw_data a pointer to the raw DID byte stream
+ * @param hdr the DID header
+ * @param bytesPerLine the number of hexadecimal bytes to print per line.
+ * @return returns a fully formatted string
+ */
+string cInertialSenseDisplay::DataToStringPacket(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine, bool colorize = true)
+{
+	(void)hdr;
+	char buf[BUF_SIZE];
+	char* ptr = buf;
+	char* ptrEnd = buf + BUF_SIZE;
+
+	#define BLACK   "\u001b[30m"
+	#define RED     "\u001b[31m"
+	#define GREEN   "\u001b[32m"
+	#define YELLOW  "\u001b[33m"
+	#define BLUE    "\u001b[34m"
+	#define MAGENTA "\u001b[35m"
+	#define CYAN    "\u001b[36m"
+	#define WHITE   "\u001b[37m"
+	#define RESET   "\u001b[0m"
+
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[PREAMB] " GREEN "49 EF ");
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[Flags: " YELLOW "%s" BLUE "] " GREEN "?? ", "?");
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[Id: " YELLOW "%s" BLUE "] " GREEN "%02x ", cISDataMappings::GetDataSetName(hdr.id), hdr.id);
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[Size: " YELLOW "%u" BLUE "] " GREEN "%02x %02x ", hdr.size, ((hdr.size >> 8) & 0xFF), (hdr.size & 0xFF));
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "[Offset: " YELLOW "%u" BLUE "] " GREEN "%02x %02x", hdr.offset, ((hdr.offset >> 8) & 0xFF), (hdr.offset & 0xFF));
+
+#if DISPLAY_DELTA_TIME==1
+	static double lastTime[2] = { 0 };
+	double dtMs = 1000.0*(wheel.timeOfWeek - lastTime[i]);
+	lastTime[i] = wheel.timeOfWeek;
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, " %4.1lfms", dtMs);
+#else
+#endif
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n");
+	int lines = (hdr.size / bytesPerLine) + 1;
+	for (int j = 0; j < lines; j++) {
+		int linelen = (j == lines-1) ? hdr.size % bytesPerLine : bytesPerLine;
+		if (linelen > 0) {
+			if (j == 0)
+				ptr += SNPRINTF(ptr, ptrEnd - ptr, BLUE "  [DATA] " GREEN);
+			else
+				ptr += SNPRINTF(ptr, ptrEnd - ptr, "         ");
+
+			for (int i = 0; i < linelen; i++) {
+				ptr += SNPRINTF(ptr, ptrEnd - ptr, "%02x ", (uint8_t) raw_data[(j * bytesPerLine) + i]);
+			}
+			ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n");
+		}
+	}
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, RESET);
+
+	return buf;
+}
+
 
 #define DISPLAY_SNPRINTF(f_, ...)	{ptr += SNPRINTF(ptr, ptrEnd - ptr, (f_), ##__VA_ARGS__);}
 #define DTS_VALUE_FORMAT	"%22s "

--- a/src/ISDisplay.h
+++ b/src/ISDisplay.h
@@ -60,6 +60,7 @@ public:
 		DMODE_SCROLL,
 		DMODE_EDIT,
 		DMODE_STATS,
+        DMODE_RAW_PARSE,
 	};
 
 	cInertialSenseDisplay(eDisplayMode displayMode = DMODE_QUIET);
@@ -121,6 +122,7 @@ public:
     std::string DataToStringGPXStatus(const gpx_status_t &gpxStatus, const p_data_hdr_t& hdr);
     std::string DataToStringDebugArray(const debug_array_t &debug, const p_data_hdr_t& hdr);
     std::string DataToStringRawHex(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine);
+    std::string DataToStringPacket(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine, bool colorize);
 	std::string DataToStringGeneric(const p_data_t* data);
 	static void AddCommaToString(bool &comma, char* &ptr, char* &ptrEnd){ if (comma) { ptr += SNPRINTF(ptr, ptrEnd - ptr, ", "); } comma = true; };
 

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -572,7 +572,8 @@ void cISLogger::CloseAllFiles()
 {
     for (auto it : m_devices)
     {
-        it.second->CloseAllFiles();
+        if (it.second != nullptr)
+            it.second->CloseAllFiles();
     }
 
     m_logStats.WriteToFile(m_directory + "/stats.txt");
@@ -606,6 +607,11 @@ void cISLogger::ShowParseErrors(bool show)
     m_showParseErrors = show;
 }
 
+uint64_t cISLogger::LogSize(uint32_t devSerialNo)
+{
+    return m_devices.contains(devSerialNo) ? m_devices[devSerialNo]->LogSize() : -1;
+}
+
 uint64_t cISLogger::LogSizeAll()
 {
     uint64_t size = 0;
@@ -615,13 +621,6 @@ uint64_t cISLogger::LogSizeAll()
     }
     return size;
 }
-
-
-uint64_t cISLogger::LogSize(uint32_t devSerialNo)
-{
-    return m_devices.contains(devSerialNo) ? m_devices[devSerialNo]->LogSize() : 0;
-}
-
 
 float cISLogger::LogSizeAllMB()
 {

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -609,7 +609,7 @@ void cISLogger::ShowParseErrors(bool show)
 
 uint64_t cISLogger::LogSize(uint32_t devSerialNo)
 {
-    return m_devices.contains(devSerialNo) ? m_devices[devSerialNo]->LogSize() : -1;
+    return (m_devices.find(devSerialNo) == m_devices.end()) ? m_devices[devSerialNo]->LogSize() : -1;
 }
 
 uint64_t cISLogger::LogSizeAll()
@@ -630,24 +630,24 @@ float cISLogger::LogSizeAllMB()
 
 float cISLogger::LogSizeMB(uint32_t devSerialNo)
 {
-    return m_devices.contains(devSerialNo) ? m_devices[devSerialNo]->LogSize() * 0.000001f : 0;
+    return (m_devices.find(devSerialNo) == m_devices.end()) ? m_devices[devSerialNo]->LogSize() * 0.000001f : 0;
 }
 
 
 float cISLogger::FileSizeMB(uint32_t devSerialNo)
 {
-    return m_devices.contains(devSerialNo) ? m_devices[devSerialNo]->FileSize() * 0.000001f : 0;
+    return (m_devices.find(devSerialNo) == m_devices.end()) ? m_devices[devSerialNo]->FileSize() * 0.000001f : 0;
 }
 
 
 uint32_t cISLogger::FileCount(uint32_t devSerialNo)
 {
-    return m_devices.contains(devSerialNo) ? m_devices[devSerialNo]->FileCount() : 0;
+    return (m_devices.find(devSerialNo) == m_devices.end()) ? m_devices[devSerialNo]->FileCount() : 0;
 }
 
 std::string cISLogger::GetNewFileName(uint32_t devSerialNo, uint32_t fileCount, const char *suffix)
 {
-    return m_devices.contains(devSerialNo) ? m_devices[devSerialNo]->GetNewFileName(devSerialNo, fileCount, suffix) : std::string("");
+    return (m_devices.find(devSerialNo) == m_devices.end()) ? m_devices[devSerialNo]->GetNewFileName(devSerialNo, fileCount, suffix) : std::string("");
 }
 
 /*
@@ -713,7 +713,6 @@ bool cISLogger::CopyLog(cISLogger &log, const string &timestamp, const string &o
 
     EnableLogging(true);
     p_data_buf_t *data = NULL;
-    // for (unsigned int dev = 0; dev < log.DeviceCount(); dev++)
     for ( auto& srcDev : log.DeviceLogs() )
     {
         auto dstDev = ( srcDev->Device() != nullptr ? registerDevice(*(srcDev->Device())) : registerDevice(0, srcDev->SerialNumber()) );

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -95,11 +95,11 @@ public:
 	std::string TimeStamp() { return m_timeStamp; }
 	std::string LogDirectory() { return m_directory; }
 	uint64_t LogSizeAll();
-	uint64_t LogSize(uint32_t devSerialNo = 0);
+	uint64_t LogSize(uint32_t devSerialNo);
 	float LogSizeAllMB();
-	float LogSizeMB(uint32_t devSerialNo = 0);
-	float FileSizeMB(uint32_t devSerialNo = 0);
-	uint32_t FileCount(uint32_t devSerialNo = 0);
+	float LogSizeMB(uint32_t devSerialNo);
+	float FileSizeMB(uint32_t devSerialNo);
+	uint32_t FileCount(uint32_t devSerialNo);
 	std::string GetNewFileName(uint32_t devSerialNo, uint32_t fileCount, const char* suffix);
     std::vector<std::shared_ptr<cDeviceLog>> DeviceLogs();
 	uint32_t DeviceCount() { return (uint32_t)m_devices.size(); }

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -979,6 +979,20 @@ void InertialSense::ProcessRxNmea(int pHandle, const uint8_t* msg, int msgSize)
 	}
 }
 
+bool InertialSense::BroadcastBinaryData(int pHandle, uint32_t dataId, int periodMultiple)
+{
+    if ((pHandle >= m_comManagerState.devices.size()) || (dataId >= (sizeof(m_comManagerState.binaryCallback)/sizeof(pfnHandleBinaryData)))) {
+        return false;
+    }
+
+    if (periodMultiple < 0) {
+        comManagerDisableData(pHandle, dataId);
+    } else if (m_comManagerState.devices[pHandle].devInfo.protocolVer[0] == PROTOCOL_VERSION_CHAR0) {
+        comManagerGetData(pHandle, dataId, 0, 0, periodMultiple);
+    }
+    return true;
+}
+
 bool InertialSense::BroadcastBinaryData(uint32_t dataId, int periodMultiple, pfnHandleBinaryData callback)
 {
     if (m_comManagerState.devices.size() == 0 || dataId >= (sizeof(m_comManagerState.binaryCallback)/sizeof(pfnHandleBinaryData)))

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -49,7 +49,7 @@ static int staticReadData(int port, unsigned char* buf, int len)
 
 	if (s_is)
 	{	// Save raw data to ISlogger
-		s_is->LogRawData(port, bytesRead, buf);
+		s_is->LogRawData(&s_cm_state->devices[port], bytesRead, buf);
 	}
 
     return bytesRead;
@@ -164,14 +164,14 @@ InertialSense::~InertialSense()
 bool InertialSense::EnableLogging(const string& path, cISLogger::eLogType logType, float maxDiskSpacePercent, uint32_t maxFileSize, const string& subFolder)
 {
     cMutexLocker logMutexLocker(&m_logMutex);
-    if (!m_logger.InitSaveTimestamp(subFolder, path, cISLogger::g_emptyString, (int)m_comManagerState.devices.size(), logType, maxDiskSpacePercent, maxFileSize, subFolder.length() != 0))
+    if (!m_logger.InitSaveTimestamp(subFolder, path, cISLogger::g_emptyString, logType, maxDiskSpacePercent, maxFileSize, subFolder.length() != 0))
     {
         return false;
     }
     m_logger.EnableLogging(true);
-    for (size_t i = 0; i < m_comManagerState.devices.size(); i++)
+    for (auto& d : m_comManagerState.devices)
     {
-        m_logger.SetDeviceInfo(&m_comManagerState.devices[i].devInfo);
+        m_logger.registerDevice(d);
     }
     if (m_logThread == NULLPTR)
     {
@@ -195,9 +195,9 @@ void InertialSense::DisableLogging()
 	}
 }
 
-void InertialSense::LogRawData(int device, int dataSize, const uint8_t* data)
+void InertialSense::LogRawData(ISDevice* device, int dataSize, const uint8_t* data)
 {
-    m_logger.LogData(device, dataSize, data);
+    m_logger.LogData(device->devLogger, dataSize, data);
 }
 
 bool InertialSense::HasReceivedDeviceInfo(size_t index)
@@ -274,7 +274,8 @@ void InertialSense::LoggerThread(void* info)
                 if (inertialSense->m_logger.GetType() != cISLogger::LOGTYPE_RAW) {
                     size_t numPackets = i->second.size();
                     for (size_t j = 0; j < numPackets; j++) {
-                        if (!inertialSense->m_logger.LogData(i->first, &i->second[j].hdr, i->second[j].buf)) {
+                        auto device = inertialSense->m_comManagerState.devices[i->first];
+                        if (!inertialSense->m_logger.LogData(device.devLogger, &i->second[j].hdr, i->second[j].buf)) {
                             // Failed to write to log
                             SLEEP_MS(20); // FIXME:  This maybe problematic, as it may unnecessarily delay the thread, leading run-away memory usage.
                         }

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -157,6 +157,11 @@ public:
     bool Update();
 
     /**
+     * Register a callback handler for data stream errors.
+     */
+    void setErrorHandler(pfnComManagerParseErrorHandler errorHandler) { m_handlerError = errorHandler; }
+
+    /**
     * Enable or disable logging - logging is disabled by default
     * @param enable enable or disable the logger - disabling the logger after enabling it will close it and flush all data to disk
     * @param path the path to write the log files to
@@ -184,7 +189,7 @@ public:
     */
     bool LoggerEnabled() { return m_logger.Enabled(); }
 
-	/**
+    /**
 	 * @brief Get pointer to ISLogger
 	 * 
 	 * @return cISLogger* ISLogger pointer

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -347,6 +347,15 @@ public:
     void ProcessRxNmea(int pHandle, const uint8_t* msg, int msgSize);
 
     /**
+     * Request a specific device broadcast binary data
+     * @param pHandle the device's pHandle to request data from
+     * @param dataId the data id (DID_* - see data_sets.h) to broadcast
+     * @param periodMultiple a scalar that the source period is multiplied by to give the output period in milliseconds, 0 for one time message, less than 0 to disable broadcast of the specified dataId
+     * @return true if success, false if error - if callback is NULL and no global callback was passed to the constructor, this will return false
+     */
+    bool BroadcastBinaryData(int pHandle, uint32_t dataId, int periodMultiple);
+
+    /**
     * Broadcast binary data
     * @param dataId the data id (DID_* - see data_sets.h) to broadcast
     * @param periodMultiple a scalar that the source period is multiplied by to give the output period in milliseconds, 0 for one time message, less than 0 to disable broadcast of the specified dataId

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -198,7 +198,7 @@ public:
 	 * @param dataSize Number of bytes of raw data.
 	 * @param data Pointer to raw data.
 	 */
-	void LogRawData(int device, int dataSize, const uint8_t* data);
+	void LogRawData(ISDevice* device, int dataSize, const uint8_t* data);
 
 	/**
 	* Connect to a server and send the data from that server to the uINS. Open must be called first to connect to the uINS unit.

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -271,6 +271,8 @@ static int serialPortOpenPlatform(serial_port_t* serialPort, const char* port, i
 {
     if (serialPort->handle != 0)
     {
+        // FIXME: Should we be closing the port and then reopen??
+        // serialPortClose(serialPort);
         // already open
         return 0;
     }

--- a/tests/test_ISLogger.cpp
+++ b/tests/test_ISLogger.cpp
@@ -26,7 +26,7 @@ static dev_info_t CreateDeviceInfo(uint32_t serial)
 	return d;
 }
 
-static bool LogData(cISLogger& logger, uint32_t device, uint32_t id, uint32_t offset, uint32_t size, void* data)
+static bool LogData(cISLogger& logger, std::shared_ptr<cDeviceLog> device, uint32_t id, uint32_t offset, uint32_t size, void* data)
 {
 	p_data_hdr_t hdr;
 	hdr.id = id;
@@ -73,8 +73,8 @@ static void TestConvertLog(string inputPath, cISLogger::eLogType inputLogType, c
 	finalLogger2.ShowParseErrors(showParseErrors);		// Allow garbage data tests to hide parse errors
 	p_data_buf_t* data1;
 	p_data_buf_t* data2;
-	unsigned int devIndex1 = 0;
-	unsigned int devIndex2 = 0;
+	size_t devIndex1 = 0;
+	size_t devIndex2 = 0;
 	int dataIndex = -1;
 
 	while (1)

--- a/tests/test_data_utils.cpp
+++ b/tests/test_data_utils.cpp
@@ -508,7 +508,7 @@ void GenerateDataLogFiles(int numDevices, string directory, cISLogger::eLogType 
         devices[d].devInfo.hardwareType = IS_HARDWARE_TYPE_IMX;
         devices[d].devInfo.hardwareVer[0] = 5;
         devices[d].devInfo.hardwareVer[1] = 0;
-        devices[d].devInfo.serialNumber = random() % 999999;
+        devices[d].devInfo.serialNumber = rand() % 999999;
         logger.registerDevice(devices[d]);
     }
     logger.EnableLogging(true);

--- a/tests/test_data_utils.cpp
+++ b/tests/test_data_utils.cpp
@@ -520,7 +520,7 @@ void GenerateDataLogFiles(int numDevices, string directory, cISLogger::eLogType 
 
     CurrentGpsTimeMs(s_gpsTowOffsetMs, s_gpsWeek);
 
-    for (s_timeMs=0; logger.LogSizeMB() < logSizeMB; s_timeMs += s_timePeriodMs)
+    for (s_timeMs=0; logger.LogSizeAllMB() < logSizeMB; s_timeMs += s_timePeriodMs)
     {
         for (auto& d : logger.DeviceLogs())
         {


### PR DESCRIPTION
Heavily refactors ISLogger and related classes to use a more deterministic reference to a device, rather than the portHandle into a vector of ports, and associated devices.  Now uses device type/serial as a key into a map of ISDevice.
Fix: IS::Update() would close all ports if any port closed. Now returns false only when all ports have been closed (but doesn't close them).
Added InertialSense::BroadcastBinaryData(pHandle) method to request broadcasts for specific ports.
Added InertialSense::setErrorHandler() to specify a callback to be called when an rx/parse error is detected.
Modified ISComm::reportParseError() to include and track the type of error (eParseErrorType).
Implemented "RAW_PARSE" display mode for ISDisplay/cltool (-raw-out), which outputs raw packets (formatted as HEX) colorized green if parsed successfully, or red if there was a parse error.
