### PR TITLE
Add -nmea option to cltool

### DIFF
--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -657,7 +657,7 @@ void cltool_outputUsage()
     cout << "             at all times to allow broadcast of critical errors." << endlbOn;
 	cout << "    -sysCmd=[c]" << boldOff << "     Send DID_SYS_CMD c (see eSystemCommand) command then exit the program." << endlbOn;
 	cout << "    -nmea=[s]" << boldOff << "       Send NMEA message s with added checksum footer, then display rx messages.  Example: `-nmea=ASCE,0,GxGGA,1` " << endlbOn;
-	cout << "    -nmea" << boldOff << "           Listen only mode for NMEA message without sending $STP command." << endlbOn;
+	cout << "    -nmea" << boldOff << "           Listen only mode for NMEA message without sending stop all broadcasts `$STP` command." << endlbOn;
 	cout << "    -factoryReset " << boldOff << "  Reset IMX flash config to factory defaults." << endlbOn;
 	cout << "    -romBootloader " << boldOff << " Reboot into ROM bootloader mode.  Requires power cycle and reloading bootloader and firmware." << endlbOn;
 	if (g_internal)

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -151,6 +151,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
     g_commandLineOptions.replaySpeed = CL_DEFAULT_REPLAY_SPEED;
     g_commandLineOptions.bootloaderVerify = CL_DEFAULT_BOOTLOAD_VERIFY;
     g_commandLineOptions.timeoutFlushLoggerSeconds = 3;
+    g_commandLineOptions.nmeaRx = false;
     g_commandLineOptions.nmeaMessage = "";
     g_commandLineOptions.updateBootloaderFilename = "";
     g_commandLineOptions.forceBootloaderUpdate = false;
@@ -386,9 +387,14 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             g_commandLineOptions.magRecalMode = strtol(a + 9, NULL, 10);
             enable_display_mode();
         }
-        else if (startsWith(a, "-nmea=") || startsWith(a, "-nema="))
+        else if (startsWith(a, "-nmea="))
         {
             g_commandLineOptions.nmeaMessage = &a[6];
+            g_commandLineOptions.nmeaRx = true;
+        }
+        else if (startsWith(a, "-nmea"))
+        {
+            g_commandLineOptions.nmeaRx = true;
         }
         else if (startsWith(a, "-platform"))
         {
@@ -651,6 +657,7 @@ void cltool_outputUsage()
     cout << "             at all times to allow broadcast of critical errors." << endlbOn;
 	cout << "    -sysCmd=[c]" << boldOff << "     Send DID_SYS_CMD c (see eSystemCommand) command then exit the program." << endlbOn;
 	cout << "    -nmea=[s]" << boldOff << "       Send NMEA message s with added checksum footer, then display rx messages.  Example: `-nmea=ASCE,0,GxGGA,1` " << endlbOn;
+	cout << "    -nmea" << boldOff << "           Listen only mode for NMEA message without sending $STP command." << endlbOn;
 	cout << "    -factoryReset " << boldOff << "  Reset IMX flash config to factory defaults." << endlbOn;
 	cout << "    -romBootloader " << boldOff << " Reboot into ROM bootloader mode.  Requires power cycle and reloading bootloader and firmware." << endlbOn;
 	if (g_internal)

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -151,7 +151,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
     g_commandLineOptions.replaySpeed = CL_DEFAULT_REPLAY_SPEED;
     g_commandLineOptions.bootloaderVerify = CL_DEFAULT_BOOTLOAD_VERIFY;
     g_commandLineOptions.timeoutFlushLoggerSeconds = 3;
-    g_commandLineOptions.asciiMessages = "";
+    g_commandLineOptions.nmeaMessage = "";
     g_commandLineOptions.updateBootloaderFilename = "";
     g_commandLineOptions.forceBootloaderUpdate = false;
 
@@ -180,12 +180,7 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             a++;
         }
 
