### PR TITLE
SN-5245 loginspector cant open raw

### DIFF
--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -288,20 +288,14 @@ bool cISLogger::InitDevicesForWriting(std::vector<ISDevice>& devices)
 
 bool nextStreamDigit(stringstream &ss, string &str)
 {
-    char c;
-    if (!(ss >> c))	// Read delimiter
-    {
-        return false;
-    }
-
-    if (isdigit(c))
-    {	// If not delimeter, put first char/digit back
-        ss.unget();
-    }
-
     if (!getline(ss, str, '_'))
     {
-        return false;	// No more data 
+        return false;	// No data 
+    }
+
+    if (str.size() == 0 || !isdigit(str[0]))
+    {
+        return false;	// No numerical data 
     }
 
     return true;
@@ -331,15 +325,20 @@ bool cISLogger::ParseFilename(string filename, int &serialNum, string &date, str
         stringstream ss(content);
 
         // Read serial number, date, time, index
-        if (!nextStreamDigit(ss, str) && str.size()) { return false; } 	serialNum = stoi(str);
-        if (!nextStreamDigit(ss, str) && str.size()) { return false; } 	date = str;
-        if (!nextStreamDigit(ss, str) && str.size()) { return false; } 	time = str;
-        if (!nextStreamDigit(ss, str) && str.size()) { return false; } 	index = stoi(str);
+        if (!nextStreamDigit(ss, str) || str.size()==0) { return false; } 	
+        serialNum = stoi(str);
+        if (!nextStreamDigit(ss, str) || str.size()==0) { return false; } 	
+        date = str;
+        if (!nextStreamDigit(ss, str) || str.size()==0) { return false; } 	
+        time = str;
+        if (!nextStreamDigit(ss, str) || str.size()==0) { return false; } 	
+        index = stoi(str);
     }
     else
     {	// No prefix - only index number
         stringstream ss(content);
-        if (!nextStreamDigit(ss, str) && str.size()) { return false; } 	index = stoi(str);
+        if (!nextStreamDigit(ss, str) && str.size()) { return false; } 	
+        index = stoi(str);
     }
 
     return true;

--- a/tests/test_ISLogger.cpp
+++ b/tests/test_ISLogger.cpp
@@ -182,6 +182,7 @@ void TestParseFileName(string filename, int rSerialNum, string rDate, string rTi
 
 TEST(ISLogger, parse_filename)
 {
+	TestParseFileName("base_station.raw", 0, "", "", -1);
 	TestParseFileName("LOG_SN60339_20240311_132545_0000.RAW", 60339, "20240311", "132545", 0);
 	TestParseFileName("LOG_SN60339_20240311_132545_0001.RAW", 60339, "20240311", "132545", 1);
 	TestParseFileName("LOG_SN60339_20240311_132545_0002.raw", 60339, "20240311", "132545", 2);


### PR DESCRIPTION
Fixed cISLogger crash caused by reading file with no numerical characters in filename.  This prevents LogInspector from being able to open certain logs.
