### PR TITLE
SN-5733 Revert gpx flash config size

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1217,8 +1217,6 @@ static void PopulateGpxFlashCfgMappings(map_name_to_info_t mappings[DID_COUNT])
     ADD_MAP(m, totalSize, "gpsTimeUserDelay", gpsTimeUserDelay, 0, DataTypeFloat, float, 0);
     ADD_MAP(m, totalSize, "gpsMinimumElevation", gpsMinimumElevation, 0, DataTypeFloat, float, 0);
     ADD_MAP(m, totalSize, "RTKCfgBits", RTKCfgBits, 0, DataTypeUInt32, uint32_t, DataFlagsDisplayHex);
-    ADD_MAP(m, totalSize, "haltReason", haltReason, 0, DataTypeUInt32, uint32_t, 0);
-    ADD_MAP(m, totalSize, "reserved", reserved, 0, DataTypeUInt32, uint32_t, 0);
 
     ASSERT_SIZE(totalSize);
 }

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4337,12 +4337,6 @@ typedef struct
     /** RTK configuration bits (see eRTKConfigBits). */
     uint32_t                RTKCfgBits;
 
-    /** (Internal use only) Reason for system halt (see k_fatal_error_reason and k_fatal_error_reason_arch). Cleared on startup. */
-    uint32_t                haltReason;
-    
-    /** (Internal use only) reserved */
-    uint32_t                reserved;           
-
 } gpx_flash_cfg_t;
 
 /** GPX status flags */
@@ -4374,7 +4368,7 @@ enum eGpxStatus
     GPX_STATUS_FATAL_DIV_ZERO                           = (int)13,
     GPX_STATUS_FATAL_SER0_REINIT                        = (int)14,
 
-    GPX_STATUS_FATAL_UNKNOWN                            = (int)0xff,
+    GPX_STATUS_FATAL_UNKNOWN                            = (int)0x1F,    // TODO: Temporarily set to (5 bits). Reset to 0xFF when gpx_flash_cfg.debug is no longer used with fault reporting. (WHJ) 
 };
 
 /** Hardware status flags */


### PR DESCRIPTION
Revert GPX flash config size.  Use gpx_flash_cfg_t::debug as the surrogate storate for variable that were removed.  See line 47-50 in globals.h for bit definitions.