### PR TITLE
Fix/SN-5371 Broken EvalTool fwUpdate

### DIFF
--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1797,7 +1797,7 @@ string cInertialSenseDisplay::DataToStringPortMonitor(const port_monitor_t &port
 }
 
 /**
- * Formats the specified DID's raw data as a "hexidecimal view". This can be used with any DID that is not
+ * Formats the specified DID's raw data as a "hexadecimal view". This can be used with any DID that is not
  * otherwise supported.
  * @param raw_data a pointer to the raw DID byte stream
  * @param hdr the DID header

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -492,7 +492,11 @@ void ISFirmwareUpdater::runCommand(std::string cmd) {
         } else if (activeCommand[0] == ':') {
             // new step section/target - we should reset certain states here if needed
             activeStep = std::string(activeCommand.c_str() + 1);
-            session_target = target = fwUpdate::TARGET_HOST;
+            if (activeCommand == ":IMX5") setTarget(fwUpdate::TARGET_IMX5);
+            else if (activeCommand == ":GPX1") setTarget(fwUpdate::TARGET_GPX1);
+            else if (activeCommand == ":GNSS1") setTarget(fwUpdate::TARGET_SONY_CXD5610__1);
+            else if (activeCommand == ":GNSS2") setTarget(fwUpdate::TARGET_SONY_CXD5610__2);
+            else session_target = target = fwUpdate::TARGET_HOST;
             session_image_slot = slotNum = 0;
             failLabel.clear();
         } else if ((activeCommand == "target") && (args.size() == 1)) {

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -48,19 +48,19 @@ static int staticReadData(unsigned int port, uint8_t* buf, int len)
     }
     int bytesRead = serialPortReadTimeout(&s_cm_state->devices[port].serialPort, buf, len, 1);
 
-	if (s_is)
-	{	// Save raw data to ISlogger
-		s_is->LogRawData(&s_cm_state->devices[port], bytesRead, buf);
-	}
+    if (s_is)
+    {   // Save raw data to ISlogger
+        s_is->LogRawData(&s_cm_state->devices[port], bytesRead, buf);
+    }
 
     return bytesRead;
 }
 
-static void staticProcessRxData(unsigned int port, p_data_t* data)
+static int staticProcessRxData(unsigned int port, p_data_t* data)
 {
     if (data->hdr.id >= (sizeof(s_cm_state->binaryCallback)/sizeof(pfnHandleBinaryData)))
     {
-        return;
+        return -1;
     }
 
     pfnHandleBinaryData handler = s_cm_state->binaryCallback[data->hdr.id];
@@ -68,7 +68,7 @@ static void staticProcessRxData(unsigned int port, p_data_t* data)
 
     if ((size_t)port > s_cm_state->devices.size())
     {
-        return;
+        return -1;
     }
 
     if (handler != NULLPTR)
@@ -101,6 +101,7 @@ static void staticProcessRxData(unsigned int port, p_data_t* data)
             }
             break;
     }
+    return 0;
 }
 
 static int staticProcessRxNmea(unsigned int port, const unsigned char* msg, int msgSize)
@@ -132,6 +133,7 @@ InertialSense::InertialSense(
     m_clientBufferBytesToSend = 0;
     m_clientServerByteCount = 0;
     m_disableBroadcastsOnClose = false;  // For Intellian
+
     for(int i=0; i<int(sizeof(m_comManagerState.binaryCallback)/sizeof(pfnHandleBinaryData)); i++)
     {
         m_comManagerState.binaryCallback[i] = {};

--- a/src/com_manager.h
+++ b/src/com_manager.h
@@ -81,13 +81,13 @@ typedef void* CMHANDLE;
 typedef int(*pfnComManagerSendBufferAvailableBytes)(unsigned int port);
 
 // pstRxFnc optional, called after data is sent to the serial port represented by pHandle
-typedef void(*pfnComManagerPostRead)(unsigned int port, p_data_t* dataRead);
+typedef int(*pfnComManagerPostRead)(unsigned int port, p_data_t* dataRead);
 
 // pstAckFnc optional, called after an ACK is received by the serial port represented by pHandle
-typedef void(*pfnComManagerPostAck)(unsigned int port, p_ack_t* ack, unsigned char packetIdentifier);
+typedef int(*pfnComManagerPostAck)(unsigned int port, p_ack_t* ack, unsigned char packetIdentifier);
 
 // disableBcastFnc optional, mostly for internal use, this can be left as 0 or NULL.  Set port to -1 for all ports.
-typedef void(*pfnComManagerDisableBroadcasts)(int port);
+typedef int(*pfnComManagerDisableBroadcasts)(int port);
 
 // Called right before data is to be sent.  Data is not sent if this callback returns 0.
 typedef int(*pfnComManagerPreSend)(unsigned int port, p_data_hdr_t *dataHdr);

--- a/src/protocol/FirmwareUpdate.cpp
+++ b/src/protocol/FirmwareUpdate.cpp
@@ -749,7 +749,7 @@ namespace fwUpdate {
         request.data.req_update.image_flags = session_image_flags = image_flags;
         request.data.req_update.chunk_size = session_chunk_size = chunk_size;
         request.data.req_update.file_size = session_image_size = image_size;
-        request.data.req_update.progress_rate = progress_rate;
+        request.data.req_update.progress_rate = session_progress_rate = progress_rate;
         request.data.req_update.md5_hash = session_md5 = image_md5;
 
         return fwUpdate_sendPayload(request);
@@ -768,6 +768,7 @@ namespace fwUpdate {
         request.data.req_update.image_flags = session_image_flags;
         request.data.req_update.chunk_size = session_chunk_size;
         request.data.req_update.file_size = session_image_size;
+        request.data.req_update.progress_rate = session_progress_rate;
         request.data.req_update.md5_hash = session_md5;
 
         return fwUpdate_sendPayload(request);

--- a/src/protocol/FirmwareUpdate.h
+++ b/src/protocol/FirmwareUpdate.h
@@ -385,6 +385,7 @@ namespace fwUpdate {
         uint16_t session_chunk_size = 0;                        //! the negotiated maximum size for each chunk.
         uint16_t session_total_chunks = 0;                      //! the total number of chunks for the given image size
         uint32_t session_image_size = 0;                        //! the total size of the image to be sent
+        uint16_t session_progress_rate = 250;                   //! the number of milliseconds between progress updates
         uint8_t session_image_slot = 0;                         //! the "slot" to which this image will be written in the flash
         uint8_t session_image_flags = 0;                        //! additional flags to be communicated to the device for special processing
         md5hash_t session_md5 = { };                            //! the md5 of the firmware image

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -15,6 +15,8 @@
 #include <string>
 #include <stdexcept>
 
+#include "ISDataMappings.h"
+
 
 namespace utils {
 
@@ -36,4 +38,41 @@ namespace utils {
         return std::string(buffer);
     }
 
+/**
+ * Formats the specified DID's raw data as a "hexadecimal view". This can be used with any DID that is not
+ * otherwise supported.
+ * @param raw_data a pointer to the raw DID byte stream
+ * @param hdr the DID header
+ * @param bytesPerLine the number of hexadecimal bytes to print per line.
+ * @return returns a fully formatted string
+ */
+    std::string did_hexdump(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine)
+    {
+        (void)hdr;
+        char buf[2048];
+        char* ptrEnd = buf + 2048;
+        char* ptr = buf;
+
+        ptr += SNPRINTF(ptr, ptrEnd - ptr, "(%d) %s (RAW):", hdr.id, cISDataMappings::GetDataSetName(hdr.id));
+
+#if DISPLAY_DELTA_TIME==1
+        static double lastTime[2] = { 0 };
+        double dtMs = 1000.0*(wheel.timeOfWeek - lastTime[i]);
+        lastTime[i] = wheel.timeOfWeek;
+        ptr += SNPRINTF(ptr, ptrEnd - ptr, " %4.1lfms", dtMs);
+#else
+#endif
+        ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n");
+        int lines = hdr.size / bytesPerLine;
+        for (int j = 0; j < lines; j++) {
+            int linelen = (j == lines-1) ? hdr.size % bytesPerLine : bytesPerLine;
+            ptr += SNPRINTF(ptr, ptrEnd - ptr, "\t");
+            for (int i = 0; i < linelen; i++) {
+                ptr += SNPRINTF(ptr, ptrEnd - ptr, "%02x ", (uint8_t)raw_data[(j * bytesPerLine) + i]);
+            }
+            ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n");
+        }
+
+        return std::string(buf);
+    }
 }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -13,8 +13,11 @@
 #include <memory>
 #include <stdexcept>
 
