### PR TITLE
Rearrange port monitor variables according to function for readability

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4651,30 +4651,30 @@ enum ePortMonPortType
 */
 typedef struct
 {
+    /** High nib port type (see ePortMonPortType) low nib index */
+    uint8_t         portInfo;
+    /** Status */
+    uint32_t        status;
+
     /** Tx data rate (bytes/s) */
     uint32_t        txBytesPerSec;
     /** Rx data rate (bytes/s) */
     uint32_t        rxBytesPerSec;
 
-    /** Status */
-    uint32_t        status;
-
-    /** Rx byte count */
-    uint32_t        rxBytes;
-    /** Rx buffer overflow occurrences, times that the receive buffer reduced in size due to overflow */
-    uint32_t        rxOverflows;
-    /** Rx number of checksum failures */
-    uint32_t        rxChecksumErrors;
-
     /** Tx byte count */
     uint32_t        txBytes;
+    /** Rx byte count */
+    uint32_t        rxBytes;
+
     /** Tx buffer overflow occurrences, times serWrite could not send all data */
     uint32_t        txOverflows;
+    /** Rx buffer overflow occurrences, times that the receive buffer reduced in size due to overflow */
+    uint32_t        rxOverflows;
+
     /** Tx number of bytes that were not sent */
     uint32_t        txBytesDropped;
-
-    /** High nib port type (see ePortMonPortType) low nib index */
-    uint8_t         portInfo;
+    /** Rx number of checksum failures */
+    uint32_t        rxChecksumErrors;
 
 } port_monitor_set_t;
 


### PR DESCRIPTION
I would prefer to have the variables in the port monitor arranged by function.  This makes it more readable and easier to add and remove additional fields by function in the future without breaking the existing structure.   This also rearranges the variables in the order as they appear in the EvalTool.