### PR TITLE
SN-5441 flash config sync platform

### DIFF
--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISBootloaderThread.h"
 #include "ISBootloaderDFU.h"
 #include "protocol/FirmwareUpdate.h"
+#include "imx_defaults.h"
 
 using namespace std;
 
@@ -870,6 +871,22 @@ void InertialSense::SyncFlashConfig(unsigned int timeMs)
     }
 }
 
+void InertialSense::UpdateFlashConfigChecksum(nvm_flash_cfg_t &flashCfg)
+{
+    bool platformCfgUpdateIoConfig = flashCfg.platformConfig & PLATFORM_CFG_UPDATE_IO_CONFIG;
+
+    // Exclude from the checksum update the following which does not get saved in the flash config
+    flashCfg.platformConfig &= ~PLATFORM_CFG_UPDATE_IO_CONFIG;
+
+    if (platformCfgUpdateIoConfig)
+    {   // Update ioConfig
+        platformConfigToFlashCfgIoConfig(&flashCfg.ioConfig, flashCfg.platformConfig);
+    }
+
+    // Update checksum
+    flashCfg.checksum = flashChecksum32(&flashCfg, sizeof(nvm_flash_cfg_t));
+}
+
 bool InertialSense::FlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
 {
     if ((size_t)pHandle >= m_comManagerState.devices.size())
@@ -893,14 +910,20 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
         return 0;
     }
     ISDevice& device = m_comManagerState.devices[pHandle];
-    
+
+    device.flashCfg.checksum = flashChecksum32(&device.flashCfg, sizeof(nvm_flash_cfg_t));
+
     // Iterate over and upload flash config in 4 byte segments.  Upload only contiguous segments of mismatched data starting at `key` (i = 2).  Don't upload size or checksum.
     static_assert(sizeof(nvm_flash_cfg_t) % 4 == 0, "Size of nvm_flash_cfg_t must be a 4 bytes in size!!!");
     uint32_t *newCfg = (uint32_t*)&flashCfg;
     uint32_t *curCfg = (uint32_t*)&device.flashCfg; 
     int iSize = sizeof(nvm_flash_cfg_t) / 4;
     bool failure = false;
-    for (int i = 2; i < iSize; i++)
+    // Exclude updateIoConfig bit from flash config and keep track of it separately so it does not affect whether the platform config gets uploaded
+    bool platformCfgUpdateIoConfig = flashCfg.platformConfig & PLATFORM_CFG_UPDATE_IO_CONFIG;
+    flashCfg.platformConfig &= ~PLATFORM_CFG_UPDATE_IO_CONFIG;
+
+    for (int i = 2; i < iSize; i++)     // Start with index 2 to exclude size and checksum
     {
         if (newCfg[i] != curCfg[i])
         {   // Found start
@@ -913,6 +936,14 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
             uint8_t *tail = (uint8_t*)&(newCfg[i]);
             int size = tail-head;
             int offset = head-((uint8_t*)newCfg);
+
+            if (platformCfgUpdateIoConfig &&
+                head <= (uint8_t*)&(flashCfg.platformConfig) &&
+                tail >  (uint8_t*)&(flashCfg.platformConfig))
+            {   // Re-apply updateIoConfig bit prior to upload
+                flashCfg.platformConfig |= PLATFORM_CFG_UPDATE_IO_CONFIG;
+            }
+            
             DEBUG_PRINT("Sending DID_FLASH_CONFIG: size %d, offset %d\n", size, offset);
             int fail = comManagerSendData(pHandle, head, DID_FLASH_CONFIG, size, offset);            
             failure = failure || fail;
@@ -925,11 +956,10 @@ bool InertialSense::SetFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle)
         printf("DID_FLASH_CONFIG in sync.  No upload.\n");
     }
 
-    // Exclude from the checksum update the following which does not get saved in the flash config
-    flashCfg.platformConfig &= ~PLATFORM_CFG_UPDATE_IO_CONFIG;
-
     // Update checksum