+#include "ISComm.h"
+
 namespace utils {
     std::string getCurrentTimestamp();
+    std::string did_hexdump(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine);
 
     template<typename ... Args>
     std::string string_format(const std::string& format, Args ... args) {

--- a/tests/test_com_manager.cpp
+++ b/tests/test_com_manager.cpp
@@ -82,7 +82,7 @@ static int portWrite(unsigned int port, const unsigned char* buf, int len)
 	return len;
 }
 
-static void postRxRead(unsigned int port, p_data_t* dataRead)
+static int postRxRead(unsigned int port, p_data_t* dataRead)
 {
 	data_holder_t td = g_testRxDeque.front();
 	g_testRxDeque.pop_front();
@@ -92,10 +92,12 @@ static void postRxRead(unsigned int port, p_data_t* dataRead)
 	EXPECT_EQ(td.did, dataRead->hdr.id);
 	EXPECT_EQ(td.size, dataRead->hdr.size);
 	EXPECT_TRUE(memcmp(&td.data, dataRead->ptr, td.size)==0);
+    return 0;
 }
 
-static void disableBroadcasts(int port)
+static int disableBroadcasts(int port)
 {
+    return 0;
 }
 
 int prepDevInfo(unsigned int port, p_data_hdr_t* dataHdr)
@@ -103,8 +105,9 @@ int prepDevInfo(unsigned int port, p_data_hdr_t* dataHdr)
 	return 1;
 }
 
-void writeNvrUserpageFlashCfg(unsigned int port, p_data_t* data)
+int writeNvrUserpageFlashCfg(unsigned int port, p_data_t* data)
 {
+    return 0;
 }
 
 // return 1 on success, 0 on failure


### PR DESCRIPTION
Updated com_manager.h callback typedefs to be consistent with other similar callbacks (return int).
Updated InertialSense class to use to new com_manager callback signatures, returning 0 on success, and -1 on error.
Updated iomanager static callbacks to match com_manager.h callback signatures. 
Added callback into evaluation.cpp for InertialSense instance used for FirmwareUpdateDialog.
Fixed FirmwareUpdate:requestUpdate() to save/rerequest the progress rate to the session; set default to 250ms.
Added step/command error reporting for each device updated in EvalTools' FirmwareUpdateDialog.
Removed unnecessary "COM port open!" message from FirmwareUpdateDialog.
Fixed ISFirmwareUpdater using TARGET_HOST when using legacy step names old manifests. Legacy step names now correctly specify the correct target (ie ":IMX5" now sets target to IMX5").
Adds utils::did_hexdump() to print a DID in a generic hexdump format for debug purposes.