### PR TITLE
Fix imx ISB firmware update status text

### DIFF
--- a/ExampleProjects/Bootloader/ISBootloaderExample.cpp
+++ b/ExampleProjects/Bootloader/ISBootloaderExample.cpp
@@ -68,19 +68,19 @@ static void bootloaderStatusText(void* obj, eLogLevel level, const char* str, ..
 
 	if (ctx->m_sn != 0 && ctx->m_port_name.size() != 0)
 	{
-		printf("%s (SN%d):\r", ctx->m_port_name.c_str(), ctx->m_sn);
+		printf("%s (SN%d):", ctx->m_port_name.c_str(), ctx->m_sn);
 	}
 	else if(ctx->m_sn != 0)
 	{
-		printf("(SN%d):\r", ctx->m_sn);
+		printf("(SN%d):", ctx->m_sn);
 	}
 	else if (ctx->m_port_name.size() != 0)
 	{
-		printf("%s:\r", ctx->m_port_name.c_str());
+		printf("%s:", ctx->m_port_name.c_str());
 	}
 	else
 	{
-		printf("SN?:\r");
+		printf("SN?:");
 	}
 
 	printf("\t\t\t%s\r\n", buffer);

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -536,23 +536,25 @@ void cltool_bootloadUpdateInfo(void* obj, ISBootloader::eLogLevel level, const c
 
     if (ctx->m_sn != 0 && ctx->m_port_name.size() != 0)
     {
-        printf("    | %s (SN%d):\r", ctx->m_port_name.c_str(), ctx->m_sn);
+        printf("    | %s (SN%d):", ctx->m_port_name.c_str(), ctx->m_sn);
     }
     else if(ctx->m_sn != 0)
     {
-        printf("    | (SN%d):\r", ctx->m_sn);
+        printf("    | (SN%d):", ctx->m_sn);
     }
     else if (ctx->m_port_name.size() != 0)
     {
-        printf("    | %s:\r", ctx->m_port_name.c_str());
+        printf("    | %s:", ctx->m_port_name.c_str());
     }
     else
     {
-        printf("    | SN?:\r");
+        printf("    | SN?:");
     }
 
     if (buffer[0])
-        printf("\t%s\r\n", buffer);
+        printf(" %s", buffer);
+
+    printf("\r\n");
 
     print_mutex.unlock();
 }


### PR DESCRIPTION
This fixes funny text formatting in the firmware update status output for cltool and the example project.

**Before:**
```
Discovered device on port /dev/ttyACM1
    | /d(APP) Rebooting to IS-bootloader mode...
Discovered device on port /dev/ttyACM2
Updating...
    | /d(ISB) Erasing flash...
    | /d(ISB) Programming flash...
5% 10% 15% 20% 25% 30% 35% 40% 45% 50% 55% 60% 65% 70% 75% 80% 85% 90% 95% 100% Update run time: 34.215000 Seconds.
    | /d(ISB) Rebooting to APP mode...
```

**AFTER:**
```
Discovered device on port /dev/ttyACM1
    | /dev/ttyACM1 (SN60339): 	(APP) Rebooting to IS-bootloader mode...
Discovered device on port /dev/ttyACM2
Updating...
    | /dev/ttyACM2 (SN60339): 	(ISB) Erasing flash...
    | /dev/ttyACM2 (SN60339): 	(ISB) Programming flash...
5% 10% 15% 20% 25% 30% 35% 40% 45% 50% 55% 60% 65% 70% 75% 80% 85% 90% 95% 100% Update run time: 33.773000 Seconds.
    | /dev/ttyACM2 (SN60339): 	(ISB) Rebooting to APP mode...
```