-    flashCfg.checksum = flashChecksum32(&flashCfg, sizeof(nvm_flash_cfg_t));
+    UpdateFlashConfigChecksum(flashCfg);
+
+    // Save checksum to ensure upload happened correctly
     if (device.flashCfgUploadTimeMs)
     {
         device.flashCfgUploadChecksum = flashCfg.checksum;

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -880,7 +880,7 @@ void InertialSense::UpdateFlashConfigChecksum(nvm_flash_cfg_t &flashCfg)
 
     if (platformCfgUpdateIoConfig)
     {   // Update ioConfig
-        platformConfigToFlashCfgIoConfig(&flashCfg.ioConfig, flashCfg.platformConfig);
+        imxPlatformConfigToFlashCfgIoConfig(&flashCfg.ioConfig, flashCfg.platformConfig);
     }
 
     // Update checksum

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -642,6 +642,7 @@ private:
     static void StepLogger(InertialSense* i, const p_data_t* data, int pHandle);
     static void BootloadStatusUpdate(void* obj, const char* str);
     void SyncFlashConfig(unsigned int timeMs);
+    void UpdateFlashConfigChecksum(nvm_flash_cfg_t &flashCfg);
 };
 
 #endif

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3242,7 +3242,7 @@ typedef struct PACKED
     /** Hardware interface configuration bits (see eIoConfig). */
     uint32_t				ioConfig;
 
-    /** Hardware platform specifying the IMX carrier board type (i.e. RUG, EVB, IG) and configuration bits (see ePlatformConfig).  The platform type is used to simplify the GPS and I/O configuration process.  */
+    /** Hardware platform specifying the IMX carrier board type (i.e. RUG, EVB, IG) and configuration bits (see ePlatformConfig).  The platform type is used to simplify the GPS and I/O configuration process.  Bit PLATFORM_CFG_UPDATE_IO_CONFIG is excluded from the flashConfig checksum and from determining whether to upload. */
     uint32_t				platformConfig;
 
     /** X,Y,Z offset in meters in Sensor Frame origin to GPS 2 antenna. */

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -4,13 +4,13 @@
 
 
 // Return 0 if not valid.  Zero is not a valid platform type.
-int platformConfigTypeValid(uint32_t platformConfig)
+int imxPlatformConfigTypeValid(uint32_t platformConfig)
 {
     uint32_t platformType = platformConfig&PLATFORM_CFG_TYPE_MASK;
     return (platformType > 0) && (platformType < PLATFORM_CFG_TYPE_COUNT);
 }
 
-void platformConfigErrorCheck(uint32_t *platformConfig)
+void imxPlatformConfigErrorCheck(uint32_t *platformConfig)
 {
     uint32_t type = *platformConfig & PLATFORM_CFG_TYPE_MASK;
     uint32_t preset = (*platformConfig & PLATFORM_CFG_PRESET_MASK) >> PLATFORM_CFG_PRESET_OFFSET;
@@ -46,8 +46,8 @@ void platformConfigErrorCheck(uint32_t *platformConfig)
     *platformConfig |= type | preset << PLATFORM_CFG_PRESET_OFFSET;
 }
 
-void platformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig);
-void platformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig)
+void imxPlatformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig);
+void imxPlatformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig)
 {
     uint32_t type = platformConfig&PLATFORM_CFG_TYPE_MASK;
     uint32_t preset = (platformConfig&PLATFORM_CFG_PRESET_MASK)>>PLATFORM_CFG_PRESET_OFFSET;
@@ -142,7 +142,7 @@ void platformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformC
     SET_IO_CFG_GPS2_TYPE(*ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
 }
 
-void platformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig)
+void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig)
 {
     uint32_t type = platformConfig&PLATFORM_CFG_TYPE_MASK;
 
@@ -189,7 +189,7 @@ void platformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfi
     case PLATFORM_CFG_TYPE_RUG2_1_G2:
     case PLATFORM_CFG_TYPE_RUG3_G1:
     case PLATFORM_CFG_TYPE_RUG3_G2:
-        platformConfigToRug3FlashCfgIoConfig(ioConfig, platformConfig);
+        imxPlatformConfigToRug3FlashCfgIoConfig(ioConfig, platformConfig);
         break;
 
     case PLATFORM_CFG_TYPE_IG1_G1:
@@ -272,19 +272,19 @@ void platformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfi
     }
 }
 
-void platformConfigTypeToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformType)
+void imxPlatformConfigTypeToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformType)
 {
-    platformConfigToFlashCfgIoConfig(ioConfig, platformConfigTypeToDefaultPlatformConfig(platformType));
+    imxPlatformConfigToFlashCfgIoConfig(ioConfig, imxPlatformConfigTypeToDefaultPlatformConfig(platformType));
 }
 
 // Return default platformConfig based on platformType
