### PR TITLE
Fix General SW Linux Build

### DIFF
--- a/scripts/install_pybind.sh
+++ b/scripts/install_pybind.sh
@@ -4,7 +4,7 @@ function echo_blue   { echo -e "\033[1;34m$@\033[0m"; }
 pushd "$(dirname "$(realpath $0)")" > /dev/null
 source ../SDK/scripts/build_test_cmake.sh
 
-/usr/bin/python3 -m pip install pytest pybind11
+python3 -m pip install pytest pybind11
 
 source ~/.bashrc
 popd > /dev/null

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1407,7 +1407,7 @@ bool InertialSense::OpenSerialPorts(const char* port, int baudRate)
                     (comManagerSendRaw((int) i, (uint8_t *) NMEA_CMD_QUERY_DEVICE_INFO, NMEA_CMD_SIZE) != 0)) {
                     // there was some other janky issue with the requested port; even though the device technically exists, its in a bad state. Let's just drop it now.
                     RemoveDevice(i);
-                    removedSerials = true, i--;
+                    removedSerials = true;
                 }
             }
 


### PR DESCRIPTION
This fixes a problem that prevents scripts/install_pybind.sh from working inside of virtual environments,
It also fixes a bug inside of the SDK that can cause OpenSerialPorts() to loop forever when a serial port doesn't respond