### PR TITLE
SN-5612 Fixed multiple cltool issues

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -44,7 +44,7 @@ using namespace std;
 #define XMIT_CLOSE_DELAY_MS    1000     // (ms) delay prior to cltool close to ensure data transmission
 
 static bool g_killThreadsNow = false;
-static bool g_enableRx = false;
+static bool g_enableDataCallback = false;
 int g_devicesUpdating = 0;
 
 static void display_server_client_status(InertialSense* i, bool server=false, bool showMessageSummary=false, bool refreshDisplay=false)
@@ -238,7 +238,7 @@ static int cltool_errorCallback(unsigned int port, is_comm_instance_t* comm)
 // [C++ COMM INSTRUCTION] STEP 5: Handle received data 
 static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
 {
-    if (!g_enableRx)
+    if (!g_enableDataCallback)
     {   // Receive disabled
         return;
     }
@@ -303,7 +303,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     // Stop streaming any messages, wait for buffer to clear, and enable Rx callback
     inertialSenseInterface.StopBroadcasts();
     SLEEP_MS(100);
-    g_enableRx = true;
+    g_enableDataCallback = true;
 
     if (g_commandLineOptions.asciiMessages.size() != 0)
     {

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -831,7 +831,7 @@ static int cltool_dataStreaming()
                     display_server_client_status(&inertialSenseInterface, false, false, refreshDisplay);
                 }
 
-                if (current_timeMs() > requestDataSetsTimeMs + 1000) {
+                if ((current_timeMs() - requestDataSetsTimeMs) > 1000) {
                     // Re-request data every 1s
                     requestDataSetsTimeMs = current_timeMs(); 
                     cltool_requestDataSets(inertialSenseInterface, g_commandLineOptions.datasets);

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -280,8 +280,6 @@ void cltool_requestDataSets(InertialSense& inertialSenseInterface, std::vector<s
 
     for (stream_did_t& dataItem : datasets)
     {   // Datasets to stream
-        g_inertialSenseDisplay.SelectEditDataset(dataItem.did, true);     // Select DID for generic display
-
         inertialSenseInterface.BroadcastBinaryData(dataItem.did, dataItem.periodMultiple);
         switch (dataItem.did)
         {
@@ -337,6 +335,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     }
     else
     {
+        g_inertialSenseDisplay.SelectEditDataset(g_commandLineOptions.datasets.front().did, true);  // Select DID for generic display, which support viewing only one DID.
         cltool_requestDataSets(inertialSenseInterface, g_commandLineOptions.datasets);
     }
     if (g_commandLineOptions.timeoutFlushLoggerSeconds > 0)

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -335,7 +335,10 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     }
     else
     {
-        g_inertialSenseDisplay.SelectEditDataset(g_commandLineOptions.datasets.front().did, true);  // Select DID for generic display, which support viewing only one DID.
+        if (g_commandLineOptions.datasets.size() > 0)
+        {   // Select DID for generic display, which support viewing only one DID.
+            g_inertialSenseDisplay.SelectEditDataset(g_commandLineOptions.datasets.front().did, true);  
+        }
         cltool_requestDataSets(inertialSenseInterface, g_commandLineOptions.datasets);
     }
     if (g_commandLineOptions.timeoutFlushLoggerSeconds > 0)

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1152,6 +1152,20 @@ char copyDataBufPToStructP(void *sptr, const p_data_buf_t *data, const unsigned 
     }
 }
 
+char copyDataPToDataP(p_data_t *dst, const p_data_t *src, const unsigned int maxsize)
+{
+    if (src->hdr.size <= maxsize)
+    {
+        dst->hdr = src->hdr;
+        memcpy(dst->ptr, src->ptr, src->hdr.size);
+        return 0;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
 /** Copies packet data into a data structure.  Returns 0 on success, -1 on failure. */
 char copyDataPToStructP2(void *sptr, const p_data_hdr_t *dataHdr, const uint8_t *dataBuf, const unsigned int maxsize)
 {

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -899,6 +899,7 @@ char copyStructPToDataP(p_data_t *data, const void *sptr, const unsigned int max
 /** Copies packet data into a data structure.  Returns 0 on success, -1 on failure. */
 char copyDataPToStructP(void *sptr, const p_data_t *data, const unsigned int maxsize);
 char copyDataBufPToStructP(void *sptr, const p_data_buf_t *data, const unsigned int maxsize);
+/** Copies from packet data to packet data.  Returns 0 on success, -1 on failure. */
 char copyDataPToDataP(p_data_t *dst, const p_data_t *src, const unsigned int maxsize);
 
 /** Copies packet data into a data structure.  Returns 0 on success, -1 on failure. */

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -899,6 +899,7 @@ char copyStructPToDataP(p_data_t *data, const void *sptr, const unsigned int max
 /** Copies packet data into a data structure.  Returns 0 on success, -1 on failure. */
 char copyDataPToStructP(void *sptr, const p_data_t *data, const unsigned int maxsize);
 char copyDataBufPToStructP(void *sptr, const p_data_buf_t *data, const unsigned int maxsize);
+char copyDataPToDataP(p_data_t *dst, const p_data_t *src, const unsigned int maxsize);
 
 /** Copies packet data into a data structure.  Returns 0 on success, -1 on failure. */
 char copyDataPToStructP2(void *sptr, const p_data_hdr_t *dataHdr, const uint8_t *dataBuf, const unsigned int maxsize);

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -457,8 +457,8 @@ void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 	switch (m_displayMode)
 	{
 	default:
-		m_displayMode = DMODE_PRETTY;
-		// fall through
+		break;
+
 	case DMODE_PRETTY:
 		// Data stays at fixed location (no scroll history)
 		DataToVector(data);
@@ -472,6 +472,11 @@ void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 	case DMODE_SCROLL:	// Scroll display
 		cout << DataToString(data) << endl;
 		break;
+	}
+
+	if (m_editData.did == data->hdr.id)
+	{	// Copy data 
+		copyDataPToDataP(&m_editData.pData, data, MAX_DATASET_SIZE);
 	}
 
     // if we are doing a onceDid for any other display type, and we got it, shutdown normally, ASAP, but not immediately...
@@ -499,8 +504,7 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 	switch (m_displayMode)
 	{
 	default:	// Do not display
-		break;
-
+		// fall through
 	case DMODE_PRETTY:
 		Home();
 		if (m_enableReplay)
@@ -519,7 +523,7 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 			cout << Connected() << endl;
 
 		// Generic column format
-		cout << DatasetToString(m_editData.pData);
+		cout << DatasetToString(&m_editData.pData);
 		return true;
 
 	case DMODE_STATS:
@@ -653,7 +657,8 @@ string cInertialSenseDisplay::DataToString(const p_data_t* data)
             str = DataToStringRawHex((const char *)data->ptr, data->hdr, 32);
 		else if (m_editData.did == data->hdr.id)	
 		{	// Default view
-			str = DatasetToString(m_editData.pData = data);
+			copyDataPToDataP(&m_editData.pData, data, MAX_DATASET_SIZE);
+			str = DatasetToString(&m_editData.pData);
 		}
 		break;
 	}
@@ -1653,9 +1658,12 @@ string cInertialSenseDisplay::DataToStringGPXStatus(const gpx_status_t &gpxStatu
     ptr += SNPRINTF(ptr, ptrEnd - ptr, " %.3lfs", gpxStatus.timeOfWeekMs / 1000.0);
 #endif
 
-    ptr += SNPRINTF(ptr, ptrEnd - ptr, ", status: 0x%08x, hdwStatus: 0x%08x, gnss1.runState: %d, gnss1.FwUpState: %d, gnss1.initState: %d, gnss2.runState: %d, gnss2.FwUpState: %d, gnss2.initState: %d, mcuTemp: %0.3lf, upTime: %lf\n",
-                    gpxStatus.status, gpxStatus.hdwStatus, gpxStatus.gnsssStatus[0].runState, gpxStatus.gnsssStatus[0].fwUpdateState, gpxStatus.gnsssStatus[0].initState, gpxStatus.gnsssStatus[1].runState, 
-					gpxStatus.gnsssStatus[1].fwUpdateState, gpxStatus.gnsssStatus[1].initState,	gpxStatus.mcuTemp, gpxStatus.upTime );
+    ptr += SNPRINTF(ptr, ptrEnd - ptr, ",  status 0x%08x,  hdwStatus 0x%08x\n", gpxStatus.status, gpxStatus.hdwStatus);
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, "    gnss1/2:  runState %d/%d,  FwUpState %d/%d,  initState %d/%d\n", 
+		gpxStatus.gnsssStatus[0].runState, 		gpxStatus.gnsssStatus[1].runState, 
+		gpxStatus.gnsssStatus[0].fwUpdateState, gpxStatus.gnsssStatus[1].fwUpdateState, 
+		gpxStatus.gnsssStatus[0].initState,		gpxStatus.gnsssStatus[1].initState);
+	ptr += SNPRINTF(ptr, ptrEnd - ptr, "    mcuTemp %0.2lf,  upTime %0.3lf\n", gpxStatus.mcuTemp, gpxStatus.upTime);
 
     return buf;
 }
@@ -1981,11 +1989,10 @@ void cInertialSenseDisplay::GetKeyboardInput()
 			m_editData.uploadNeeded = true;
 
 			// Copy data into local Rx buffer
-			if (m_editData.pData!=NULL && 
-				m_editData.pData->hdr.id == m_editData.did &&
-				m_editData.pData->hdr.size+ m_editData.pData->hdr.offset >= m_editData.info.dataSize+m_editData.info.dataOffset)
+			if (m_editData.pData.hdr.id == m_editData.did &&
+				m_editData.pData.hdr.size+ m_editData.pData.hdr.offset >= m_editData.info.dataSize+m_editData.info.dataOffset)
 			{
-				memcpy(m_editData.pData->ptr + m_editData.info.dataOffset, m_editData.data, m_editData.info.dataSize);
+				memcpy(m_editData.pData.ptr + m_editData.info.dataOffset, m_editData.data, m_editData.info.dataSize);
 			}
 		}
 		StopEditing();

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -453,6 +453,11 @@ void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 		}
 	}
 
+	if (m_editData.did == data->hdr.id)
+	{	// Copy data 
+		copyDataPToDataP(&m_editData.pData, data, MAX_DATASET_SIZE);
+	}
+
 	// Save data to be displayed from PrintData()
 	switch (m_displayMode)
 	{
@@ -472,11 +477,6 @@ void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 	case DMODE_SCROLL:	// Scroll display
 		cout << DataToString(data) << endl;
 		break;
-	}
-
-	if (m_editData.did == data->hdr.id)
-	{	// Copy data 
-		copyDataPToDataP(&m_editData.pData, data, MAX_DATASET_SIZE);
 	}
 
     // if we are doing a onceDid for any other display type, and we got it, shutdown normally, ASAP, but not immediately...
@@ -657,7 +657,6 @@ string cInertialSenseDisplay::DataToString(const p_data_t* data)
             str = DataToStringRawHex((const char *)data->ptr, data->hdr, 32);
 		else if (m_editData.did == data->hdr.id)	
 		{	// Default view
-			copyDataPToDataP(&m_editData.pData, data, MAX_DATASET_SIZE);
 			str = DatasetToString(&m_editData.pData);
 		}
 		break;

--- a/src/ISDisplay.h
+++ b/src/ISDisplay.h
@@ -50,9 +50,8 @@ public:
 		bool            uploadNeeded;
 		uint8_t 		data[MAX_DATASET_SIZE];
 		data_info_t 	info;
-		uint8_t			aeroPDataBuf[MAX_DATASET_SIZE];
-		p_data_t 		zeroPData = {{},aeroPDataBuf};
-		const p_data_t*	pData = &zeroPData;
+		uint8_t			pDataBuf[MAX_DATASET_SIZE];
+		p_data_t		pData = {{}, pDataBuf};
 	} edit_data_t;
 
 	enum eDisplayMode


### PR DESCRIPTION
- Fix `-did x` option stops streaming when message was previously streaming. 
  - Prevent reception of stray data by disabling cltool_dataCallback() until stop broadcast in cltool_setupCommunications() is called. This prevents the cltool from processing any data received prior to cltool_setupCommunications().
  - Simplify data request to be more robust, re-requesting data once a second. 
- Fix `-edit` option not displaying.  Copy data into m_editData.pData.pDataBuf to ensure large data sets at high rates do not get mangled when print to display. 
- Fix `-edit` option variable selection.  
- Reformat print of DID_GPX_STATUS state variables for readability.