-uint32_t platformConfigTypeToDefaultPlatformConfig(uint32_t platformType)
+uint32_t imxPlatformConfigTypeToDefaultPlatformConfig(uint32_t platformType)
 {
-    return platformType | (platformConfigTypeToDefaultPlatformPreset(platformType) << PLATFORM_CFG_PRESET_OFFSET);
+    return platformType | (imxPlatformConfigTypeToDefaultPlatformPreset(platformType) << PLATFORM_CFG_PRESET_OFFSET);
 }
 
 // Return default platform preset based on platformType
-uint32_t platformConfigTypeToDefaultPlatformPreset(uint32_t platformType)
+uint32_t imxPlatformConfigTypeToDefaultPlatformPreset(uint32_t platformType)
 {
     switch (platformType)
     {
@@ -303,7 +303,7 @@ uint32_t platformConfigTypeToDefaultPlatformPreset(uint32_t platformType)
     }
 }
 
-uint32_t minNavOutputMs(nvm_flash_cfg_t *cfg)
+uint32_t imxMinNavOutputMs(nvm_flash_cfg_t *cfg)
 {
     if (cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_INS_EKF)
     {
@@ -322,20 +322,6 @@ uint32_t minNavOutputMs(nvm_flash_cfg_t *cfg)
     else
     {   // VRS: no GPS or magnetometer
         return tNAV_MIN_PERIOD_MS_VRS_MODE;
-    }
-}
-
-void setNavOutputRateMs(nvm_flash_cfg_t *cfg, sys_params_t *sysParams, uint32_t dtMs)
-{
-    // Limit based on enabled features
-    uint32_t minNavOutput = minNavOutputMs(cfg);
-    uint32_t minNavUpdate = (cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_INS_EKF ? minNavOutput : 2 * minNavOutput);
-
-    // Apply limits
-    sysParams->navUpdatePeriodMs = sysParams->navOutputPeriodMs = _MAX(dtMs, minNavOutput);
-    while (sysParams->navUpdatePeriodMs < minNavUpdate)
-    {   // Set update as multiple of period
-        sysParams->navUpdatePeriodMs += sysParams->navOutputPeriodMs;
     }
 }
 

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -1,0 +1,343 @@
+#include "imx_defaults.h"
+
+
+
+
+// Return 0 if not valid.  Zero is not a valid platform type.
+int platformConfigTypeValid(uint32_t platformConfig)
+{
+    uint32_t platformType = platformConfig&PLATFORM_CFG_TYPE_MASK;
+    return (platformType > 0) && (platformType < PLATFORM_CFG_TYPE_COUNT);
+}
+
+void platformConfigErrorCheck(uint32_t *platformConfig)
+{
+    uint32_t type = *platformConfig & PLATFORM_CFG_TYPE_MASK;
+    uint32_t preset = (*platformConfig & PLATFORM_CFG_PRESET_MASK) >> PLATFORM_CFG_PRESET_OFFSET;
+
+    // Error check type
+    if (type > PLATFORM_CFG_TYPE_COUNT)
+    {
+        type = PLATFORM_CFG_TYPE_NONE;
+    }
+
+    // Error check preset
+    switch (type)
+    {
+    case PLATFORM_CFG_TYPE_RUG2_1_G0:
+    case PLATFORM_CFG_TYPE_RUG3_G0:
+        if (preset > PLATFORM_CFG_RUG3_PRESET__COUNT)
+        {
+            preset = PLATFORM_CFG_RUG3_PRESET__G0_DEFAULT;
+        }
+        break;
+    case PLATFORM_CFG_TYPE_RUG2_1_G1:
+    case PLATFORM_CFG_TYPE_RUG2_1_G2:
+    case PLATFORM_CFG_TYPE_RUG3_G1:
+    case PLATFORM_CFG_TYPE_RUG3_G2:
+        if (preset > PLATFORM_CFG_RUG3_PRESET__COUNT)
+        {
+            preset = PLATFORM_CFG_RUG3_PRESET__G0_DEFAULT;
+        }
+        break;
+    }
+
+    *platformConfig &= (PLATFORM_CFG_TYPE_MASK | PLATFORM_CFG_PRESET_MASK);
+    *platformConfig |= type | preset << PLATFORM_CFG_PRESET_OFFSET;
+}
+
+void platformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig);
+void platformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig)
+{
+    uint32_t type = platformConfig&PLATFORM_CFG_TYPE_MASK;
+    uint32_t preset = (platformConfig&PLATFORM_CFG_PRESET_MASK)>>PLATFORM_CFG_PRESET_OFFSET;
+
+    switch (type)
+    {
+    default:    // Not RUG-3
+        return;
+
+    case PLATFORM_CFG_TYPE_RUG2_1_G0:
+    case PLATFORM_CFG_TYPE_RUG2_1_G1:
+    case PLATFORM_CFG_TYPE_RUG2_1_G2:
+    case PLATFORM_CFG_TYPE_RUG3_G0:
+    case PLATFORM_CFG_TYPE_RUG3_G1:
+    case PLATFORM_CFG_TYPE_RUG3_G2:
+        break;  // RUG-3
+    }
+
+    // ioConfig - P8,P10 (G1,G2)
+    *ioConfig &= ~IO_CONFIG_G1G2_MASK;
+    switch (preset)
+    {   // CAN
+    case PLATFORM_CFG_RUG3_PRESET__1__S0_RS232_7_9___CAN_11_12______S1_GPS1:
+    case PLATFORM_CFG_RUG3_PRESET__2__S0_TTL_7_9_____CAN_11_12______S1_GPS1:
+    case PLATFORM_CFG_RUG3_PRESET__8_________________CAN_11_12______S1_GPS1__S0_GPS2:
+        *ioConfig |= IO_CONFIG_G1G2_CAN_BUS;
+        break;
+        // Ser 2
+    case PLATFORM_CFG_RUG3_PRESET__3__S0_TTL_7_9_____S2_TTL_8_10____S1_GPS1:
+    case PLATFORM_CFG_RUG3_PRESET__5__S1_RS485_7_8_9_10_____________S2_GPS1__S0_GPS2:
+    case PLATFORM_CFG_RUG3_PRESET__9__S2_TTL_8_10___________________S1_GPS1__S0_GPS2:
+        *ioConfig |= IO_CONFIG_G1G2_COM2;
+        break;
+    }
+
+    // ioConfig - P7-P10 (G3,G4,G5,G8)
+     *ioConfig &= ~IO_CONFIG_G5G8_MASK;
+    switch (preset)  
+    {   // RUG-3 P7P9 (G3,G4) - SPI
+    case PLATFORM_CFG_RUG3_PRESET__6__SPI_7_8_9_10__________________S2_GPS1__S0_GPS2:
+        *ioConfig |= IO_CONFIG_G5G8_G6G7_SPI_ENABLE;
+        break;
+        // RUG-3 P7P9 (G3,G4) - No strobe available
+    default:
+        *ioConfig |= IO_CONFIG_G5G8_DEFAULT;
+        break;
+    }
+
+    // GPS Ports
+    switch (preset)
+    {
+    case PLATFORM_CFG_RUG3_PRESET__1__S0_RS232_7_9___CAN_11_12______S1_GPS1:
+    case PLATFORM_CFG_RUG3_PRESET__2__S0_TTL_7_9_____CAN_11_12______S1_GPS1:
+    case PLATFORM_CFG_RUG3_PRESET__3__S0_TTL_7_9_____S2_TTL_8_10____S1_GPS1:
+    case PLATFORM_CFG_RUG3_PRESET__4__S0_RS232_7_9___S1_RS232_8_10__S2_GPS1:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER1);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        break;
+    case PLATFORM_CFG_RUG3_PRESET__5__S1_RS485_7_8_9_10_____________S2_GPS1__S0_GPS2:
+    case PLATFORM_CFG_RUG3_PRESET__6__SPI_7_8_9_10__________________S2_GPS1__S0_GPS2:
+    case PLATFORM_CFG_RUG3_PRESET__7__S1_RS232_8_10_________________S2_GPS1__S0_GPS2:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER2);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER0);
+        break;
+    case PLATFORM_CFG_RUG3_PRESET__8_________________CAN_11_12______S1_GPS1__S0_GPS2:
+    case PLATFORM_CFG_RUG3_PRESET__9__S2_TTL_8_10___________________S1_GPS1__S0_GPS2:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER1);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER0);
+        break;
+    }
+
+    // Disable GPS if not available
+    switch(type)
+    {
+    case PLATFORM_CFG_TYPE_RUG2_1_G0:
+    case PLATFORM_CFG_TYPE_RUG3_G0:   
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        break;
+    }
+    switch(type)
+    {
+    case PLATFORM_CFG_TYPE_RUG2_1_G0:
+    case PLATFORM_CFG_TYPE_RUG3_G0:
+    case PLATFORM_CFG_TYPE_RUG2_1_G1:
+    case PLATFORM_CFG_TYPE_RUG3_G1:   
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        break;
+    }
+
+    // GPS type: ZED-F9P
+    SET_IO_CFG_GPS1_TYPE(*ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+    SET_IO_CFG_GPS2_TYPE(*ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+}
+
+void platformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig)
+{
+    uint32_t type = platformConfig&PLATFORM_CFG_TYPE_MASK;
+
+    switch (type)
+    {
+    default:    // No GPS 
+    case PLATFORM_CFG_TYPE_NONE:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_M8);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_M8);
+        break;
+
+    case PLATFORM_CFG_TYPE_NONE_ONBOARD_G2:
+    case PLATFORM_CFG_TYPE_RUG1:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_ONBOARD_1);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_ONBOARD_2);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_M8);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_M8);
+        break;
+
+    case PLATFORM_CFG_TYPE_EVB2_G2:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER1);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER2);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        break;
+
+    case PLATFORM_CFG_TYPE_RUG2_0_G1:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER1);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        break;
+
+    case PLATFORM_CFG_TYPE_RUG2_0_G2:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER1);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER0);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        break;
+
+    case PLATFORM_CFG_TYPE_RUG2_1_G1:
+    case PLATFORM_CFG_TYPE_RUG2_1_G2:
+    case PLATFORM_CFG_TYPE_RUG3_G1:
+    case PLATFORM_CFG_TYPE_RUG3_G2:
+        platformConfigToRug3FlashCfgIoConfig(ioConfig, platformConfig);
+        break;
+
+    case PLATFORM_CFG_TYPE_IG1_G1:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER0);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        break;
+
+    case PLATFORM_CFG_TYPE_IG1_0_G2:
+    case PLATFORM_CFG_TYPE_IG1_G2:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER0);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER2);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        break;
+
+    case PLATFORM_CFG_TYPE_IG2:
+    case PLATFORM_CFG_TYPE_TBED3:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER0);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER0);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_GPX);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_GPX);
+        break;
+
+    case PLATFORM_CFG_TYPE_LAMBDA_G1:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER1);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        break;
+
+    case PLATFORM_CFG_TYPE_LAMBDA_G2:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER1);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER2);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        break;
+
+    case PLATFORM_CFG_TYPE_TBED2_G1_W_LAMBDA:
+    case PLATFORM_CFG_TYPE_TBED2_G2_W_LAMBDA:
+        SET_IO_CFG_GPS1_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_SER2);
+        SET_IO_CFG_GPS2_SOURCE(*ioConfig, IO_CONFIG_GPS_SOURCE_DISABLE);
+        SET_IO_CFG_GPS1_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        SET_IO_CFG_GPS2_TYPE(  *ioConfig, IO_CONFIG_GPS_TYPE_UBX_F9P);
+        *ioConfig |= IO_CONFIG_GPS1_NO_INIT;
+        *ioConfig |= IO_CONFIG_GPS2_NO_INIT;
+        break;
+    }
+
+    // GPS timepulse source
+    *ioConfig &= ~IO_CFG_GPS_TIMEPUSE_SOURCE_BITMASK;
+    switch (type)
+    {
+        // Disabled
+    case PLATFORM_CFG_TYPE_RUG2_1_G0:
+    case PLATFORM_CFG_TYPE_RUG3_G0:               
+    case PLATFORM_CFG_TYPE_NONE:
+        break;
+        // G8
+    case PLATFORM_CFG_TYPE_EVB2_G2:
+    case PLATFORM_CFG_TYPE_RUG2_0_G1:
+    case PLATFORM_CFG_TYPE_RUG2_0_G2:
+    case PLATFORM_CFG_TYPE_IG1_0_G2:
+        *ioConfig |= IO_CFG_GPS_TIMEPUSE_SOURCE_STROBE_G8_PIN12<<IO_CFG_GPS_TIMEPUSE_SOURCE_OFFSET;
+        break;
+        // G5
+    case PLATFORM_CFG_TYPE_TBED3:
+        *ioConfig |= IO_CFG_GPS_TIMEPUSE_SOURCE_STROBE_G5_PIN9<<IO_CFG_GPS_TIMEPUSE_SOURCE_OFFSET;
+        break;
+        // G9
+    case PLATFORM_CFG_TYPE_RUG2_1_G1:
+    case PLATFORM_CFG_TYPE_RUG2_1_G2:
+        *ioConfig |= IO_CFG_GPS_TIMEPUSE_SOURCE_STROBE_G9_PIN13<<IO_CFG_GPS_TIMEPUSE_SOURCE_OFFSET;
+        break;
+        // GPS1 PPS (pin 20)
+    default:
+        *ioConfig |= IO_CFG_GPS_TIMEPUSE_SOURCE_GNSS_PPS_PIN20<<IO_CFG_GPS_TIMEPUSE_SOURCE_OFFSET;
+        break;
+    }
+}
+
+void platformConfigTypeToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformType)
+{
+    platformConfigToFlashCfgIoConfig(ioConfig, platformConfigTypeToDefaultPlatformConfig(platformType));
+}
+
+// Return default platformConfig based on platformType
+uint32_t platformConfigTypeToDefaultPlatformConfig(uint32_t platformType)
+{
+    return platformType | (platformConfigTypeToDefaultPlatformPreset(platformType) << PLATFORM_CFG_PRESET_OFFSET);
+}
+
+// Return default platform preset based on platformType
+uint32_t platformConfigTypeToDefaultPlatformPreset(uint32_t platformType)
+{
+    switch (platformType)
+    {
+    case PLATFORM_CFG_TYPE_RUG2_1_G0:
+    case PLATFORM_CFG_TYPE_RUG3_G0:
+        return PLATFORM_CFG_RUG3_PRESET__G0_DEFAULT;
+        break;
+    case PLATFORM_CFG_TYPE_RUG2_1_G1:
+    case PLATFORM_CFG_TYPE_RUG2_1_G2:
+    case PLATFORM_CFG_TYPE_RUG3_G1:
+    case PLATFORM_CFG_TYPE_RUG3_G2:
+        return PLATFORM_CFG_RUG3_PRESET__G2_DEFAULT;
+        break;
+    default:
+        return 0;
+    }
+}
+
+uint32_t minNavOutputMs(nvm_flash_cfg_t *cfg)
+{
+    if (cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_INS_EKF)
+    {
+        return 4;
+    }
+    else if (!(cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_GPS1_FUSION) ||
+             !(cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_GPS2_FUSION))
+    {   // Nav: GPS enabled
+        return tNAV_MIN_PERIOD_MS_NAV_MODE;
+    }
+    else if (!(cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_MAGNETOMETER_FUSION) ||
+             !(cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_AUTO_ZERO_ANGULAR_RATE_UPDATES))
+    {   // AHRS: no GPS, magnetometer enabled
+        return tNAV_MIN_PERIOD_MS_AHRS_MODE;
+    }
+    else
+    {   // VRS: no GPS or magnetometer
+        return tNAV_MIN_PERIOD_MS_VRS_MODE;
+    }
+}
+
+void setNavOutputRateMs(nvm_flash_cfg_t *cfg, sys_params_t *sysParams, uint32_t dtMs)
+{
+    // Limit based on enabled features
+    uint32_t minNavOutput = minNavOutputMs(cfg);
+    uint32_t minNavUpdate = (cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_INS_EKF ? minNavOutput : 2 * minNavOutput);
+
+    // Apply limits
+    sysParams->navUpdatePeriodMs = sysParams->navOutputPeriodMs = _MAX(dtMs, minNavOutput);
+    while (sysParams->navUpdatePeriodMs < minNavUpdate)
+    {   // Set update as multiple of period
+        sysParams->navUpdatePeriodMs += sysParams->navOutputPeriodMs;
+    }
+}
+
+
+

