### PR TITLE
SN-5304 unsigned serial port number

### DIFF
--- a/ExampleProjects/Communications/ISCommunicationsExample.cpp
+++ b/ExampleProjects/Communications/ISCommunicationsExample.cpp
@@ -55,7 +55,7 @@ static void handleImuMessage(imu_t* imu)
 		imu->I.acc[0], imu->I.acc[1], imu->I.acc[2]);
 }
 
-static int portWrite(int port, const unsigned char* buf, int len)
+static int portWrite(unsigned int port, const unsigned char* buf, int len)
 {
 	return serialPortWrite(&s_serialPort, buf, len);
 }

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -224,14 +224,14 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             g_commandLineOptions.evFCont.dest = stoi(token);
 
             if (g_commandLineOptions.evFCont.dest == 0)
-                printf("EVF Target: Primary device.\n", token);
+                printf("EVF Target: Primary device\n");
             else if (g_commandLineOptions.evFCont.dest == 1)
-                printf("EVF Target: device GNSS1 port.\n", token);
+                printf("EVF Target: device GNSS1 port\n");
             else if (g_commandLineOptions.evFCont.dest == 2)
-                printf("EVF Target: device GNSS2 port.\n", token);
+                printf("EVF Target: device GNSS2 port\n");
             else 
             {
-                printf("EVF Target: INVALID\n", token); 
+                printf("EVF Target: INVALID\n"); 
                 g_commandLineOptions.evFCont.sendEVF = false;
                 continue;
             }

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -138,7 +138,7 @@ static void display_logger_status(InertialSense* i, bool refreshDisplay=false)
         printf("\nLogging %.2f KB to: %s\n", logSize * 0.001f, logger.LogDirectory().c_str());
 }
 
-static int cltool_errorCallback(int port, is_comm_instance_t* comm)
+static int cltool_errorCallback(unsigned int port, is_comm_instance_t* comm)
 {
     #define BUF_SIZE    8192
     #define BLACK   "\u001b[30m"

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -979,7 +979,7 @@ int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t*
     return is_comm_write_to_buf(buf, buf_size, comm, PKT_TYPE_GET_DATA, 0, sizeof(p_data_get_t), 0, &get);
 }
 
-int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint32_t did, uint32_t size, uint32_t offset, uint32_t periodMultiple)
+int is_comm_get_data(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, uint32_t did, uint32_t size, uint32_t offset, uint32_t periodMultiple)
 {
     p_data_get_t get;
 
@@ -1050,7 +1050,7 @@ int is_comm_write_isb_precomp_to_buffer(uint8_t *buf, uint32_t buf_size, is_comm
     return pkt->size;
 }
 
-int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *pkt)
+int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, packet_t *pkt)
 {
     // TODO: Debug test_flash_sync, remove later (WHJ)
     int j;
@@ -1117,7 +1117,7 @@ int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* co
     return is_comm_write_isb_precomp_to_buffer(buf, buf_size, comm, &txPkt);
 }
 
-int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data)
+int is_comm_write(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data)
 {
     packet_t txPkt;
 
@@ -1125,7 +1125,7 @@ int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* co
     return is_comm_write_pkt(portWrite, port, comm, &txPkt, flags, did, data_size, offset, data);
 }
 