-        if (startsWith(a, "-asciiMessages="))
-        {
-            g_commandLineOptions.asciiMessages = &a[15];
-            enable_display_mode();
-        }
-        else if (startsWith(a, "-base="))
+        if (startsWith(a, "-base="))
         {
             g_commandLineOptions.baseConnection = &a[6];
             enable_display_mode();
@@ -390,6 +385,10 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             g_commandLineOptions.magRecal = true;
             g_commandLineOptions.magRecalMode = strtol(a + 9, NULL, 10);
             enable_display_mode();
+        }
+        else if (startsWith(a, "-nmea=") || startsWith(a, "-nema="))
+        {
+            g_commandLineOptions.nmeaMessage = &a[6];
         }
         else if (startsWith(a, "-platform"))
         {
@@ -651,6 +650,7 @@ void cltool_outputUsage()
     cout << "             See:eEventProtocol for protocol EV_ID values]. It is recommended to mask (0x01 << EVENT_MSG_TYPE_ID_ASCII)" << endlbOn;
     cout << "             at all times to allow broadcast of critical errors." << endlbOn;
 	cout << "    -sysCmd=[c]" << boldOff << "     Send DID_SYS_CMD c (see eSystemCommand) command then exit the program." << endlbOn;
+	cout << "    -nmea=[s]" << boldOff << "       Send NMEA message s with added checksum footer, then display rx messages.  Example: `-nmea=ASCE,0,GxGGA,1` " << endlbOn;
 	cout << "    -factoryReset " << boldOff << "  Reset IMX flash config to factory defaults." << endlbOn;
 	cout << "    -romBootloader " << boldOff << " Reboot into ROM bootloader mode.  Requires power cycle and reloading bootloader and firmware." << endlbOn;
 	if (g_internal)

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -75,7 +75,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
 	bool magRecal;
 	uint32_t magRecalMode;
 	survey_in_t surveyIn;
-	std::string asciiMessages;
+	std::string nmeaMessage;				// A full NMEA message with checksum terminator will be automatically added and then nmeaMessage sent 
 	double replaySpeed;
 	int displayMode;	
 	

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -75,6 +75,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
 	bool magRecal;
 	uint32_t magRecalMode;
 	survey_in_t surveyIn;
+	bool nmeaRx;
 	std::string nmeaMessage;				// A full NMEA message with checksum terminator will be automatically added and then nmeaMessage sent 
 	double replaySpeed;
 	int displayMode;	

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -942,6 +942,9 @@ static int inertialSenseMain()
                 printf("%s", (char*)asciiData);
                 printf("\r\n");
             }
+
+            // Scan for "q" press to exit program
+            g_inertialSenseDisplay.GetKeyboardInput();
         }
     }
     else

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -311,9 +311,9 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         g_inertialSenseDisplay.SetCommInstance(&(cm->ports->comm));
     }
 
-    if (g_commandLineOptions.asciiMessages.size() != 0)
+    if (g_commandLineOptions.nmeaMessage.size() != 0)
     {
-        serialPortWriteAscii(inertialSenseInterface.SerialPort(), g_commandLineOptions.asciiMessages.c_str(), (int)g_commandLineOptions.asciiMessages.size());
+        serialPortWriteAscii(inertialSenseInterface.SerialPort(), g_commandLineOptions.nmeaMessage.c_str(), (int)g_commandLineOptions.nmeaMessage.size());
         return true;
     }
 
@@ -766,7 +766,7 @@ static int cltool_dataStreaming()
         }
 
         // [LOGGER INSTRUCTION] Setup and start data logger
-        if (g_commandLineOptions.asciiMessages.size() == 0 && !cltool_setupLogger(inertialSenseInterface))
+        if (g_commandLineOptions.nmeaMessage.size() == 0 && !cltool_setupLogger(inertialSenseInterface))
         {
             cout << "Failed to setup logger!" << endl;
             // No need to Close() the InertialSense class interface; It will be closed when destroyed.
@@ -878,6 +878,22 @@ static void sigint_cb(int sig)
     signal(SIGINT, SIG_DFL);
 }
 