--- a/src/imx_defaults.h
+++ b/src/imx_defaults.h
@@ -1,0 +1,50 @@
+#ifndef __IMX_DEFAULTS_H_
+#define __IMX_DEFAULTS_H_
+
+#ifndef NAPP
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "data_sets.h"
+
+#define tNAV_MIN_PERIOD_IMX5_MS_NAV_MODE    7       // W/ GPS
+#define tNAV_MIN_PERIOD_IMX5_MS_AHRS_MODE   5       // No GPS
+#define tNAV_MIN_PERIOD_IMX5_MS_VRS_MODE    4       // No GPS or magnetometer
+#define tNAV_MIN_PERIOD_INS3_MS_NAV_MODE    2       // W/ GPS
+#define tNAV_MIN_PERIOD_INS3_MS_AHRS_MODE   2       // No GPS
+#define tNAV_MIN_PERIOD_INS3_MS_VRS_MODE    2       // No GPS or magnetometer
+#ifdef IMX_5
+#define tNAV_MIN_PERIOD_MS_NAV_MODE         tNAV_MIN_PERIOD_IMX5_MS_NAV_MODE        // W/ GPS
+#define tNAV_MIN_PERIOD_MS_AHRS_MODE        tNAV_MIN_PERIOD_IMX5_MS_AHRS_MODE       // No GPS
+#define tNAV_MIN_PERIOD_MS_VRS_MODE         tNAV_MIN_PERIOD_IMX5_MS_VRS_MODE        // No GPS or magnetometer
+#define tMAINT_MAX_RUN_TIME_US              100000  // Used to increment gap count and indicate error
+#define tNAV_DEFAULT_PERIOD_MS              tNAV_MIN_PERIOD_MS_NAV_MODE      // Reliable / safe period for operation
+#else // uINS-3
+#define tNAV_MIN_PERIOD_MS_NAV_MODE         tNAV_MIN_PERIOD_INS3_MS_NAV_MODE        // W/ GPS
+#define tNAV_MIN_PERIOD_MS_AHRS_MODE        tNAV_MIN_PERIOD_INS3_MS_AHRS_MODE       // No GPS
+#define tNAV_MIN_PERIOD_MS_VRS_MODE         tNAV_MIN_PERIOD_INS3_MS_VRS_MODE        // No GPS or magnetometer
+#define tMAINT_MAX_RUN_TIME_US              40000   // Used to increment gap count and indicate error. uINS-3 onboard RTK takes ~20ms max maint task.
+#define tNAV_DEFAULT_PERIOD_MS              4      // Reliable / safe period for operation
+#endif
+
+int platformConfigTypeValid(uint32_t platformConfig);
+void platformConfigErrorCheck(uint32_t *platformConfig);
+void platformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig);
+void platformConfigTypeToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformType);
+uint32_t platformConfigTypeToDefaultPlatformConfig(uint32_t platformType);
+uint32_t platformConfigTypeToDefaultPlatformPreset(uint32_t platformType);
+
+uint32_t minNavOutputMs(nvm_flash_cfg_t *cfg);
+void setNavOutputRateMs(nvm_flash_cfg_t *cfg, sys_params_t *sysParams, uint32_t dtMs);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NAPP
+
+#endif // __IMX_DEFAULTS_H_
+

