### PR TITLE
Only use --break-system-packages with python 3.11 and later

### DIFF
--- a/scripts/build_log_inspector.sh
+++ b/scripts/build_log_inspector.sh
@@ -23,6 +23,19 @@ for i in "$@"; do
     esac
 done
 
+# Get the Python version
+PYTHON_VERSION=$(python3 --version 2>&1)
+# Extract the major and minor version numbers
+PYTHON_MAJOR_VERSION=$(echo $PYTHON_VERSION | awk '{print $2}' | cut -d. -f1)
+PYTHON_MINOR_VERSION=$(echo $PYTHON_VERSION | awk '{print $2}' | cut -d. -f2)
+# Define your pip install command
+PIP_INSTALL_COMMAND="pip3 install logInspector/"
+# Check if the Python version is 3.11 or higher
+if [[ $PYTHON_MAJOR_VERSION -eq 3 && $PYTHON_MINOR_VERSION -ge 11 ]] || [[ $PYTHON_MAJOR_VERSION -gt 3 ]]; then
+    # If Python version is 3.11 or higher, use --break-system-packages option
+    PIP_INSTALL_COMMAND="$PIP_INSTALL_COMMAND --break-system-packages"
+fi
+
 pushd "../python/logInspector" > /dev/null
     if [ -n "${clean}" ]; then
         echo -e "\n\n=== Running make clean... ==="
@@ -32,7 +45,8 @@ pushd "../python/logInspector" > /dev/null
     else
         echo -e "\n\n=== Running make... ==="
         cd ..
-        python3 -m pip install logInspector/ python3 --break-system-packages
+        echo "$PIP_INSTALL_COMMAND"
+        $PIP_INSTALL_COMMAND
         cd logInspector
         python3 setup.py build_ext --inplace
     fi

--- a/scripts/install_log_inspector_dependencies.sh
+++ b/scripts/install_log_inspector_dependencies.sh
@@ -10,12 +10,7 @@ echo_blue "==============================================="
 sudo apt install -y python3 python3-pip python3-setuptools
 /usr/bin/python3 -m pip install -U pip # update pip3 to latest version
 
-pushd ../python > /dev/null
-pip3 install logInspector/
-pushd logInspector > /dev/null
-/usr/bin/python3 setup.py build_ext --inplace
-popd > /dev/null
-popd > /dev/null
+./build_log_inspector.sh
 
 source ~/.bashrc
 


### PR DESCRIPTION
Only use the --break-system-packages option with python 3.11 and later. 