+// Create and send full NMEA message with terminator w/ checksum trailer
+static void sendNmea(serial_port_t &port, string nmeaMsg)
+{
+    char buf[1024] = {0};
+    int n = 0; 
+    if (nmeaMsg[0] != '$')
+    {   // Append header
+        nmeaMsg = "$" + nmeaMsg;
+    }
+    memcpy(buf, nmeaMsg.c_str(), nmeaMsg.size());
+    n += nmeaMsg.size();
+    nmea_sprint_footer(buf, sizeof(buf), n);
+    printf("Sending: %.*s\\r\\n\n", n-2, buf);
+    serialPortWrite(&port, (unsigned char*)buf, n);
+}
+
 static int inertialSenseMain()
 {
     // clear display
@@ -907,18 +923,20 @@ static int inertialSenseMain()
     {
         return cltool_createHost();
     }
-    else if (g_commandLineOptions.asciiMessages.size() != 0)
+    else if (!g_commandLineOptions.nmeaMessage.empty())
     {
-        serial_port_t serialForAscii;
-        serialPortPlatformInit(&serialForAscii);
-        serialPortOpen(&serialForAscii, g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, 0);
-        serialPortWriteAscii(&serialForAscii, "STPB", 4);
-        serialPortWriteAscii(&serialForAscii, ("ASCB," + g_commandLineOptions.asciiMessages).c_str(), (int)(5 + g_commandLineOptions.asciiMessages.size()));
+        serial_port_t port;
+        serialPortPlatformInit(&port);
+        serialPortOpen(&port, g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, 0);
+
+        sendNmea(port, "STPB");
+        sendNmea(port, g_commandLineOptions.nmeaMessage);
+
         unsigned char line[512];
         unsigned char* asciiData;
         while (!g_inertialSenseDisplay.ExitProgram())
         {
-            int count = serialPortReadAsciiTimeout(&serialForAscii, line, sizeof(line), 100, &asciiData);
+            int count = serialPortReadAsciiTimeout(&port, line, sizeof(line), 10, &asciiData);
             if (count > 0)
             {
                 printf("%s", (char*)asciiData);

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -923,18 +923,24 @@ static int inertialSenseMain()
     {
         return cltool_createHost();
     }
-    else if (!g_commandLineOptions.nmeaMessage.empty())
+    else if (!g_commandLineOptions.nmeaMessage.empty() || g_commandLineOptions.nmeaRx)
     {
         serial_port_t port;
         serialPortPlatformInit(&port);
-        serialPortOpen(&port, g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, 0);
+        if (!serialPortOpen(&port, g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, 0))
+        {   // Failed to open port
+            return -1;
+        }
 
-        sendNmea(port, "STPB");
-        sendNmea(port, g_commandLineOptions.nmeaMessage);
+        if (!g_commandLineOptions.nmeaMessage.empty())
+        {
+            sendNmea(port, "STPB");
+            sendNmea(port, g_commandLineOptions.nmeaMessage);
+        }
 
         unsigned char line[512];
         unsigned char* asciiData;
-        while (!g_inertialSenseDisplay.ExitProgram())
+        while (!g_inertialSenseDisplay.ExitProgram() && g_commandLineOptions.nmeaRx)
         {
             int count = serialPortReadAsciiTimeout(&port, line, sizeof(line), 10, &asciiData);
             if (count > 0)

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1149,7 +1149,6 @@ typedef struct PACKED
 	gps_sig_sv_t			sig[MAX_NUM_SAT_SIGNALS];	
 } gps_sig_t;
 
-
 typedef uint8_t         gps_extension_ver_t[30];
 #define GPS_VER_NUM_EXTENSIONS	6
 /** (DID_GPS1_VERSION) GPS version strings */


### PR DESCRIPTION
- Renamed `asciiMessages` to `nmeaMessage`.
- Added `-nmea` option to cltool help menu.
- Print to screen sent NMEA message with checksum footer.