### PR TITLE
Sn 5349 save gpx fault reason

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4318,12 +4318,16 @@ enum eGpxStatus
     /** Fatal event */
     GPX_STATUS_FATAL_MASK                               = (int)0xFF000000,
     GPX_STATUS_FATAL_OFFSET                             = 24,
-    GPX_STATUS_FATAL_CPU_EXCEPTION                      = (int)1,                     
-    GPX_STATUS_FATAL_UNHANDLED_INTERRUPT                = (int)2,
-    GPX_STATUS_FATAL_STACK_OVERFLOW                     = (int)3,
-    GPX_STATUS_FATAL_KERNEL_OOPS                        = (int)4,
-    GPX_STATUS_FATAL_KERNEL_PANIC                       = (int)5,
-    GPX_STATUS_FATAL_UNKNOWN                            = (int)6,
+    GPX_STATUS_FATAL_RESET_WATCHDOG                     = (int)1,   /** Reset from Watchdog */
+    GPX_STATUS_FATAL_RESET_BROWN                        = (int)2,   /** Reset from brown out */
+    GPX_STATUS_FATAL_LOW_POW                            = (int)3,   /** Reset from low power */
+    GPX_STATUS_FATAL_CPU_EXCEPTION                      = (int)4,                     
+    GPX_STATUS_FATAL_UNHANDLED_INTERRUPT                = (int)5,
+    GPX_STATUS_FATAL_STACK_OVERFLOW                     = (int)6,
+    GPX_STATUS_FATAL_KERNEL_OOPS                        = (int)7,
+    GPX_STATUS_FATAL_KERNEL_PANIC                       = (int)8,
+
+    GPX_STATUS_FATAL_UNKNOWN                            = (int)0xff,
 };
 
 /** Hardware status flags */
@@ -4387,16 +4391,10 @@ enum eGPXHdwStatusFlags
     GPX_HDW_STATUS_FAULT_RESET_MASK                     = (int)0x70000000,    
     /** Reset from Backup mode (low-power state w/ CPU off) */
     GPX_HDW_STATUS_FAULT_RESET_BACKUP_MODE              = (int)0x10000000,
-    /** Reset from Watchdog */
-    GPX_HDW_STATUS_FAULT_RESET_WATCHDOG                 = (int)0x20000000,
     /** Reset from Software */
-    GPX_HDW_STATUS_FAULT_RESET_SOFT                     = (int)0x30000000,
+    GPX_HDW_STATUS_FAULT_RESET_SOFT                     = (int)0x20000000,
     /** Reset from Hardware (NRST pin low) */
     GPX_HDW_STATUS_FAULT_RESET_HDW                      = (int)0x40000000,
-    /** Reset from brown out */
-    GPX_HDW_STATUS_FAULT_RESET_BROWN                    = (int)0x50000000,
-    /** Reset from low power */
-    GPX_HDW_STATUS_FAULT_RESET_LOW_POW                  = (int)0x60000000,
 
     /** Critical System Fault - CPU error */
     GPX_HDW_STATUS_FAULT_SYS_CRITICAL                   = (int)0x80000000,

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4393,6 +4393,10 @@ enum eGPXHdwStatusFlags
     GPX_HDW_STATUS_FAULT_RESET_SOFT                     = (int)0x30000000,
     /** Reset from Hardware (NRST pin low) */
     GPX_HDW_STATUS_FAULT_RESET_HDW                      = (int)0x40000000,
+    /** Reset from brown out */
+    GPX_HDW_STATUS_FAULT_RESET_BROWN                    = (int)0x50000000,
+    /** Reset from low power */
+    GPX_HDW_STATUS_FAULT_RESET_LOW_POW                  = (int)0x60000000,
 
     /** Critical System Fault - CPU error */
     GPX_HDW_STATUS_FAULT_SYS_CRITICAL                   = (int)0x80000000,

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -1618,7 +1618,7 @@ int nmea_gsv_gnss(char a[], int aSize, gps_sat_t &gsat, gps_sig_t &gsig, uint8_t
 
     for (int i = 0; i<numSigIds; i++)
     {
-        n += nmea_gsv_group(a, aSize, gsat, gsig, gnssId, sigIds[i]);
+        n += nmea_gsv_group(a+n, aSize-n, gsat, gsig, gnssId, sigIds[i]);
     }
 
     return n;
@@ -1636,7 +1636,7 @@ int nmea_gsv(char a[], const int aSize, gps_sat_t &gsat, gps_sig_t &gsig)
             // printf("gnssId: %d\n", gnssId);
 
             // With CNO
-            if(aSize - n > 0)
+            if((aSize - n) > 0)
                 n += nmea_gsv_gnss(a+n, aSize - n, gsat, gsig, gnssId);
             else 
                 break;

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -1492,11 +1492,8 @@ bool gsv_freq_ena(gps_sig_sv_t* sig)
     return false;
 }
 
