### PR TITLE
SN-5328 bit not working

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1135,26 +1135,8 @@ int is_comm_write_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t
     // Encode header and header checksum
     is_comm_encode_hdr(txPkt, flags, did, data_size, offset, data);
 
-#if 0   // Send packet in pieces to reduce buffer and memcpy
     // Update checksum and write packet to port.  Returns number of bytes written on success or -1 on failure.
     return is_comm_write_isb_precomp_to_port(portWrite, port, comm, txPkt);
-
-#else   // Buffer and send entire packet
-    uint8_t buf[PKT_BUF_SIZE];
-
-    // Update checksum and write packet to buffer.  Returns number of bytes written on success or -1 on failure.
-    int n = is_comm_write_isb_precomp_to_buffer(buf, sizeof(buf), comm, txPkt);
-    int bytes = portWrite(port, buf, n);
-
-#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
-    if (n <= 0 || n != bytes)
-    {
-        printf("ISComm.c::is_comm_write_pkt() failed to portWrite: %d,%d\n", bytes, n);
-    }
-#endif
-
-    return bytes;
-#endif
 }
 
 char copyStructPToDataP(p_data_t *data, const void *sptr, const unsigned int maxsize)

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1135,8 +1135,19 @@ int is_comm_write_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t
     // Encode header and header checksum
     is_comm_encode_hdr(txPkt, flags, did, data_size, offset, data);
 
+#if 0   // Send packet in pieces to reduce buffer and memcpy
     // Update checksum and write packet to port.  Returns number of bytes written on success or -1 on failure.
     return is_comm_write_isb_precomp_to_port(portWrite, port, comm, txPkt);
+
+#else   // Buffer and send entire packet
+    uint8_t buf[PKT_BUF_SIZE];
+
+    // Update checksum and write packet to buffer.  Returns number of bytes written on success or -1 on failure.
+    int n = is_comm_write_isb_precomp_to_buffer(buf, sizeof(buf), comm, txPkt);
+
+    // Update checksum and write packet to port.  Returns number of bytes written on success or -1 on failure.
+    return portWrite(port, buf, n);
+#endif
 }
 
 char copyStructPToDataP(p_data_t *data, const void *sptr, const unsigned int maxsize)

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1144,9 +1144,16 @@ int is_comm_write_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t
 
     // Update checksum and write packet to buffer.  Returns number of bytes written on success or -1 on failure.
     int n = is_comm_write_isb_precomp_to_buffer(buf, sizeof(buf), comm, txPkt);
+    int bytes = portWrite(port, buf, n);
 
-    // Update checksum and write packet to port.  Returns number of bytes written on success or -1 on failure.
-    return portWrite(port, buf, n);
+#if !PLATFORM_IS_EMBEDDED    // TODO: Debug test_flash_sync, remove later (WHJ)
+    if (n <= 0 || n != bytes)
+    {
+        printf("ISComm.c::is_comm_write_pkt() failed to portWrite: %d,%d\n", bytes, n);
+    }
+#endif
+
+    return bytes;
 #endif
 }
 

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -308,7 +308,11 @@ static void PopulateBitMappings(map_name_to_info_t mappings[DID_COUNT])
     typedef bit_t MAP_TYPE;
     map_name_to_info_t& m = mappings[DID_BIT];
     uint32_t totalSize = 0;
