### PR TITLE
SN-3376 sensonor lambda support for TBED-3

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1119,48 +1119,24 @@ int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* co
 
 int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data)
 {
+    packet_t txPkt;
+
+    // Encode header and header checksum.  Update checksum and write packet to buffer.  Returns number of bytes written on success or -1 on failure.
+    return is_comm_write_pkt(portWrite, port, comm, &txPkt, flags, did, data_size, offset, data);
+}
+
+int is_comm_write_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *txPkt, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data)
+{
     if (portWrite == NULL)
     {
         return -1;
     }
 
-    packet_t txPkt;
-
     // Encode header and header checksum
-    is_comm_encode_hdr(&txPkt, flags, did, data_size, offset, data);
+    is_comm_encode_hdr(txPkt, flags, did, data_size, offset, data);
 
     // Update checksum and write packet to port.  Returns number of bytes written on success or -1 on failure.
-    return is_comm_write_isb_precomp_to_port(portWrite, port, comm, &txPkt);
-}
-
-int is_comm_set_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
-{
-    return is_comm_write_to_buf(buf, buf_size, comm, PKT_TYPE_SET_DATA, did, size, offset, data);    
-}    
-
-int is_comm_set_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
-{
-    return is_comm_write(portWrite, port, comm, PKT_TYPE_SET_DATA, did, size, offset, data);
-}    
-
-int is_comm_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
-{
-    return is_comm_write_to_buf(buf, buf_size, comm, PKT_TYPE_DATA, did, size, offset, data);    
-}    
-
-int is_comm_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
-{
-    return is_comm_write(portWrite, port, comm, PKT_TYPE_DATA, did, size, offset, data);
-}    
-
-int is_comm_stop_broadcasts_all_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm)
-{
-    return is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_ALL_PORTS, 0, 0, 0, NULL);
-}
-
-int is_comm_stop_broadcasts_current_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm)
-{
-    return is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_CURRENT_PORT, 0, 0, 0, NULL);
+    return is_comm_write_isb_precomp_to_port(portWrite, port, comm, txPkt);
 }
 
 char copyStructPToDataP(p_data_t *data, const void *sptr, const unsigned int maxsize)

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -717,6 +717,33 @@ static inline protocol_type_t is_comm_parse(is_comm_instance_t* instance)
 }
 
 /**
+ * @brief Generate InertialSense binary (ISB) packet.
+ * @param buf Buffer to write to.
+ * @param buf_size Available size of buffer.
+ * @param comm ISComm instance
+ * @param flags ISB packet flags which includes the packet type (see eISBPacketFlags).
+ * @param did ISB data ID
+ * @param data_size Size in bytes of the payload data.
+ * @param offset Offset of the payload data into the data set structure.
+ * @param data Pointer to payload data.
+ * @return int Number of bytes written on success or -1 on failure
+ */
+int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
+
+/**
+ * @brief Same as is_comm_write_to_buf() except for writing packet to serial port.
+ * @param portWrite Serial port callback function used send packet.
+ * @param port Serial port number packet will be written to.
+ */
+int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
+
+/**
+ * @brief Same as is_comm_write() except passing in pointer to Tx packet structure.  
+ * @param txPkt Pointer to packet_t structure used to organize message sent.
+ */
+int is_comm_write_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *txPkt, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
+
+/**
  * Removed old data and shift unparsed data to the the buffer start if running out of space at the buffer end.  Returns number of bytes available in the bufer.
  * @param instance the comm instance passed to is_comm_init
  * @return the number of bytes available in the comm buffer 
@@ -754,38 +781,65 @@ int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t*
  * @return int Number of bytes written on success or -1 on failure
  * @remarks pass an offset and length of 0 to set the entire data structure, in which case data needs to have the full number of bytes available for the appropriate struct matching the dataId parameter.
  */
