### PR TITLE
Sn 5745 - ISbootloader can't access last 32kb

### DIFF
--- a/src/ISBootloaderISB.cpp
+++ b/src/ISBootloaderISB.cpp
@@ -593,6 +593,9 @@ is_operation_result cISBootloaderISB::fill_current_page(int* currentPage, int* c
         unsigned char hexData[256];
         memset(hexData, 'F', 256);
 
+        // FIXME: This isn't okay... We have about 32k of additional flash that we can't access because is not the 65k "logical" page size.
+        //  This function should recognize when we are on the last page, and how many bytes are in that page if its not a full page and handle things accordingly.
+        //  until then, we'll return OK in the error condition below, because the bootloader won't let us write out of bounds anyway...
         while (*currentOffset < FLASH_PAGE_SIZE)
         {
             int byteCount = (FLASH_PAGE_SIZE - *currentOffset) * 2;
@@ -605,7 +608,7 @@ is_operation_result cISBootloaderISB::fill_current_page(int* currentPage, int* c
             if (upload_hex_page(hexData, byteCount / 2, currentOffset, totalBytes, verifyCheckSum) != IS_OP_OK)
             {
                 status_update("(ISB) Failed to fill page with bytes", IS_LOG_LEVEL_ERROR);
-                return IS_OP_ERROR;
+                return IS_OP_OK; // FIXME - this should actually be an error
             }
         }
     }


### PR DESCRIPTION
Correctly calculates the number of available logical pages of flash for application firmware, including partial pages.
Removes (temporarily) error/failure when trying to write to the last partial "logical page" of application flash memory.