-int nmea_gsv_group(char a[], int aSize, int &offset, gps_sat_t &gsat, gps_sig_t &gsig, uint8_t gnssId, uint8_t sigId=0xFF, bool noCno=false)
+int nmea_gsv_group(char a[], int aSize, gps_sat_t &gsat, gps_sig_t &gsig, uint8_t gnssId, uint8_t sigId=0xFF, bool noCno=false)
 {
-    // Apply offset to buffer
-    a += offset;
-    aSize -= offset;
     char *bufStart = a;
 
     int numSigs = nmea_gsv_num_sat_sigs(gnssId, sigId, gsig);
@@ -1549,7 +1546,6 @@ int nmea_gsv_group(char a[], int aSize, int &offset, gps_sat_t &gsat, gps_sig_t 
         }
         nmea_sprint_footer(a, aSize, n);
 
-        offset += n;
         // Move buffer pointer
         a += n;
         aSize -= n;
@@ -1559,12 +1555,12 @@ int nmea_gsv_group(char a[], int aSize, int &offset, gps_sat_t &gsat, gps_sig_t 
 }
 
 
-int nmea_gsv_gnss(char a[], int aSize, int &offset, gps_sat_t &gsat, gps_sig_t &gsig, uint8_t gnssId, bool noCno)
+int nmea_gsv_gnss(char a[], int aSize, gps_sat_t &gsat, gps_sig_t &gsig, uint8_t gnssId, bool noCno)
 {
     (void)noCno;
     if (s_protocol_version < NMEA_PROTOCOL_4P10)
     {
-        return nmea_gsv_group(a, aSize, offset, gsat, gsig, gnssId);
+        return nmea_gsv_group(a, aSize, gsat, gsig, gnssId);
     }
 
     uint8_t *sigIds;
@@ -1622,7 +1618,7 @@ int nmea_gsv_gnss(char a[], int aSize, int &offset, gps_sat_t &gsat, gps_sig_t &
 
     for (int i = 0; i<numSigIds; i++)
     {
-        n += nmea_gsv_group(a, aSize, offset, gsat, gsig, gnssId, sigIds[i]);
+        n += nmea_gsv_group(a, aSize, gsat, gsig, gnssId, sigIds[i]);
     }
 
     return n;
@@ -1630,7 +1626,7 @@ int nmea_gsv_gnss(char a[], int aSize, int &offset, gps_sat_t &gsat, gps_sig_t &
 
 int nmea_gsv(char a[], const int aSize, gps_sat_t &gsat, gps_sig_t &gsig)
 {
-    int n=0;
+    int n = 0;
 
     // eSatSvGnssId
     for (int gnssId=1; gnssId<=SAT_SV_GNSS_ID_IRN; gnssId++)
@@ -1640,7 +1636,10 @@ int nmea_gsv(char a[], const int aSize, gps_sat_t &gsat, gps_sig_t &gsig)
             // printf("gnssId: %d\n", gnssId);
 
             // With CNO
-            nmea_gsv_gnss(a, aSize, n, gsat, gsig, gnssId);
+            if(aSize - n > 0)
+                n += nmea_gsv_gnss(a+n, aSize - n, gsat, gsig, gnssId);
+            else 
+                break;
 
             // Zero CNO
             // nmea_gsv_gnss(a, aSize, n, gsat, gsig, gnssId, true);

--- a/src/protocol_nmea.h
+++ b/src/protocol_nmea.h
@@ -62,7 +62,7 @@ int nmea_rmc(char a[], const int aSize, gps_pos_t &pos, gps_vel_t &vel, float ma
 int nmea_zda(char a[], const int aSize, gps_pos_t &pos);
 int nmea_vtg(char a[], const int aSize, gps_pos_t &pos, gps_vel_t &vel, float magVarCorrectionRad=0.0f);
 int nmea_pashr(char a[], const int aSize, gps_pos_t &pos, ins_1_t &ins1, float heave, inl2_ned_sigma_t &sigma);
-int nmea_gsv_gnss(char a[], const int aSize, int &offset, gps_sat_t &gsat, gps_sig_t &gsig, uint8_t gnssId, bool noCno=false);
+int nmea_gsv_gnss(char a[], const int aSize, gps_sat_t &gsat, gps_sig_t &gsig, uint8_t gnssId, bool noCno=false);
 int nmea_gsv(char a[], const int aSize, gps_sat_t &gpsSat, gps_sig_t &gpsSig);
 int nmea_intel(char a[], const int aSize, dev_info_t &info, gps_pos_t &pos, gps_vel_t &vel);
 


### PR DESCRIPTION
(SDK) Fixed bug where GxGSV would be mangled on non-GPS constellations.
(GPX) Fixed bug when DID_GPX_PORT_MONITOR reports invalid values for port 0 (SN-5363).
(GPX) Added reset reason to DID_GPX_STATUS