--- a/src/imx_defaults.h
+++ b/src/imx_defaults.h
@@ -29,15 +29,14 @@ extern "C" {
 #define tNAV_DEFAULT_PERIOD_MS              4      // Reliable / safe period for operation
 #endif
 
-int platformConfigTypeValid(uint32_t platformConfig);
-void platformConfigErrorCheck(uint32_t *platformConfig);
-void platformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig);
-void platformConfigTypeToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformType);
-uint32_t platformConfigTypeToDefaultPlatformConfig(uint32_t platformType);
-uint32_t platformConfigTypeToDefaultPlatformPreset(uint32_t platformType);
+int imxPlatformConfigTypeValid(uint32_t platformConfig);
+void imxPlatformConfigErrorCheck(uint32_t *platformConfig);
+void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformConfig);
+void imxPlatformConfigTypeToFlashCfgIoConfig(uint32_t *ioConfig, uint32_t platformType);
+uint32_t imxPlatformConfigTypeToDefaultPlatformConfig(uint32_t platformType);
+uint32_t imxPlatformConfigTypeToDefaultPlatformPreset(uint32_t platformType);
 
-uint32_t minNavOutputMs(nvm_flash_cfg_t *cfg);
-void setNavOutputRateMs(nvm_flash_cfg_t *cfg, sys_params_t *sysParams, uint32_t dtMs);
+uint32_t imxMinNavOutputMs(nvm_flash_cfg_t *cfg);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixed issue where flash config sync would not update checksum correctly and perform unnecessary flash sync if platformConfig type was unchanged.  Ignore bit PLATFORM_CFG_UPDATE_IO_CONFIG when checking whether to upload flash config platformConfig from InertialSense class.