-int is_comm_write_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *txPkt, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data)
+int is_comm_write_pkt(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, packet_t *txPkt, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data)
 {
     if (portWrite == NULL)
     {

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -134,7 +134,7 @@ typedef enum
 #define MAX_MSG_LENGTH_NMEA					200
 
 /** Send data to the serial port.  Returns number of bytes written. */ 
-typedef int(*pfnIsCommPortWrite)(int port, const uint8_t* buf, int len);
+typedef int(*pfnIsCommPortWrite)(unsigned int port, const uint8_t* buf, int len);
 
 /** We must not allow any packing or shifting as these data structures must match exactly in memory on all devices */
 PUSH_PACK_1

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -735,13 +735,13 @@ int is_comm_write_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_instance_t* co
  * @param portWrite Serial port callback function used send packet.
  * @param port Serial port number packet will be written to.
  */
-int is_comm_write(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
+int is_comm_write(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
 
 /**
  * @brief Same as is_comm_write() except passing in pointer to Tx packet structure.  
  * @param txPkt Pointer to packet_t structure used to organize message sent.
  */
-int is_comm_write_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *txPkt, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
+int is_comm_write_pkt(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, packet_t *txPkt, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, void* data);
 
 /**
  * Removed old data and shift unparsed data to the the buffer start if running out of space at the buffer end.  Returns number of bytes available in the bufer.
@@ -767,7 +767,7 @@ int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t*
  * @param portWrite Call back function for serial port write
  * @param port Port number for serial port
  */
-int is_comm_get_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint32_t did, uint32_t size, uint32_t offset, uint32_t periodMultiple);
+int is_comm_get_data(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, uint32_t did, uint32_t size, uint32_t offset, uint32_t periodMultiple);
 
 /**
  * @brief Encode a binary packet to set data on the device - puts the data ready to send into the buffer passed into is_comm_init.  An acknowledge packet is sent in response to this packet.
@@ -791,7 +791,7 @@ static inline int is_comm_set_data_to_buf(uint8_t* buf, uint32_t buf_size, is_co
  * @param portWrite Call back function for serial port write
  * @param port Port number for serial port
  */
-static inline int is_comm_set_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
+static inline int is_comm_set_data(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
 {
     return is_comm_write(portWrite, port, comm, PKT_TYPE_SET_DATA, did, size, offset, data);
 }    
@@ -807,7 +807,7 @@ static inline int is_comm_data_to_buf(uint8_t* buf, uint32_t buf_size, is_comm_i
 /**
  * Same as is_comm_set_data() except NO acknowledge packet is sent in response to this packet.
  */
-static inline int is_comm_data(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
+static inline int is_comm_data(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, uint16_t did, uint16_t size, uint16_t offset, void* data)
 {
     return is_comm_write(portWrite, port, comm, PKT_TYPE_DATA, did, size, offset, data);
 }    
@@ -816,7 +816,7 @@ static inline int is_comm_data(pfnIsCommPortWrite portWrite, int port, is_comm_i
  * @brief Same as is_comm_data() except passing in pointer to Tx packet structure.  
  * @param txPkt Pointer to packet_t structure used to organize message sent.
  */
-static inline int is_comm_data_pkt(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *txPkt, uint16_t did, uint16_t size, uint16_t offset, void* data)
+static inline int is_comm_data_pkt(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, packet_t *txPkt, uint16_t did, uint16_t size, uint16_t offset, void* data)
 {
     return is_comm_write_pkt(portWrite, port, comm, txPkt, PKT_TYPE_DATA, did, size, offset, data);
 }    
@@ -826,7 +826,7 @@ static inline int is_comm_data_pkt(pfnIsCommPortWrite portWrite, int port, is_co
  * @param comm the comm instance passed to is_comm_init
  * @return 0 if success, otherwise an error code
  */
-static inline int is_comm_stop_broadcasts_all_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm)
+static inline int is_comm_stop_broadcasts_all_ports(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm)
 {
     return is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_ALL_PORTS, 0, 0, 0, NULL);
 }
@@ -836,7 +836,7 @@ static inline int is_comm_stop_broadcasts_all_ports(pfnIsCommPortWrite portWrite
  * @param comm the comm instance passed to is_comm_init
  * @return 0 if success, otherwise an error code
  */
-static inline int is_comm_stop_broadcasts_current_ports(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm)
+static inline int is_comm_stop_broadcasts_current_ports(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm)
 {
     return is_comm_write(portWrite, port, comm, PKT_TYPE_STOP_BROADCASTS_CURRENT_PORT, 0, 0, 0, NULL);
 }
@@ -886,7 +886,7 @@ void is_comm_encode_hdr(packet_t *pkt, uint8_t flags, uint16_t did, uint16_t dat
  * @param pkt Pointer to precomputed ISB packet
  * @return int Number of bytes written on success or -1 on failure
  */
-int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, int port, is_comm_instance_t* comm, packet_t *pkt);
+int is_comm_write_isb_precomp_to_port(pfnIsCommPortWrite portWrite, unsigned int port, is_comm_instance_t* comm, packet_t *pkt);
 
 unsigned int calculate24BitCRCQ(unsigned char* buffer, unsigned int len);
 unsigned int getBitsAsUInt32(const unsigned char* buffer, unsigned int pos, unsigned int len);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -30,7 +30,7 @@ using namespace std;
 static InertialSense *s_is;
 static InertialSense::com_manager_cpp_state_t *s_cm_state;
 
-static int staticSendData(int port, const unsigned char* buf, int len)
+static int staticSendData(unsigned int port, const unsigned char* buf, int len)
 {
     if ((size_t)port >= s_cm_state->devices.size())
     {
@@ -39,7 +39,7 @@ static int staticSendData(int port, const unsigned char* buf, int len)
     return serialPortWrite(&(s_cm_state->devices[port].serialPort), buf, len);
 }
 
-static int staticReadData(int port, unsigned char* buf, int len)
+static int staticReadData(unsigned int port, unsigned char* buf, int len)
 {
     if ((size_t)port >= s_cm_state->devices.size())
     {

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -55,7 +55,7 @@ static int staticReadData(unsigned int port, unsigned char* buf, int len)
     return bytesRead;
 }
 
-static void staticProcessRxData(int port, p_data_t* data)
+static void staticProcessRxData(unsigned int port, p_data_t* data)
 {
     if (data->hdr.id >= (sizeof(s_cm_state->binaryCallback)/sizeof(pfnHandleBinaryData)))
     {
@@ -102,7 +102,7 @@ static void staticProcessRxData(int port, p_data_t* data)
     }
 }
 
-static int staticProcessRxNmea(int port, const unsigned char* msg, int msgSize)
+static int staticProcessRxNmea(unsigned int port, const unsigned char* msg, int msgSize)
 {
     if ((size_t)port > s_cm_state->devices.size())
     {

--- a/src/com_manager.h
+++ b/src/com_manager.h
@@ -81,28 +81,28 @@ typedef void* CMHANDLE;
 typedef int(*pfnComManagerRead)(unsigned int port, unsigned char* buf, int len);
 
 // txFreeFnc optional, return the number of free bytes in the send buffer for the serial port represented by pHandle
-typedef int(*pfnComManagerSendBufferAvailableBytes)(int port);
+typedef int(*pfnComManagerSendBufferAvailableBytes)(unsigned int port);
 
 // pstRxFnc optional, called after data is sent to the serial port represented by pHandle
-typedef void(*pfnComManagerPostRead)(int port, p_data_t* dataRead);
+typedef void(*pfnComManagerPostRead)(unsigned int port, p_data_t* dataRead);
 
 // pstAckFnc optional, called after an ACK is received by the serial port represented by pHandle
-typedef void(*pfnComManagerPostAck)(int port, p_ack_t* ack, unsigned char packetIdentifier);
+typedef void(*pfnComManagerPostAck)(unsigned int port, p_ack_t* ack, unsigned char packetIdentifier);
 
 // disableBcastFnc optional, mostly for internal use, this can be left as 0 or NULL
-typedef void(*pfnComManagerDisableBroadcasts)(int port);
+typedef void(*pfnComManagerDisableBroadcasts)(unsigned int port);
 
 // Called right before data is to be sent.  Data is not sent if this callback returns 0.
-typedef int(*pfnComManagerPreSend)(int port, p_data_hdr_t *dataHdr);
+typedef int(*pfnComManagerPreSend)(unsigned int port, p_data_hdr_t *dataHdr);
 
 // Generic message handler function, return 1 if message handled
-typedef int(*pfnComManagerGenMsgHandler)(int port, const unsigned char* msg, int msgSize);
+typedef int(*pfnComManagerGenMsgHandler)(unsigned int port, const unsigned char* msg, int msgSize);
 
 // Parse error handler function, return 1 if message handled
-typedef int(*pfnComManagerParseErrorHandler)(int port, is_comm_instance_t* comm);
+typedef int(*pfnComManagerParseErrorHandler)(unsigned int port, is_comm_instance_t* comm);
 
 // broadcast message handler
-typedef int(*pfnComManagerAsapMsg)(int port, p_data_get_t* req);
+typedef int(*pfnComManagerAsapMsg)(unsigned int port, p_data_get_t* req);
 
 /* Contains callback information for a before and after send for a data structure */
 typedef struct

--- a/src/com_manager.h
+++ b/src/com_manager.h
@@ -89,8 +89,8 @@ typedef void(*pfnComManagerPostRead)(unsigned int port, p_data_t* dataRead);
 // pstAckFnc optional, called after an ACK is received by the serial port represented by pHandle
 typedef void(*pfnComManagerPostAck)(unsigned int port, p_ack_t* ack, unsigned char packetIdentifier);
 
-// disableBcastFnc optional, mostly for internal use, this can be left as 0 or NULL
-typedef void(*pfnComManagerDisableBroadcasts)(unsigned int port);
+// disableBcastFnc optional, mostly for internal use, this can be left as 0 or NULL.  Set port to -1 for all ports.
+typedef void(*pfnComManagerDisableBroadcasts)(int port);
 
 // Called right before data is to be sent.  Data is not sent if this callback returns 0.
 typedef int(*pfnComManagerPreSend)(unsigned int port, p_data_hdr_t *dataHdr);
@@ -154,7 +154,7 @@ typedef struct
 	// Callback function pointer, used to respond to ack
 	pfnComManagerPostAck pstAckFnc;
 
-	// Callback function pointer, used when disabling all broadcast messages
+	// Callback function pointer to disable broadcasts on specified port, or all ports if port is -1
 	pfnComManagerDisableBroadcasts disableBcastFnc;
 
 	// Pointer to local data and data specific callback functions

--- a/src/com_manager.h
+++ b/src/com_manager.h
@@ -78,7 +78,7 @@ typedef void* CMHANDLE;
 
 // com manager callback prototypes
 // readFnc read data from the serial port. Returns number of bytes read.
-typedef int(*pfnComManagerRead)(int port, unsigned char* buf, int len);
+typedef int(*pfnComManagerRead)(unsigned int port, unsigned char* buf, int len);
 
 // txFreeFnc optional, return the number of free bytes in the send buffer for the serial port represented by pHandle
 typedef int(*pfnComManagerSendBufferAvailableBytes)(int port);

--- a/tests/test_ISComm.cpp
+++ b/tests/test_ISComm.cpp
@@ -81,7 +81,7 @@ static int portRead(int pHandle, unsigned char* buf, int len)
 	return ringBufRead(&tcm.portRxBuf, buf, len);
 }
 
-static int portWrite(int pHandle, const unsigned char* buf, int len)
+static int portWrite(unsigned int pHandle, const unsigned char* buf, int len)
 {
 	if (ringBufWrite(&tcm.portTxBuf, (unsigned char*)buf, len))
 	{	// Buffer overflow

--- a/tests/test_com_manager.cpp
+++ b/tests/test_com_manager.cpp
@@ -94,7 +94,7 @@ static void postRxRead(unsigned int port, p_data_t* dataRead)
 	EXPECT_TRUE(memcmp(&td.data, dataRead->ptr, td.size)==0);
 }
 
-static void disableBroadcasts(unsigned int port)
+static void disableBroadcasts(int port)
 {
 }
 

--- a/tests/test_com_manager.cpp
+++ b/tests/test_com_manager.cpp
@@ -82,7 +82,7 @@ static int portWrite(unsigned int port, const unsigned char* buf, int len)
 	return len;
 }
 
-static void postRxRead(int port, p_data_t* dataRead)
+static void postRxRead(unsigned int port, p_data_t* dataRead)
 {
 	data_holder_t td = g_testRxDeque.front();
 	g_testRxDeque.pop_front();
@@ -94,21 +94,21 @@ static void postRxRead(int port, p_data_t* dataRead)
 	EXPECT_TRUE(memcmp(&td.data, dataRead->ptr, td.size)==0);
 }
 
-static void disableBroadcasts(int port)
+static void disableBroadcasts(unsigned int port)
 {
 }
 
-int prepDevInfo(int port, p_data_hdr_t* dataHdr)
+int prepDevInfo(unsigned int port, p_data_hdr_t* dataHdr)
 {
 	return 1;
 }
 
-void writeNvrUserpageFlashCfg(int port, p_data_t* data)
+void writeNvrUserpageFlashCfg(unsigned int port, p_data_t* data)
 {
 }
 
 // return 1 on success, 0 on failure
-static int msgHandlerNmea(int port, const uint8_t* msg, int msgSize)
+static int msgHandlerNmea(unsigned int port, const uint8_t* msg, int msgSize)
 {
 // 	comWrite(pHandle, line, lineLength); // echo back
 // 	time_delay_msec(50); // give time for the echo to come back
@@ -168,7 +168,7 @@ static int msgHandlerNmea(int port, const uint8_t* msg, int msgSize)
 	return 0;
 }
 
-static int msgHandlerUblox(int port, const uint8_t* msg, int msgSize)
+static int msgHandlerUblox(unsigned int port, const uint8_t* msg, int msgSize)
 {
 	data_holder_t td = g_testRxDeque.front();
 	g_testRxDeque.pop_front();
@@ -206,7 +206,7 @@ static int msgHandlerUblox(int port, const uint8_t* msg, int msgSize)
 	return 0;
 }
 
-static int msgHandlerRtcm3(int port, const uint8_t* msg, int msgSize)
+static int msgHandlerRtcm3(unsigned int port, const uint8_t* msg, int msgSize)
 {
 	data_holder_t td = g_testRxDeque.front();
 	g_testRxDeque.pop_front();
@@ -244,7 +244,7 @@ static int msgHandlerRtcm3(int port, const uint8_t* msg, int msgSize)
 	return 0;
 }
 
-static int msgHandlerError(int port, is_comm_instance_t* comm)
+static int msgHandlerError(unsigned int port, is_comm_instance_t* comm)
 {
 	return 0;
 }

--- a/tests/test_com_manager.cpp
+++ b/tests/test_com_manager.cpp
@@ -67,12 +67,12 @@ static std::deque<data_holder_t> g_testRxDeque;
 static std::deque<data_holder_t> g_testTxDeque;
 
 
-static int portRead(int port, unsigned char* buf, int len)
+static int portRead(unsigned int port, unsigned char* buf, int len)
 {
 	return ringBufRead(&tcm.portRxBuf, buf, len);
 }
 
-static int portWrite(int port, const unsigned char* buf, int len)
+static int portWrite(unsigned int port, const unsigned char* buf, int len)
 {
 	if (ringBufWrite(&tcm.portTxBuf, (unsigned char*)buf, len))
 	{	// Buffer overflow

--- a/tests/test_com_manager_2.cpp
+++ b/tests/test_com_manager_2.cpp
@@ -41,7 +41,7 @@ struct comManagerTest
 
 static comManagerTest cm1, cm2;
 
-static int portRead(int port, unsigned char* buf, int len)
+static int portRead(unsigned int port, unsigned char* buf, int len)
 {
 	comManagerTest* t = (comManagerTest*)comManagerGetUserPointer(cmHandle);
 	t->readFncCallCount++;
@@ -51,7 +51,7 @@ static int portRead(int port, unsigned char* buf, int len)
 	return c;
 }
 
-static int portWrite(int port, const unsigned char* buf, int len)
+static int portWrite(unsigned int port, const unsigned char* buf, int len)
 {
 	comManagerTest* t = (comManagerTest*)comManagerGetUserPointer(cmHandle);
 	t->sendFncCallCount++;

--- a/tests/test_serial_utils.cpp
+++ b/tests/test_serial_utils.cpp
@@ -44,7 +44,7 @@ void serWriteInPieces(int serPort, const unsigned char *buf, int length)
  * @param dstPort Serial port to write to.
  * @param testMode Enable test mode to perform sequential serWrite() calls back to back to test capability of the serial driver.
  */
-void serial_port_bridge_forward_unidirectional(is_comm_instance_t &comm, uint8_t &serialPortBridge, int srcPort, int dstPort, uint32_t led, int testMode)
+void serial_port_bridge_forward_unidirectional(is_comm_instance_t &comm, uint8_t &serialPortBridge, unsigned int srcPort, unsigned int dstPort, uint32_t led, int testMode)
 {
 #if TEST_ENABLE_MANUAL_TX   // Manual Tx Test - Uncomment and run device_tx_manual_test in run test_serial_driver.cpp 
     while(1)

--- a/tests/test_serial_utils.h
+++ b/tests/test_serial_utils.h
@@ -5,7 +5,7 @@
 
 
 #if PLATFORM_IS_EMBEDDED
-void serial_port_bridge_forward_unidirectional(is_comm_instance_t &comm, uint8_t &serialPortBridge, int srcPort, int dstPort, uint32_t led=0, int testMode=1);
+void serial_port_bridge_forward_unidirectional(is_comm_instance_t &comm, uint8_t &serialPortBridge, unsigned int srcPort, unsigned int dstPort, uint32_t led=0, int testMode=1);
 #endif
 int64_t test_serial_rx_receive(uint8_t rxBuf[], int len, bool waitForStartSequence=true);
 int test_serial_generate_ordered_data(uint8_t buf[], int bufSize);


### PR DESCRIPTION
Switch the serial port number function parameter from signed int to unsigned int.  This addresses a problem where a negative serial port number caused an invalid Tx overlow indication and indexed out of bounds in the port monitor array.  Rather than try to catch a negative serial port number in all of the cases where it may be problematic, we switch it to an unsigned int.  We have no need for a negative serial port number.