### PR TITLE
SN-5281 fix ISComm function return

### DIFF
--- a/ExampleProjects/Arduino/ReadIS/ReadIS.ino
+++ b/ExampleProjects/Arduino/ReadIS/ReadIS.ino
@@ -64,7 +64,7 @@ void setup()
 
     // Ask for ins_1 message 20 times per second.  Ask for the whole thing, so
     // set 0's for the offset and size
-    messageSize = is_comm_get_data(&comm, DID_INS_1, 0, sizeof(ins_1_t), 1000);
+    messageSize = is_comm_get_data_to_buf(buffer, bufferSize, &comm, DID_INS_1, 0, sizeof(ins_1_t), 1000);
     Serial1.write(comm.rxBuf.start, messageSize); // Transmit the message to the inertialsense device
 }
 

--- a/ExampleProjects/Communications/ISCommunicationsExample.c
+++ b/ExampleProjects/Communications/ISCommunicationsExample.c
@@ -68,7 +68,7 @@ int set_configuration(serial_port_t *serialPort, is_comm_instance_t *comm)
 {
 	// Set INS output Euler rotation in radians to 90 degrees roll for mounting
 	float rotation[3] = { 90.0f*C_DEG2RAD_F, 0.0f, 0.0f };
-	if (!is_comm_set_data(portWrite, 0, comm, DID_FLASH_CONFIG, sizeof(float) * 3, offsetof(nvm_flash_cfg_t, insRotation), rotation))
+	if (is_comm_set_data(portWrite, 0, comm, DID_FLASH_CONFIG, sizeof(float) * 3, offsetof(nvm_flash_cfg_t, insRotation), rotation))
 	{
 		printf("Failed to encode and write set INS rotation\r\n");
 		return -3;
@@ -81,7 +81,7 @@ int set_configuration(serial_port_t *serialPort, is_comm_instance_t *comm)
 int stop_message_broadcasting(serial_port_t *serialPort, is_comm_instance_t *comm)
 {
 	// Stop all broadcasts on the device
-	if (!is_comm_stop_broadcasts_all_ports(portWrite, 0, comm))
+	if (is_comm_stop_broadcasts_all_ports(portWrite, 0, comm))
 	{
 		printf("Failed to encode and write stop broadcasts message\r\n");
 		return -3;
@@ -96,7 +96,7 @@ int save_persistent_messages(serial_port_t *serialPort, is_comm_instance_t *comm
 	cfg.command = SYS_CMD_SAVE_PERSISTENT_MESSAGES;
 	cfg.invCommand = ~cfg.command;
 
-	if (!is_comm_set_data(portWrite, 0, comm, DID_SYS_CMD, 0, 0, &cfg))
+	if (is_comm_set_data(portWrite, 0, comm, DID_SYS_CMD, 0, 0, &cfg))
 	{
 		printf("Failed to write save persistent message\r\n");
 		return -3;
@@ -108,7 +108,7 @@ int save_persistent_messages(serial_port_t *serialPort, is_comm_instance_t *comm
 int enable_message_broadcasting(serial_port_t *serialPort, is_comm_instance_t *comm)
 {
 	// Ask for INS message w/ update 40ms period (4ms source period x 10).  Set data rate to zero to disable broadcast and pull a single packet.
-	if (!is_comm_get_data(portWrite, 0, comm, DID_INS_1, 0, 0, 10))
+	if (is_comm_get_data(portWrite, 0, comm, DID_INS_1, 0, 0, 10))
 	{
 		printf("Failed to encode and write get INS message\r\n");
 		return -4;
@@ -116,7 +116,7 @@ int enable_message_broadcasting(serial_port_t *serialPort, is_comm_instance_t *c
 
 #if 1
 	// Ask for GPS message at period of 200ms (200ms source period x 1).  Offset and size can be left at 0 unless you want to just pull a specific field from a data set.
-	if (!is_comm_get_data(portWrite, 0, comm, DID_GPS1_POS, 0, 0, 1))
+	if (is_comm_get_data(portWrite, 0, comm, DID_GPS1_POS, 0, 0, 1))
 	{
 		printf("Failed to encode and write get GPS message\r\n");
 		return -5;
@@ -125,7 +125,7 @@ int enable_message_broadcasting(serial_port_t *serialPort, is_comm_instance_t *c
 
 #if 0
 	// Ask for IMU message at period of 100ms (1ms source period x 100).  This could be as high as 1000 times a second (period multiple of 1)
-	if (!is_comm_get_data(portWrite, 0, comm, DID_IMU, 0, 0, 100))
+	if (is_comm_get_data(portWrite, 0, comm, DID_IMU, 0, 0, 100))
 	{
 		printf("Failed to encode and write get IMU message\r\n");
 		return -6;

--- a/ExampleProjects/Communications/README.md
+++ b/ExampleProjects/Communications/README.md
@@ -76,7 +76,7 @@ This [ISCommunicationsExample](https://github.com/inertialsense/inertial-sense-s
 ```C++
 	// Set INS output Euler rotation in radians to 90 degrees roll for mounting
 	float rotation[3] = { 90.0f*C_DEG2RAD_F, 0.0f, 0.0f };
-	int messageSize = is_comm_set_data(comm, DID_FLASH_CONFIG, sizeof(float) * 3, offsetof(nvm_flash_cfg_t, insRotation), rotation);
+	int messageSize = is_comm_set_data_to_buf(comm, DID_FLASH_CONFIG, sizeof(float) * 3, offsetof(nvm_flash_cfg_t, insRotation), rotation);
 	if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 	{
 		printf("Failed to encode and write set INS rotation\r\n");
@@ -96,7 +96,7 @@ rmc.bits = RMC_BITS_INS1 | RMC_BITS_GPS_NAV;
 rmc.insPeriodMs = 50;	// INS @ 20Hz
 rmc.options = 0;		// current port
 
-int messageSize = is_comm_set_data(comm, DID_RMC, 0, 0, &rmc);
+int messageSize = is_comm_set_data_to_buf(comm, DID_RMC, 0, 0, &rmc);
 if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 {
 	printf("Failed to encode and write RMC message\r\n");
@@ -106,7 +106,7 @@ if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 
 ```C++
 	// Ask for INS message 20 times a second (period of 50 milliseconds).  Max rate is 500 times a second (2ms period).
-	int messageSize = is_comm_get_data(comm, DID_INS_1, 0, 0, 50);
+	int messageSize = is_comm_get_data_to_buf(buffer, bufferSize, comm, DID_INS_1, 0, 0, 50);
 	if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 	{
 		printf("Failed to encode and write get INS message\r\n");
@@ -114,7 +114,7 @@ if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 
 #if 1
 	// Ask for gps message 5 times a second (period of 200 milliseconds) - offset and size can be left at 0 unless you want to just pull a specific field from a data set
-	messageSize = is_comm_get_data(comm, _DID_GPS_NAV, 0, 0, 200);
+	messageSize = is_comm_get_data_to_buf(buffer, bufferSize, comm, _DID_GPS_NAV, 0, 0, 200);
 	if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 	{
 		printf("Failed to encode and write get GPS message\r\n");

--- a/ExampleProjects/NTRIP_rover/README.md
+++ b/ExampleProjects/NTRIP_rover/README.md
@@ -76,13 +76,13 @@ To use NTRIP, we must enable the DID_GPS1_POS message which will be rebroadcast 
 ```C++
 int enable_message_broadcasting(serial_port_t *serialPort, is_comm_instance_t *comm)
 {
-	int n = is_comm_get_data(comm, DID_GPS1_POS, 0, 0, 1);
+	int n = is_comm_get_data_to_buf(buffer, bufferSize, comm, DID_GPS1_POS, 0, 0, 1);
 	if (n != serialPortWrite(serialPort, comm->buf.start, n))
 	{
 		printf("Failed to encode and write get GPS message\r\n");
 		return -5;
 	}
-	n = is_comm_get_data(comm, DID_GPS1_RTK_POS_REL, 0, 0, 1);
+	n = is_comm_get_data_to_buf(buffer, bufferSize, comm, DID_GPS1_RTK_POS_REL, 0, 0, 1);
 	if (n != serialPortWrite(serialPort, comm->buf.start, n))
 	{
 		printf("Failed to encode and write get GPS message\r\n");

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1069,21 +1069,23 @@ int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is
     // Write packet to port
     int n = j = portWrite(port, (uint8_t*)&(pkt->hdr), sizeof(packet_hdr_t));  // Header
 
-    // TODO: Debug test_flash_sync, remove later (WHJ)
+#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
     if (j != sizeof(packet_hdr_t))
     {
-        printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite header: %d,%d\n", j, (int)(sizeof(packet_hdr_t)));
+        printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite header: %d,%d\n", j, (int)sizeof(packet_hdr_t));
     }
+#endif
 
     if (pkt->offset)
     {
         n += j = portWrite(port, (uint8_t*)&(pkt->offset), 2);                 // Offset (optional)
 
-        // TODO: Debug test_flash_sync, remove later (WHJ)
+#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
         if (j != 2)
         {
             printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite optional offset: %d\n", j);
         }
+#endif
 
     }
 
@@ -1094,20 +1096,22 @@ int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is
 
         n += j = portWrite(port, (uint8_t*)pkt->data.ptr, pkt->data.size);     // Payload
 
-        // TODO: Debug test_flash_sync, remove later (WHJ)
+#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
         if (j != pkt->data.size)
         {
             printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite payload: %d,%d\n", j, pkt->data.size);
         }
+#endif
 
     }
     n += j = portWrite(port, (uint8_t*)&(pkt->checksum), 2);                   // Footer (checksum)
 
-    // TODO: Debug test_flash_sync, remove later (WHJ)
+#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
     if (j != 2)
     {
         printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite footer: %d\n", j);
     }
+#endif
 
     // Increment Tx count
     comm->txPktCount++;

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1018,10 +1018,6 @@ void is_comm_encode_hdr(packet_t *pkt, uint8_t flags, uint16_t did, uint16_t dat
     }
 }
 
-/**
- * Writes ISB header, payload, and Checksum to given buffer
- * Returns number of bytes written
- */ 
 int is_comm_write_isb_precomp_to_buffer(uint8_t *buf, uint32_t buf_size, is_comm_instance_t* comm, packet_t *pkt)
 {
     if (pkt->size > buf_size)
@@ -1054,39 +1050,17 @@ int is_comm_write_isb_precomp_to_buffer(uint8_t *buf, uint32_t buf_size, is_comm
     return pkt->size;
 }
 
-/**
- * Writes ISB header, payload, and Checksum to given port
- * Returns number of bytes written
- */ 
 int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *pkt)
 {
-    // TODO: Debug test_flash_sync, remove later (WHJ)
-    int j;
-
     // Set checksum using precomputed header checksum
     pkt->checksum = pkt->hdrCksum;
 
     // Write packet to port
-    int n = j = portWrite(port, (uint8_t*)&(pkt->hdr), sizeof(packet_hdr_t));  // Header
-
-#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
-    if (j != sizeof(packet_hdr_t))
-    {
-        printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite header: %d,%d\n", j, (int)sizeof(packet_hdr_t));
-    }
-#endif
+    int n = portWrite(port, (uint8_t*)&(pkt->hdr), sizeof(packet_hdr_t));  // Header
 
     if (pkt->offset)
     {
-        n += j = portWrite(port, (uint8_t*)&(pkt->offset), 2);                 // Offset (optional)
-
-#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
-        if (j != 2)
-        {
-            printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite optional offset: %d,2\n", j);
-        }
-#endif
-
+        n += portWrite(port, (uint8_t*)&(pkt->offset), 2);                 // Offset (optional)
     }
 
     if (pkt->data.size)
@@ -1094,29 +1068,16 @@ int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is
         // Include payload in checksum calculation
         pkt->checksum = is_comm_isb_checksum16(pkt->checksum, (uint8_t*)pkt->data.ptr, pkt->data.size);
 
-        n += j = portWrite(port, (uint8_t*)pkt->data.ptr, pkt->data.size);     // Payload
-
-#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
-        if (j != (int)(pkt->data.size))
-        {
-            printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite payload: %d,%d\n", j, pkt->data.size);
-        }
-#endif
-
+        n += portWrite(port, (uint8_t*)pkt->data.ptr, pkt->data.size);     // Payload
     }
-    n += j = portWrite(port, (uint8_t*)&(pkt->checksum), 2);                   // Footer (checksum)
 
-#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
-    if (j != 2)
-    {
-        printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite footer: %d,2\n", j);
-    }
-#endif
+    n += portWrite(port, (uint8_t*)&(pkt->checksum), 2);                   // Footer (checksum)
 
     // Increment Tx count
     comm->txPktCount++;
 
-    return n;
+    // Check that number of bytes sent matches packet size.  Return 0 on success, -1 on failure.
+    return (n == pkt->size) ? 0 : -1;
 }
 
 int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data)
@@ -1126,7 +1087,7 @@ int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* co
     // Encode header and header checksum
     is_comm_encode_hdr(&txPkt, flags, did, data_size, offset, data);
 
-    // Update checksum and write packet to buffer
+    // Update checksum and write packet to buffer.  Returns packet length in bytes.
     return is_comm_write_isb_precomp_to_buffer(buf, buf_size, comm, &txPkt);
 }
 
@@ -1142,11 +1103,8 @@ int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* co
     // Encode header and header checksum
     is_comm_encode_hdr(&txPkt, flags, did, data_size, offset, data);
 
-    // Update checksum and write packet to port
-    int n = is_comm_write_isb_precomp_to_port(portWrite, port, comm, &txPkt);
-
-    // Check that number of bytes sent matches packet size
-    return (n == txPkt.size) ? n : -1;
+    // Update checksum and write packet to port.  Returns 0 on success, -1 of failure.
+    return is_comm_write_isb_precomp_to_port(portWrite, port, comm, &txPkt);
 }
 
 int is_comm_set_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
@@ -1156,7 +1114,7 @@ int is_comm_set_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t*
 
 int is_comm_set_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
 {
-    return (portWrite) ? is_comm_write(portWrite, port, comm, PKT_TYPE_SET_DATA, did, size, offset, data) : -1;
+    return is_comm_write(portWrite, port, comm, PKT_TYPE_SET_DATA, did, size, offset, data);
 }    
 
 int is_comm_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
@@ -1166,17 +1124,17 @@ int is_comm_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* com
 
 int is_comm_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
 {
-    return (portWrite) ? is_comm_write(portWrite, port, comm, PKT_TYPE_DATA, did, size, offset, data) : -1;
+    return is_comm_write(portWrite, port, comm, PKT_TYPE_DATA, did, size, offset, data);
 }    
 
 int is_comm_stop_broadcasts_all_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm)
 {
-    return (portWrite) ? is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_ALL_PORTS, 0, 0, 0, NULL) : -1;
+    return is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_ALL_PORTS, 0, 0, 0, NULL);
 }
 
 int is_comm_stop_broadcasts_current_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm)
 {
-    return (portWrite) ? is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_CURRENT_PORT, 0, 0, 0, NULL) : -1;
+    return is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_CURRENT_PORT, 0, 0, 0, NULL);
 }
 
 char copyStructPToDataP(p_data_t *data, const void *sptr, const unsigned int maxsize)

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1097,7 +1097,7 @@ int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is
         n += j = portWrite(port, (uint8_t*)pkt->data.ptr, pkt->data.size);     // Payload
 
 #if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
-        if (j != pkt->data.size)
+        if (j != (int)(pkt->data.size))
         {
             printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite payload: %d,%d\n", j, pkt->data.size);
         }

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1083,7 +1083,7 @@ int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is
 #if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
         if (j != 2)
         {
-            printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite optional offset: %d\n", j);
+            printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite optional offset: %d,2\n", j);
         }
 #endif
 
@@ -1109,7 +1109,7 @@ int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is
 #if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
     if (j != 2)
     {
-        printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite footer: %d\n", j);
+        printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite footer: %d,2\n", j);
     }
 #endif
 

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1132,13 +1132,21 @@ int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* co
 
 int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data)
 {
+    if (portWrite == NULL)
+    {
+        return -1;
+    }
+
     packet_t txPkt;
 
     // Encode header and header checksum
     is_comm_encode_hdr(&txPkt, flags, did, data_size, offset, data);
 
     // Update checksum and write packet to port
-    return (portWrite) ? is_comm_write_isb_precomp_to_port(portWrite, port, comm, &txPkt) : -1;
+    int n = is_comm_write_isb_precomp_to_port(portWrite, port, comm, &txPkt);
+
+    // Check that number of bytes sent matches packet size
+    return (n == txPkt.size) ? n : -1;
 }
 
 int is_comm_set_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1069,23 +1069,21 @@ int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is
     // Write packet to port
     int n = j = portWrite(port, (uint8_t*)&(pkt->hdr), sizeof(packet_hdr_t));  // Header
 
-#ifdef IS_CI_HDW    // TODO: Debug test_flash_sync, remove later (WHJ)
+    // TODO: Debug test_flash_sync, remove later (WHJ)
     if (j != sizeof(packet_hdr_t))
     {
-        printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite header: %d,%d\n", j, sizeof(packet_hdr_t));
+        printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite header: %d,%d\n", j, (int)(sizeof(packet_hdr_t)));
     }
-#endif
 
     if (pkt->offset)
     {
         n += j = portWrite(port, (uint8_t*)&(pkt->offset), 2);                 // Offset (optional)
 
-#ifdef IS_CI_HDW    // TODO: Debug test_flash_sync, remove later (WHJ)
+        // TODO: Debug test_flash_sync, remove later (WHJ)
         if (j != 2)
         {
             printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite optional offset: %d\n", j);
         }
-#endif
 
     }
 
@@ -1096,22 +1094,20 @@ int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is
 
         n += j = portWrite(port, (uint8_t*)pkt->data.ptr, pkt->data.size);     // Payload
 
-#ifdef IS_CI_HDW    // TODO: Debug test_flash_sync, remove later (WHJ)
+        // TODO: Debug test_flash_sync, remove later (WHJ)
         if (j != pkt->data.size)
         {
             printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite payload: %d,%d\n", j, pkt->data.size);
         }
-#endif
 
     }
     n += j = portWrite(port, (uint8_t*)&(pkt->checksum), 2);                   // Footer (checksum)
 
-#ifdef IS_CI_HDW    // TODO: Debug test_flash_sync, remove later (WHJ)
+    // TODO: Debug test_flash_sync, remove later (WHJ)
     if (j != 2)
     {
         printf("ISComm.c::is_comm_write_isb_precomp_to_port() failed to portWrite footer: %d\n", j);
     }
-#endif
 
     // Increment Tx count
     comm->txPktCount++;

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -717,65 +717,76 @@ static inline protocol_type_t is_comm_parse(is_comm_instance_t* instance)
 }
 
 /**
-* Removed old data and shift unparsed data to the the buffer start if running out of space at the buffer end.  Returns number of bytes available in the bufer.
-* @param instance the comm instance passed to is_comm_init
-* @return the number of bytes available in the comm buffer 
-*/
+ * Removed old data and shift unparsed data to the the buffer start if running out of space at the buffer end.  Returns number of bytes available in the bufer.
+ * @param instance the comm instance passed to is_comm_init
+ * @return the number of bytes available in the comm buffer 
+ */
 int is_comm_free(is_comm_instance_t* instance);
 
 /**
-* Encode a binary packet to get data from the device - puts the data ready to send into the buffer passed into is_comm_init
-* @param instance the comm instance passed to is_comm_init
-* @param dataId the data id to request (see DID_* at top of this file)
-* @param offset the offset into data to request. Set offset and length to 0 for entire data structure.
-* @param length the length into data from offset to request. Set offset and length to 0 for entire data structure.
-* @param periodMultiple how often you want the data to stream out, 0 for a one time message and turn off.
-* @return the number of bytes written to the comm buffer (from is_comm_init), will be less than 1 if error
-* @remarks pass an offset and length of 0 to request the entire data structure
-*/
+ * @brief Encode a binary packet to get data from the device - puts the data ready to send into the buffer passed into is_comm_init
+ * @param instance the comm instance passed to is_comm_init
+ * @param dataId the data id to request (see DID_* at top of this file)
+ * @param offset the offset into data to request. Set offset and length to 0 for entire data structure.
+ * @param length the length into data from offset to request. Set offset and length to 0 for entire data structure.
+ * @param periodMultiple how often you want the data to stream out, 0 for a one time message and turn off.
+ * @return int Number of bytes written to the comm buffer or less than 1 if error
+ * @remarks pass an offset and length of 0 to request the entire data structure
+ */
 int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t* comm, uint32_t did, uint32_t offset, uint32_t size, uint32_t periodMultiple);
-int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint32_t did, uint32_t offset, uint32_t size, uint32_t periodMultiple);
-
-// /**
-// * Encode a binary packet to get predefined list of data sets from the device - puts the data ready to send into the buffer passed into is_comm_init
-// * @param comm the comm instance passed to is_comm_init
-// * @param RMC bits specifying data messages to stream.  See presets: RMC_PRESET_PPD_BITS = post processing data, RMC_PRESET_INS_BITS = INS2 and GPS data at full rate
-// * @return the number of bytes written to the comm buffer (from is_comm_init), will be less than 1 if error
-// * @remarks pass an offset and length of 0 to request the entire data structure
-// */
-// int is_comm_get_data_rmc(is_comm_instance_t* instance, uint64_t rmcBits);
 
 /**
-* Encode a binary packet to set data on the device - puts the data ready to send into the buffer passed into is_comm_init.  An acknowledge packet is sent in response to this packet.
-* @param comm the comm instance passed to is_comm_init
-* @param did the data id to set on the device (see DID_* at top of this file)
-* @param size the number of bytes to set on the data structure on the device
-* @param offset the offset to start setting data at on the data structure on the device
-* @param data the actual data to change on the data structure on the device - this should have at least size bytes available
-* @return the number of bytes written to the comm buffer (from is_comm_init), will be less than 1 if error
-* @remarks pass an offset and length of 0 to set the entire data structure, in which case data needs to have the full number of bytes available for the appropriate struct matching the dataId parameter.
-*/
+ * @brief Same as is_comm_get_data_to_buf() except for writing packet to serial port and return value.
+ * @param portWrite Call back function for serial port write
+ * @param port Port number for serial port
+ * @return int 0 on success, -1 on failure
+ */
+int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint32_t did, uint32_t offset, uint32_t size, uint32_t periodMultiple);
+
+/**
+ * @brief Encode a binary packet to set data on the device - puts the data ready to send into the buffer passed into is_comm_init.  An acknowledge packet is sent in response to this packet.
+ * @param buf Buffer to write to.
+ * @param buf_size Available size of buffer.
+ * @param comm the ISComm instance. 
+ * @param did the data id to set on the device (see DID_* at top of this file)
+ * @param size the number of bytes to set on the data structure on the device
+ * @param offset the offset to start setting data at on the data structure on the device
+ * @param data the actual data to change on the data structure on the device - this should have at least size bytes available
+ * @return int Number of bytes written to the comm buffer or less than 1 if error
+ * @remarks pass an offset and length of 0 to set the entire data structure, in which case data needs to have the full number of bytes available for the appropriate struct matching the dataId parameter.
+ */
 int is_comm_set_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data);
+
+/**
+ * @brief Same as is_comm_set_data_to_buf() except for writing packet to serial port and return value.
+ * @param portWrite Call back function for serial port write
+ * @param port Port number for serial port
+ * @return int 0 on success, -1 on failure
+ */
 int is_comm_set_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data);
 
 /**
-* Same as is_comm_set_data() except NO acknowledge packet is sent in response to this packet.
-*/
+ * Same as is_comm_set_data_buf() except NO acknowledge packet is sent in response to this packet.
+ */
 int is_comm_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data);
+
+/**
+ * Same as is_comm_set_data() except NO acknowledge packet is sent in response to this packet.
+ */
 int is_comm_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data);
 
 /**
-* Encode a binary packet to stop all messages being broadcast on the device on all ports
-* @param comm the comm instance passed to is_comm_init
-* @return 0 if success, otherwise an error code
-*/
+ * Encode a binary packet to stop all messages being broadcast on the device on all ports
+ * @param comm the comm instance passed to is_comm_init
+ * @return 0 if success, otherwise an error code
+ */
 int is_comm_stop_broadcasts_all_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm);
 
 /**
-* Encode a binary packet to stop all messages being broadcast on the device on this port
-* @param comm the comm instance passed to is_comm_init
-* @return 0 if success, otherwise an error code
-*/
+ * Encode a binary packet to stop all messages being broadcast on the device on this port
+ * @param comm the comm instance passed to is_comm_init
+ * @return 0 if success, otherwise an error code
+ */
 int is_comm_stop_broadcasts_current_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm);
 
 /**
@@ -806,7 +817,7 @@ uint16_t is_comm_xor16(uint16_t cksum_init, const void* data, uint32_t size);
 // -------------------------------------------------------------------------------------------------------------------------------
 
 /**
- * @brief Encode ISB InertialSense binary (ISB) packet header.
+ * @brief Encode InertialSense binary (ISB) packet header.
  * 
  * @param pkt Packet storage location.
  * @param flags ISB packet flags which includes the packet type (see eISBPacketFlags).
@@ -816,24 +827,46 @@ uint16_t is_comm_xor16(uint16_t cksum_init, const void* data, uint32_t size);
  * @param data Pointer to payload data.
  */
 void is_comm_encode_hdr(packet_t *pkt, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
-// Returns number of bytes written
-int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *pkt);
 
+/**
+ * @brief Updates the checksum for a precomputed InertialSense binary (ISB) packet and writes it to the specified serial port.
+ * 
+ * @param portWrite Callback function for serial port write
+ * @param port Port number for serial port
+ * @param comm IS comm instance used to increment Tx packet counter statistic
+ * @param pkt Pointer to precomputed ISB packet
+ * @return int 0 on success, -1 on failure
+ */
+int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *pkt);
 
 /**
  * @brief Generate InertialSense binary (ISB) packet.
  * 
  * @param buf Buffer to write to.
  * @param buf_size Available size of buffer.
+ * @param comm ISComm instance
+ * @param flags ISB packet flags which includes the packet type (see eISBPacketFlags).
+ * @param did ISB data ID
+ * @param data_size Size in bytes of the payload data.
+ * @param offset Offset of the payload data into the data set structure.
+ * @param data Pointer to payload data.
+ * @return int Number of bytes written into buffer 
+ */
+int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
+
+/**
+ * @brief Generate InertialSense binary (ISB) packet.
+ * 
+ * @param portWrite Serial port callback function used send packet.
+ * @param port Serial port number packet will be written to.
  * @param comm ISComm instance.
  * @param flags ISB packet flags which includes the packet type (see eISBPacketFlags).
  * @param did ISB data ID
  * @param data_size Size in bytes of the payload data.
  * @param offset Offset of the payload data into the data set structure.
  * @param data Pointer to payload data.
- * @return number of bytes written 
+ * @return int 0 on success, -1 of failure 
  */
-int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
 int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
 
 unsigned int calculate24BitCRCQ(unsigned char* buffer, unsigned int len);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -870,7 +870,14 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
             int size = tail-head;
             int offset = head-((uint8_t*)newCfg);
             DEBUG_PRINT("Sending DID_FLASH_CONFIG: size %d, offset %d\n", size, offset);
-            failure = failure || comManagerSendData(pHandle, head, DID_FLASH_CONFIG, size, offset);
+            int fail = comManagerSendData(pHandle, head, DID_FLASH_CONFIG, size, offset);
+            // TODO: Debug test_flash_sync, remove later (WHJ)
+            if (fail != 0)
+            {
+                printf("InertialSense::SetFlashConfig() failed to send flash config using comManagerSendData(): port %d, size %d, offset %d\n", pHandle, size, offset);
+                printf("  buf %p, head %p, tail %p\n", (void*)&(newCfg), (void*)head, (void*)tail);
+            }
+            failure = failure || fail;
             device.flashCfgUploadTimeMs = current_timeMs();						// non-zero indicates upload in progress
         }
     }
@@ -892,12 +899,6 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
 
     // Update local copy of flash config
     device.flashCfg = flashCfg;
-
-    // TODO: Debug test_flash_sync, remove later (WHJ)
-    if (failure)
-    {
-        printf("InertialSense::SetFlashConfig() failed to send flash config!\n");
-    }
 
     // Success
     return !failure;

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -844,8 +844,9 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
 {
     if ((size_t)pHandle >= m_comManagerState.devices.size())
     {
-        // TODO: Debug test_flash_sync, remove later (WHJ)
+#ifdef IS_CI_HDW    // TODO: Debug test_flash_sync, remove later (WHJ)
         printf("InertialSense::SetFlashConfig() no devices present.\n");
+#endif
         return 0;
     }
     ISDevice& device = m_comManagerState.devices[pHandle];
@@ -871,12 +872,13 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
             int offset = head-((uint8_t*)newCfg);
             DEBUG_PRINT("Sending DID_FLASH_CONFIG: size %d, offset %d\n", size, offset);
             int fail = comManagerSendData(pHandle, head, DID_FLASH_CONFIG, size, offset);
-            // TODO: Debug test_flash_sync, remove later (WHJ)
+#ifdef IS_CI_HDW    // TODO: Debug test_flash_sync, remove later (WHJ)
             if (fail != 0)
             {
                 printf("InertialSense::SetFlashConfig() failed to send flash config using comManagerSendData(): port %d, size %d, offset %d\n", pHandle, size, offset);
                 printf("  buf %p, head %p, tail %p\n", (void*)&(newCfg), (void*)head, (void*)tail);
             }
+#endif
             failure = failure || fail;
             device.flashCfgUploadTimeMs = current_timeMs();						// non-zero indicates upload in progress
         }

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -917,10 +917,10 @@ bool InertialSense::WaitForFlashSynced(int pHandle)
 
         if (current_timeMs() - startMs > 3000)
         {   // Timeout waiting for flash config
-            printf("Failed to read DID_FLASH_CONFIG!\n");
+            printf("Timeout waiting for DID_FLASH_CONFIG failure!\n");
 
             #if PRINT_DEBUG
-            is_device_t &device = m_comManagerState.devices[pHandle]; 
+            ISDevice& device = m_comManagerState.devices[pHandle];
             DEBUG_PRINT("device.flashCfg.checksum:          %u\n", device.flashCfg.checksum);
             DEBUG_PRINT("device.sysParams.flashCfgChecksum: %u\n", device.sysParams.flashCfgChecksum); 
             DEBUG_PRINT("device.flashCfgUploadTimeMs:       %u\n", device.flashCfgUploadTimeMs);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -844,9 +844,9 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
 {
     if ((size_t)pHandle >= m_comManagerState.devices.size())
     {
-#ifdef IS_CI_HDW    // TODO: Debug test_flash_sync, remove later (WHJ)
+        // TODO: Debug test_flash_sync, remove later (WHJ)
         printf("InertialSense::SetFlashConfig() no devices present.\n");
-#endif
+
         return 0;
     }
     ISDevice& device = m_comManagerState.devices[pHandle];
@@ -872,13 +872,14 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
             int offset = head-((uint8_t*)newCfg);
             DEBUG_PRINT("Sending DID_FLASH_CONFIG: size %d, offset %d\n", size, offset);
             int fail = comManagerSendData(pHandle, head, DID_FLASH_CONFIG, size, offset);
-#ifdef IS_CI_HDW    // TODO: Debug test_flash_sync, remove later (WHJ)
+            
+            // TODO: Debug test_flash_sync, remove later (WHJ)
             if (fail != 0)
             {
                 printf("InertialSense::SetFlashConfig() failed to send flash config using comManagerSendData(): port %d, size %d, offset %d\n", pHandle, size, offset);
                 printf("  buf %p, head %p, tail %p\n", (void*)&(newCfg), (void*)head, (void*)tail);
             }
-#endif
+
             failure = failure || fail;
             device.flashCfgUploadTimeMs = current_timeMs();						// non-zero indicates upload in progress
         }

--- a/src/com_manager.c
+++ b/src/com_manager.c
@@ -560,7 +560,7 @@ int comManagerSend(int pHandle, uint8_t pFlags, void* data, uint16_t did, uint16
 int comManagerSendInstance(CMHANDLE cmInstance, int port, uint8_t pFlags, void *data, uint16_t did, uint16_t size, uint16_t offset)
 {
     com_manager_t *cm = (com_manager_t*)cmInstance;
-    return (is_comm_write(cm->portWrite, port, &(cm->ports[port].comm), pFlags, did, size, offset, data) ? 0 : -1);
+    return is_comm_write(cm->portWrite, port, &(cm->ports[port].comm), pFlags, did, size, offset, data);
 }
 
 int findAsciiMessage(const void * a, const void * b)
@@ -981,7 +981,7 @@ void disableDidBroadcast(com_manager_t* cmInstance, int pHandle, uint16_t did)
 // Consolidate this with sendPacket() so that we break up packets into multiples that fit our buffer size.  Returns 0 on success, -1 on failure.
 int sendDataPacket(com_manager_t* cm, int port, packet_t* pkt)
 {
-    return (is_comm_write_isb_precomp_to_port(cm->portWrite, port, &(cm->ports[port].comm), pkt) ? 0 : -1);
+    return is_comm_write_isb_precomp_to_port(cm->portWrite, port, &(cm->ports[port].comm), pkt);
 }
 
 void sendAck(com_manager_t* cmInstance, int pHandle, packet_t *pkt, uint8_t pTypeFlags)

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -751,7 +751,8 @@ static int serialPortWritePlatform(serial_port_t* serialPort, const unsigned cha
     if (count < 0)
     {
         if ((errno != EAGAIN) && (errno != EWOULDBLOCK)) {
-            // error_message("[%s] error %d: %s\n", serialPort->port, errno, strerror(errno));
+            // TODO: Debug test_flash_sync, comment out later (WHJ)
+            error_message("[%s] error %d: %s\n", serialPort->port, errno, strerror(errno));
             serialPort->errorCode = errno;
         }
         return 0;


### PR DESCRIPTION
Address issue in ISComm where the return value needs to be different for the following functions:

- **is_comm_write()** and related functions that writes directly to the serial port should.  These should return success or failure because the results are not recoverable as multiple serial port writes occure. 
- **is_comm_write_to_buf()** and related functions that write into a buffer should return the number of bytes written into the buffer so that the caller can properly send the message. 