### PR TITLE
SN-5270 Fix Action Runner Log Inspector Build

### DIFF
--- a/python/logInspector/setup.py
+++ b/python/logInspector/setup.py
@@ -159,6 +159,7 @@ setup(
         'scipy', 
         'simplekml',
         'tqdm'],
+    setup_requires=['pybind11>=2.2'],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
 )

--- a/scripts/install_pybind.sh
+++ b/scripts/install_pybind.sh
@@ -2,7 +2,7 @@
 function echo_blue   { echo -e "\033[1;34m$@\033[0m"; }
 
 pushd "$(dirname "$(realpath $0)")" > /dev/null
-source ../SDK/scripts/build_test_cmake.sh
+source build_test_cmake.sh
 
 python3 -m pip install pytest pybind11
 


### PR DESCRIPTION
Fixes some GitHub Actions errors related to building Log Inspector on GitHub Action Runners related to missing pybind11 during LogInspector Package setup.

also fixes a non fatal error related having the wrong path for `scripts/build_cmake_tests.sh` in `scripts/install_pybind.sh`