### PR TITLE
SN-5391 evaltool file conversion issues

### DIFF
--- a/src/DeviceLogCSV.cpp
+++ b/src/DeviceLogCSV.cpp
@@ -223,7 +223,7 @@ bool cDeviceLogCSV::SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf, prot
 	{
 		return false;
 	}
-	else if (dataHdr->id == DID_DEV_INFO)
+	else if (dataHdr->id == DID_DEV_INFO && device)
 	{
 		memcpy((void *)&(device->devInfo), dataBuf, sizeof(dev_info_t));
 	}


### PR DESCRIPTION
Fix EvalTool log conversion tool.  Prevent access to uninitialized device pointer. 