### PR TITLE
SN-5346 manufacturing support for 2.x software

### DIFF
--- a/python/logInspector/src/log_reader.cpp
+++ b/python/logInspector/src/log_reader.cpp
@@ -1,6 +1,11 @@
 #include "convert_ins.h"
 #include "log_reader.h"
 
+#define STRINGIZE(x) #x
+#define STRINGIZE_VALUE_OF(x) STRINGIZE(x)
+#define MESSAGE_VALUE(x) message(__FILE__ "(" STRINGIZE_VALUE_OF(__LINE__) "): " #x " = " STRINGIZE_VALUE_OF(x))
+#define CONCAT_MESSAGE(text, value) message(__FILE__ "(" STRINGIZE_VALUE_OF(__LINE__) "): " text " = " STRINGIZE_VALUE_OF(value))
+
 using namespace std;
 
 static py::object g_python_parent;  // Including this inside LogReader class causes problems w/ garbage collection.
@@ -76,6 +81,12 @@ void LogReader::forward_message(eDataIDs did, std::vector<gps_raw_wrapper_t>& ve
 
 bool LogReader::init(py::object python_class, std::string log_directory, py::list serials)
 {
+    printf("SDK Protocol: %d.%d.%d.%d\n", 
+        PROTOCOL_VERSION_CHAR0,
+        PROTOCOL_VERSION_CHAR1,
+        PROTOCOL_VERSION_CHAR2,
+        PROTOCOL_VERSION_CHAR3);
+
     vector<string> stl_serials = serials.cast<vector<string>>();
     cout << "Loading from: " << log_directory << endl;
     cout << "Serial numbers: ";
@@ -319,6 +330,8 @@ void LogReader::forwardData(int device_id)
 
 bool LogReader::load()
 {
+    printf("LogReader::load() ");
+
     std::vector<std::shared_ptr<cDeviceLog>> devices = logger_.DeviceLogs();
     for (int i = 0; i < (int)devices.size(); i++)
     {
@@ -341,7 +354,15 @@ pybind11::list LogReader::getSerialNumbers()
 }
 
 pybind11::list LogReader::protocolVersion()
-{ 
+{
+#pragma CONCAT_MESSAGE("PROTOCOL_VERSION_CHAR0: ", PROTOCOL_VERSION_CHAR0)
+#pragma CONCAT_MESSAGE("PROTOCOL_VERSION_CHAR1: ", PROTOCOL_VERSION_CHAR1)
+#pragma CONCAT_MESSAGE("PROTOCOL_VERSION_CHAR2: ", PROTOCOL_VERSION_CHAR2)
+#pragma CONCAT_MESSAGE("PROTOCOL_VERSION_CHAR3: ", PROTOCOL_VERSION_CHAR3)
+
+#warning "PROTOCOL_VERSION_CHAR0"
+#warning "The value of MY_VALUE = " STRINGIZE_VALUE_OF(PROTOCOL_VERSION_CHAR0)
+
     vector<int> version;
     version.push_back(PROTOCOL_VERSION_CHAR0);
     version.push_back(PROTOCOL_VERSION_CHAR1);

--- a/python/logInspector/src/log_reader.cpp
+++ b/python/logInspector/src/log_reader.cpp
@@ -360,9 +360,6 @@ pybind11::list LogReader::protocolVersion()
 #pragma CONCAT_MESSAGE("PROTOCOL_VERSION_CHAR2: ", PROTOCOL_VERSION_CHAR2)
 #pragma CONCAT_MESSAGE("PROTOCOL_VERSION_CHAR3: ", PROTOCOL_VERSION_CHAR3)
 
-#warning "PROTOCOL_VERSION_CHAR0"
-#warning "The value of MY_VALUE = " STRINGIZE_VALUE_OF(PROTOCOL_VERSION_CHAR0)
-
     vector<int> version;
     version.push_back(PROTOCOL_VERSION_CHAR0);
     version.push_back(PROTOCOL_VERSION_CHAR1);

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -2220,8 +2220,9 @@ enum eCalBitStatusFlags
     CAL_BIT_FAULT_TCAL_ACC_SLOPE            = (int)0x00010000,    // Temperature calibration accelerometer slope
     CAL_BIT_FAULT_TCAL_ACC_LIN              = (int)0x00020000,    // Temperature calibration accelerometer linearity
     CAL_BIT_FAULT_CAL_SERIAL_NUM            = (int)0x00040000,    // Calibration info: wrong device serial number
+    CAL_BIT_FAULT_MCAL_MAG_INVALID          = (int)0x00080000,    // Motion calibration MAG Cross-axis alignment is poorly formed
     CAL_BIT_FAULT_MCAL_EMPTY                = (int)0x00100000,    // Motion calibration Cross-axis alignment is not calibrated
-    CAL_BIT_FAULT_MCAL_INVALID              = (int)0x00200000,    // Motion calibration Cross-axis alignment is poorly formed
+    CAL_BIT_FAULT_MCAL_IMU_INVALID          = (int)0x00200000,    // Motion calibration IMU Cross-axis alignment is poorly formed
     CAL_BIT_FAULT_MOTION_PQR                = (int)0x00400000,    // Motion on gyros
     CAL_BIT_FAULT_MOTION_ACC                = (int)0x00800000,    // Motion on accelerometers
     CAL_BIT_NOTICE_IMU1_PQR_BIAS            = (int)0x01000000,    // IMU 1 gyro bias offset detected.  If stationary, zero gyros command may be used.


### PR DESCRIPTION
SN-5346 manufacturing support for 2.x software.  Separate CAL_BIT_FAULT_MCAL_INVALID into CAL_BIT_FAULT_MCAL_IMU_INVALID and CAL_BIT_FAULT_MCAL_MAG_INVALID.  Print SDK protocol version from log_reader.