### PR TITLE
SN-5793 - Fix test_ISLogger

### DIFF
--- a/tests/test_ISLogger.cpp
+++ b/tests/test_ISLogger.cpp
@@ -112,7 +112,7 @@ static void TestConvertLog(string inputPath, cISLogger::eLogType inputLogType, c
 		double timestamp2 = cISDataMappings::GetTimestamp(&(data2->hdr), data2->buf);
 		if (timestamp1 != timestamp2)
 		{
-			EXPECT_EQ(timestamp1, timestamp2) << "MISMATCHED TIMESTAMPS: " << timestamp1 << " " << timestamp1 << " dataIndex: " << dataIndex << std::endl;
+			EXPECT_DOUBLE_EQ(timestamp1, timestamp2) << "MISMATCHED TIMESTAMPS: " << timestamp1 << " " << timestamp1 << " dataIndex: " << dataIndex << std::endl;
 			// break;
 		}
 


### PR DESCRIPTION
Previous update to unit tests introduced a EXPECT_EQ() from a pair of doubles, which is generally bad.  This fixes that with EXPECT_DOUBLE_EQ, which seems to work (but may need to be switch to a EXPECT_NEAR()