-    ADD_MAP(m, totalSize, "state", state, 0, DataTypeUInt32, uint32_t, 0);
+    ADD_MAP(m, totalSize, "command", command, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "lastCommand", lastCommand, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "state", state, 0, DataTypeUInt8, uint8_t, 0);
+    ADD_MAP(m, totalSize, "reserved", reserved, 0, DataTypeUInt8, uint8_t, 0);
+
     ADD_MAP(m, totalSize, "hdwBitStatus", hdwBitStatus, 0, DataTypeUInt32, uint32_t, 0);
     ADD_MAP(m, totalSize, "calBitStatus", calBitStatus, 0, DataTypeUInt32, uint32_t, 0);
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -2220,11 +2220,11 @@ typedef struct PACKED
 enum eBitCommand
 {
     BIT_CMD_NONE                                    = (int)0,       // No command
+    BIT_CMD_OFF                                     = (int)1,       // Stop built-in test
     BIT_CMD_FULL_STATIONARY                         = (int)2,       // (FULL) Comprehensive test.  Requires system be completely stationary without vibrations. 
     BIT_CMD_BASIC_MOVING                            = (int)3,       // (BASIC) Ignores sensor output.  Can be run while moving.  This mode is automatically run after bootup.
     BIT_CMD_FULL_STATIONARY_HIGH_ACCURACY           = (int)4,       // Same as BIT_CMD_FULL_STATIONARY but with higher requirements for accuracy.  In order to pass, this test may require the Infield Calibration (DID_INFIELD_CAL) to be run. 
     BIT_CMD_RESERVED_2                              = (int)5,   
-    BIT_CMD_OFF                                     = (int)8,       // Stop built-in test
 };
 
 /** Built-in Test: State */

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -2216,29 +2216,35 @@ typedef struct PACKED
     float                   bias_cal[3];
 } inl2_mag_obs_info_t;
 
+/** Built-in Test: Input Command */
+enum eBitCommand
+{
+    BIT_CMD_NONE                                    = (int)0,       // No command
+    BIT_CMD_FULL_STATIONARY                         = (int)2,       // (FULL) Comprehensive test.  Requires system be completely stationary without vibrations. 
+    BIT_CMD_BASIC_MOVING                            = (int)3,       // (BASIC) Ignores sensor output.  Can be run while moving.  This mode is automatically run after bootup.
+    BIT_CMD_FULL_STATIONARY_HIGH_ACCURACY           = (int)4,       // Same as BIT_CMD_FULL_STATIONARY but with higher requirements for accuracy.  In order to pass, this test may require the Infield Calibration (DID_INFIELD_CAL) to be run. 
+    BIT_CMD_RESERVED_2                              = (int)5,   
+    BIT_CMD_OFF                                     = (int)8,       // Stop built-in test
+};
+
 /** Built-in Test: State */
 enum eBitState
 {
-    BIT_STATE_OFF					                    = (int)0,
-    BIT_STATE_DONE				                        = (int)1,       // Test is finished
-    BIT_STATE_CMD_FULL_STATIONARY                       = (int)2,       // (FULL) Comprehensive test.  Requires system be completely stationary without vibrations. 
-    BIT_STATE_CMD_BASIC_MOVING                          = (int)3,       // (BASIC) Ignores sensor output.  Can be run while moving.  This mode is automatically run after bootup.
-    BIT_STATE_CMD_FULL_STATIONARY_HIGH_ACCURACY         = (int)4,       // Same as BIT_STATE_CMD_FULL_STATIONARY but with higher requirements for accuracy.  In order to pass, this test may require the Infield Calibration (DID_INFIELD_CAL) to be run. 
-    BIT_STATE_RESERVED_2                                = (int)5,   
-    BIT_STATE_RUNNING                                   = (int)6,   
-    BIT_STATE_FINISHING                                 = (int)7,	    // Computing results
-    BIT_STATE_CMD_OFF                                   = (int)8,       // Stop built-in test
+    BIT_STATE_OFF					                = (int)0,
+    BIT_STATE_DONE				                    = (int)1,       // Test is finished
+    BIT_STATE_RUNNING                               = (int)6,
+    BIT_STATE_FINISHING                             = (int)7,	    // Computing results
 };
 
 /** Built-in Test: Test Mode */
 enum eBitTestMode
 {
-    BIT_TEST_MODE_FAILED                                = (int)98,      // Test mode ran and failed
-    BIT_TEST_MODE_DONE                                  = (int)99,      // Test mode ran and completed
-    BIT_TEST_MODE_SIM_GPS_NOISE                         = (int)100,     // Simulate CNO noise
-    BIT_TEST_MODE_COMMUNICATIONS_REPEAT                 = (int)101,     // Send duplicate message 
-    BIT_TEST_MODE_SERIAL_DRIVER_RX_OVERFLOW             = (int)102,     // Cause Rx buffer overflow on current serial port by blocking date read until the overflow occurs.
-    BIT_TEST_MODE_SERIAL_DRIVER_TX_OVERFLOW             = (int)103,     // Cause Tx buffer overflow on current serial port by sending too much data.
+    BIT_TEST_MODE_FAILED                            = (int)98,      // Test mode ran and failed
+    BIT_TEST_MODE_DONE                              = (int)99,      // Test mode ran and completed
+    BIT_TEST_MODE_SIM_GPS_NOISE                     = (int)100,     // Simulate CNO noise
+    BIT_TEST_MODE_COMMUNICATIONS_REPEAT             = (int)101,     // Send duplicate message 
+    BIT_TEST_MODE_SERIAL_DRIVER_RX_OVERFLOW         = (int)102,     // Cause Rx buffer overflow on current serial port by blocking date read until the overflow occurs.
+    BIT_TEST_MODE_SERIAL_DRIVER_TX_OVERFLOW         = (int)103,     // Cause Tx buffer overflow on current serial port by sending too much data.
 };
 
 /** Hardware built-in test (BIT) flags */
