### PR TITLE
Match convention of size and offset parameter order

### DIFF
--- a/ExampleProjects/Arduino/ReadIS/ReadIS.ino
+++ b/ExampleProjects/Arduino/ReadIS/ReadIS.ino
@@ -64,7 +64,7 @@ void setup()
 
     // Ask for ins_1 message 20 times per second.  Ask for the whole thing, so
     // set 0's for the offset and size
-    messageSize = is_comm_get_data_to_buf(buffer, bufferSize, &comm, DID_INS_1, 0, sizeof(ins_1_t), 1000);
+    messageSize = is_comm_get_data_to_buf(buffer, bufferSize, &comm, DID_INS_1, sizeof(ins_1_t), 0, 1000);
     Serial1.write(comm.rxBuf.start, messageSize); // Transmit the message to the inertialsense device
 }
 

--- a/ExampleProjects/Communications/README.md
+++ b/ExampleProjects/Communications/README.md
@@ -113,7 +113,7 @@ if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 	}
 
 #if 1
-	// Ask for gps message 5 times a second (period of 200 milliseconds) - offset and size can be left at 0 unless you want to just pull a specific field from a data set
+	// Ask for gps message 5 times a second (period of 200 milliseconds) - size and offset can be left at 0 unless you want to just pull a specific field from a data set
 	messageSize = is_comm_get_data_to_buf(buffer, bufferSize, comm, _DID_GPS_NAV, 0, 0, 200);
 	if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 	{

--- a/ExampleProjects/Communications/setup_debug.sh
+++ b/ExampleProjects/Communications/setup_debug.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+pushd "$(dirname "$(realpath $0)")" > /dev/null
+
+mkdir -p build
+rm -rf build/*
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make -j 7
+
+popd > /dev/null

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -967,7 +967,7 @@ protocol_type_t is_comm_parse_timeout(is_comm_instance_t* c, uint32_t timeMs)
     return _PTYPE_NONE;
 }
 
-int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t* comm, uint32_t did, uint32_t offset, uint32_t size, uint32_t periodMultiple)
+int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t* comm, uint32_t did, uint32_t size, uint32_t offset, uint32_t periodMultiple)
 {
     p_data_get_t get;
 
@@ -979,7 +979,7 @@ int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t*
     return is_comm_write_to_buf(buf, buf_size, comm, PKT_TYPE_GET_DATA, 0, sizeof(p_data_get_t), 0, &get);
 }
 
-int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint32_t did, uint32_t offset, uint32_t size, uint32_t periodMultiple)
+int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint32_t did, uint32_t size, uint32_t offset, uint32_t periodMultiple)
 {
     p_data_get_t get;
 

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -727,20 +727,20 @@ int is_comm_free(is_comm_instance_t* instance);
  * @brief Encode a binary packet to get data from the device - puts the data ready to send into the buffer passed into is_comm_init
  * @param instance the comm instance passed to is_comm_init
  * @param dataId the data id to request (see DID_* at top of this file)
+ * @param size the length into data from offset to request. Set size and offset to 0 to request entire data structure.
  * @param offset the offset into data to request. Set offset and length to 0 for entire data structure.
- * @param length the length into data from offset to request. Set offset and length to 0 for entire data structure.
  * @param periodMultiple how often you want the data to stream out, 0 for a one time message and turn off.
  * @return int Number of bytes written on success or -1 on failure
  * @remarks pass an offset and length of 0 to request the entire data structure
  */
-int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t* comm, uint32_t did, uint32_t offset, uint32_t size, uint32_t periodMultiple);
+int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t* comm, uint32_t did, uint32_t size, uint32_t offset, uint32_t periodMultiple);
 
 /**
  * @brief Same as is_comm_get_data_to_buf() except for writing packet to serial port.
  * @param portWrite Call back function for serial port write
  * @param port Port number for serial port
  */
-int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint32_t did, uint32_t offset, uint32_t size, uint32_t periodMultiple);
+int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint32_t did, uint32_t size, uint32_t offset, uint32_t periodMultiple);
 
 /**
  * @brief Encode a binary packet to set data on the device - puts the data ready to send into the buffer passed into is_comm_init.  An acknowledge packet is sent in response to this packet.

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1999,6 +1999,7 @@ typedef struct PACKED
 
     /** NMEA period multiple of above ISB period multiple indexed by NMEA_MSG_ID... */
     uint8_t                 nmeaPeriod[NMEA_MSG_ID_COUNT];
+
 }rmcNmea_t;
 
 /** Realtime message controller internal (RMCI). */

--- a/tests/test_ISComm.cpp
+++ b/tests/test_ISComm.cpp
@@ -1046,7 +1046,7 @@ TEST(ISComm, IsCommGetDataTest)
 	int period = 3;
 
 	// Generate packet
-	int n = is_comm_get_data(portWrite, 0, &g_comm, did, offset, size, period);
+	int n = is_comm_get_data(portWrite, 0, &g_comm, did, size, offset, period);
 
 	// Reset buffer if needed
 	is_comm_free(&g_comm);


### PR DESCRIPTION
This PR matches the parameter order of size and offset in functions is_comm_get_data() and is_comm_get_data_to_buf().

In the release 2.x, similar functions were refactored to have consistent parameter order of did, size, offset.  These less commonly used functions were overlooked.