-int is_comm_set_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data);
+static inline int is_comm_set_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
+{
+    return is_comm_write_to_buf(buf, buf_size, comm, PKT_TYPE_SET_DATA, did, size, offset, data);    
+}    
 
 /**
  * @brief Same as is_comm_set_data_to_buf() except for writing packet to serial port.
  * @param portWrite Call back function for serial port write
  * @param port Port number for serial port
  */
-int is_comm_set_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data);
+static inline int is_comm_set_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
+{
+    return is_comm_write(portWrite, port, comm, PKT_TYPE_SET_DATA, did, size, offset, data);
+}    
 
 /**
  * Same as is_comm_set_data_buf() except NO acknowledge packet is sent in response to this packet.
  */
-int is_comm_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data);
+static inline int is_comm_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
+{
+    return is_comm_write_to_buf(buf, buf_size, comm, PKT_TYPE_DATA, did, size, offset, data);    
+}    
 
 /**
  * Same as is_comm_set_data() except NO acknowledge packet is sent in response to this packet.
  */
-int is_comm_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data);
+static inline int is_comm_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
+{
+    return is_comm_write(portWrite, port, comm, PKT_TYPE_DATA, did, size, offset, data);
+}    
+
+/**
+ * @brief Same as is_comm_data() except passing in pointer to Tx packet structure.  
+ * @param txPkt Pointer to packet_t structure used to organize message sent.
+ */
+static inline int is_comm_data_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *txPkt, uint16_t did, uint16_t size, uint16_t offset, void* data)
+{
+    return is_comm_write_pkt(portWrite, port, comm, txPkt, PKT_TYPE_DATA, did, size, offset, data);
+}    
 
 /**
  * Encode a binary packet to stop all messages being broadcast on the device on all ports
  * @param comm the comm instance passed to is_comm_init
  * @return 0 if success, otherwise an error code
  */
-int is_comm_stop_broadcasts_all_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm);
+static inline int is_comm_stop_broadcasts_all_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm)
+{
+    return is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_ALL_PORTS, 0, 0, 0, NULL);
+}
 
 /**
  * Encode a binary packet to stop all messages being broadcast on the device on this port
  * @param comm the comm instance passed to is_comm_init
  * @return 0 if success, otherwise an error code
  */
-int is_comm_stop_broadcasts_current_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm);
+static inline int is_comm_stop_broadcasts_current_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm)
+{
+    return is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_CURRENT_PORT, 0, 0, 0, NULL);
+}
 
 /**
  * @brief Compute the fletcher 16 bit checksum for the given data array.
@@ -833,27 +887,6 @@ void is_comm_encode_hdr(packet_t *pkt, uint8_t flags, uint16_t did, uint16_t dat
  * @return int Number of bytes written on success or -1 on failure
  */
 int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *pkt);
-
-/**
- * @brief Generate InertialSense binary (ISB) packet.
- * @param buf Buffer to write to.
- * @param buf_size Available size of buffer.
- * @param comm ISComm instance
- * @param flags ISB packet flags which includes the packet type (see eISBPacketFlags).
- * @param did ISB data ID
- * @param data_size Size in bytes of the payload data.
- * @param offset Offset of the payload data into the data set structure.
- * @param data Pointer to payload data.
- * @return int Number of bytes written on success or -1 on failure
- */
-int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
-
-/**
- * @brief Same as is_comm_write_to_buf() except for writing packet to serial port.
- * @param portWrite Serial port callback function used send packet.
- * @param port Serial port number packet will be written to.
- */
-int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
 
 unsigned int calculate24BitCRCQ(unsigned char* buffer, unsigned int len);
 unsigned int getBitsAsUInt32(const unsigned char* buffer, unsigned int pos, unsigned int len);


### PR DESCRIPTION
Support for reference IMU use with Lambda and TBED-3.
Added is_comm_data_pkt() to ISComm as a way to access the packet_t used for sending data without having to copy into a buffer.   
Move simple function calls to static inline in ISComm.h