@@ -2294,11 +2300,20 @@ enum eCalBitStatusFlags
 };
 
 
-/** (DID_BIT) Built-in self-test parameters */
+/** (DID_BIT) Built-in self-test (BIT) parameters */
 typedef struct PACKED
 {
-    /** Built-in self-test state (see eBitState) */
-    uint32_t                state;
+    /** BIT input command (see eBitCommand).  Ignored when zero.  */
+    uint8_t                 command;
+
+    /** BIT last input command (see eBitCommand) */
+    uint8_t                 lastCommand;
+
+    /** BIT current state (see eBitState) */
+    uint8_t                 state;
+
+    /** Unused */
+    uint8_t                 reserved;
 
     /** Hardware BIT status (see eHdwBitStatusFlags) */
     uint32_t                hdwBitStatus;

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -60,7 +60,7 @@ PYBIND11_NUMPY_DTYPE(inl2_mag_obs_info_t, timeOfWeekMs, Ncal_samples, ready, cal
 // PYBIND11_NUMPY_DTYPE(gps_raw_t, receiverIndex, dataType, obsCount, reserved, data);
 // PYBIND11_NUMPY_DTYPE(gps_rtk_opt_t, mode, soltype, nf, navsys, elmin, snrmin, modear, glomodear, gpsmodear, sbsmodear, bdsmodear, arfilter, maxout, maxrej, minlock, minfixsats, minholdsats, mindropsats, rcvstds, minfix, armaxiter, dynamics, niter, intpref, rovpos, refpos, eratio, err, std, prn, sclkstab, thresar, elmaskar, elmaskhold, thresslip, varholdamb, gainholdamb, maxtdiff, fix_reset_base_msgs, maxinnocode, maxinnophase, maxnis, maxgdop, baseline, max_baseline_error, reset_baseline_error, max_ubx_error, ru, rb, maxaveep, outsingle, prcopt_t);
 PYBIND11_NUMPY_DTYPE(manufacturing_info_t, serialNumber, lotNumber, date, key, uid);
-PYBIND11_NUMPY_DTYPE(bit_t, state, hdwBitStatus, calBitStatus, tcPqrBias, tcAccBias, tcPqrSlope, tcAccSlope, tcPqrLinearity, tcAccLinearity, pqr, acc, pqrSigma, accSigma, testMode, testVar, detectedHardwareId);
+PYBIND11_NUMPY_DTYPE(bit_t, command, lastCommand, state, reserved, hdwBitStatus, calBitStatus, tcPqrBias, tcAccBias, tcPqrSlope, tcAccSlope, tcPqrLinearity, tcAccLinearity, pqr, acc, pqrSigma, accSigma, testMode, testVar, detectedHardwareId);
 PYBIND11_NUMPY_DTYPE(inl2_ned_sigma_t, timeOfWeekMs, StdPosNed, StdVelNed, StdAttNed, StdAccBias, StdGyrBias, StdBarBias, StdMagDeclination);
 PYBIND11_NUMPY_DTYPE(strobe_in_time_t, week, timeOfWeekMs, pin, count);
 PYBIND11_NUMPY_DTYPE(diag_msg_t, timeOfWeekMs, messageLength, message);


### PR DESCRIPTION
Fixed issue in which serial loopback in manufacturing testbed causes the DID_BIT to erroneously cancel.   Separated BIT input command from BIT state to prevent BIT output status from incorrectly overwriting the BIT command.