### PR TITLE
SN-5802 - Log Inspector Improvements

### DIFF
--- a/python/logInspector/logInspector.py
+++ b/python/logInspector/logInspector.py
@@ -458,9 +458,12 @@ class LogInspectorWindow(QMainWindow):
         self.checkboxResidual.stateChanged.connect(self.changeResidualCheckbox)
         self.checkboxTime = QCheckBox("Timestamp", self)
         self.checkboxTime.stateChanged.connect(self.changeTimeCheckbox)
+        self.xAxisSample = QCheckBox("XAxis Msg Index", self)
+        self.xAxisSample.stateChanged.connect(self.changeXAxisSampleCheckbox)
         self.LayoutOptions = QVBoxLayout()
         self.LayoutOptions.addWidget(self.checkboxResidual)
         self.LayoutOptions.addWidget(self.checkboxTime)
+        self.LayoutOptions.addWidget(self.xAxisSample)
         self.LayoutOptions.setSpacing(0)
         self.LayoutBelowPlotSelection = QHBoxLayout()
         self.LayoutBelowPlotSelection.addLayout(self.LayoutOptions)
@@ -575,6 +578,11 @@ class LogInspectorWindow(QMainWindow):
     def changeTimeCheckbox(self, state):
         if self.plotter:
             self.plotter.enableTimestamp(state)
+            self.updatePlot()
+
+    def changeXAxisSampleCheckbox(self, state):
+        if self.plotter:
+            self.plotter.enableXAxisSample(state)
             self.updatePlot()
 
     def saveAllPlotsToFile(self):

--- a/python/logInspector/logPlotter.py
+++ b/python/logInspector/logPlotter.py
@@ -49,6 +49,7 @@ class logPlot:
         self.d = 1
         self.residual = False
         self.timestamp = False
+        self.xAxisSample = False
         self.enableLegends = False  # Enable interactive legends
         if self.enableLegends:
             self.legends = InteractiveLegend()
@@ -80,6 +81,9 @@ class logPlot:
 
     def enableTimestamp(self, enable):
         self.timestamp = enable
+
+    def enableXAxisSample(self, enable):
+        self.xAxisSample = enable
 
     def setActiveSerials(self, serials):
         self.active_devs = []
@@ -2601,13 +2605,13 @@ class logPlot:
         N = 4
         if refImuPresent:
             N = N + 2
-        ax = fig.subplots(N, 1, sharex=True)
+        ax = fig.subplots(N, 1, sharex=(self.xAxisSample==0))
 
         fig.suptitle('Timestamps - ' + os.path.basename(os.path.normpath(self.log.directory)))
         self.configureSubplot(ax[0], 'INS dt', 's')
         self.configureSubplot(ax[1], 'GPS dt', 's')
         self.configureSubplot(ax[2], 'IMU Integration Period', 's')
-        self.configureSubplot(ax[3], 'IMU Delta Timestamp', 's')
+        self.configureSubplot(ax[3], 'IMU Delta Timestamp', 's', xlabel = 'Message Index' if self.xAxisSample else 'Time of Week' )
 
         for d in self.active_devs_no_ref:
             dtIns = self.getData(d, DID_INS_2, 'timeOfWeek')[1:] - self.getData(d, DID_INS_2, 'timeOfWeek')[0:-1]
@@ -2648,11 +2652,20 @@ class logPlot:
                 deltaTimestamp = deltaTimestamp / self.d
                 timeImu = getTimeFromTow(timeImu3[1:] + towOffset)
 
-            ax[0].plot(timeIns, dtIns, label=self.log.serials[d])
-            ax[1].plot(timeGps, dtGps)
+            if self.xAxisSample:
+                xIns = np.arange(0, np.shape(dtIns)[0])
+                xGps = np.arange(0, np.shape(dtGps)[0])
+                xImu = np.arange(0, np.shape(deltaTimestamp)[0])
+            else:
+                xIns = timeIns
+                xGps = timeGps
+                xImu = timeImu
+
+            ax[0].plot(xIns, dtIns, label=self.log.serials[d])
+            ax[1].plot(xGps, dtGps)
             if integrationPeriod.size:
-                ax[2].plot(timeImu, integrationPeriod)
-            ax[3].plot(timeImu, deltaTimestamp)
+                ax[2].plot(xImu, integrationPeriod)
+            ax[3].plot(xImu, deltaTimestamp)
 
         self.setPlotYSpanMin(ax[0], 0.005)
         self.setPlotYSpanMin(ax[1], 0.005)

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -724,7 +724,7 @@ int g_copyReadDid;
  * @param enableCsvIns2ToIns1Conversion
  * @return
  */
-bool cISLogger::CopyLog(cISLogger &log, const string &timestamp, const string &outputDir, eLogType logType, float maxLogSpacePercent, uint32_t maxFileSize, bool useSubFolderTimestamp, bool enableCsvIns2ToIns1Conversion)
+bool cISLogger::CopyLog(cISLogger &log, const string &timestamp, const string &outputDir, eLogType logType, uint32_t maxFileSize, float maxLogSpacePercent, bool useSubFolderTimestamp, bool enableCsvIns2ToIns1Conversion)
 {
     m_logStats.Clear();
     if (!InitSaveTimestamp(timestamp, outputDir, g_emptyString, logType, maxLogSpacePercent, maxFileSize, useSubFolderTimestamp))
@@ -768,7 +768,12 @@ bool cISLogger::CopyLog(cISLogger &log, const string &timestamp, const string &o
             // CSV special cases 
             if (logType == eLogType::LOGTYPE_CSV && enableCsvIns2ToIns1Conversion)
             {
-                if (data->hdr.id == DID_INS_2)
+                static bool hasIns1 = false;
+                if (data->hdr.id == DID_INS_1)
+                {   // Indicate log contains DID_INS_1 so we don't need to convert from DID_INS_2
+                    hasIns1 = true;
+                }
+                if (data->hdr.id == DID_INS_2 && !hasIns1)
                 {	// Convert INS2 to INS1 when creating .csv logs
                     ins_1_t ins1;
                     ins_2_t ins2;

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -42,8 +42,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 // default logging path if none specified
-#define DEFAULT_LOGS_DIRECTORY "IS_logs"
-
+#define DEFAULT_LOGS_DIRECTORY          "IS_logs"
+#define DEFAULT_LOGS_MAX_FILE_SIZE      (1024 * 1024 * 5)	// 5 MB
 
 class cISLogger
 {
@@ -113,8 +113,8 @@ public:
 		const std::string& timestamp = g_emptyString,
 		const std::string& outputDir = g_emptyString,
 		eLogType logType = LOGTYPE_DAT,
+		uint32_t maxFileSize = DEFAULT_LOGS_MAX_FILE_SIZE,
 		float maxDiskSpacePercent = 0.5f,
-		uint32_t maxFileSize = 1024 * 1024 * 5,
 		bool useSubFolderTimestamp = true,
 		bool enableCsvIns2ToIns1Conversion = true);
 	const cLogStats& GetStats() { return m_logStats; }

--- a/tests/test_ISLogger.cpp
+++ b/tests/test_ISLogger.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-static const int s_maxFileSize = 5242880;
+static const int s_maxFileSize = DEFAULT_LOGS_MAX_FILE_SIZE;
 //static const int s_maxFileSize = 100000;	// Make many small files
 static const float s_maxDiskSpacePercent = 0.5f;
 static const float s_maxDiskSpaceMBLarge = 1024.0f * 1024.0f * 10.0f;
@@ -51,7 +51,7 @@ static void TestConvertLog(string inputPath, cISLogger::eLogType inputLogType, c
 	cISLogger logger2;
 	EXPECT_TRUE(logger1.LoadFromDirectory(inputPath, inputLogType));
 	logger1.ShowParseErrors(showParseErrors);			// Allow garbage data tests to hide parse errors
-	EXPECT_TRUE(logger2.CopyLog(logger1, cISLogger::g_emptyString, outputPath1, convertLogType, s_maxDiskSpacePercent, s_maxFileSize, s_useTimestampSubFolder, false));
+	EXPECT_TRUE(logger2.CopyLog(logger1, cISLogger::g_emptyString, outputPath1, convertLogType, s_maxFileSize, s_maxDiskSpacePercent, s_useTimestampSubFolder, false));
 	logger1.CloseAllFiles();
 	logger2.CloseAllFiles();
 
@@ -60,7 +60,7 @@ static void TestConvertLog(string inputPath, cISLogger::eLogType inputLogType, c
 	cISLogger logger4;
 	EXPECT_TRUE(logger3.LoadFromDirectory(outputPath1, convertLogType));
 	logger3.ShowParseErrors(showParseErrors);			// Allow garbage data tests to hide parse errors
-	EXPECT_TRUE(logger4.CopyLog(logger3, cISLogger::g_emptyString, outputPath2, inputLogType, s_maxDiskSpacePercent, s_maxFileSize, s_useTimestampSubFolder, false));
+	EXPECT_TRUE(logger4.CopyLog(logger3, cISLogger::g_emptyString, outputPath2, inputLogType, s_maxFileSize, s_maxDiskSpacePercent, s_useTimestampSubFolder, false));
 	logger3.CloseAllFiles();
 	logger4.CloseAllFiles();
 

--- a/tests/test_data_utils.cpp
+++ b/tests/test_data_utils.cpp
@@ -33,7 +33,7 @@
 
 using namespace std;
 
-static const int s_maxFileSize = 5242880;
+static const int s_maxFileSize = DEFAULT_LOGS_MAX_FILE_SIZE;
 //static const int s_maxFileSize = 100000;	// Make many small files
 static const float s_maxDiskSpacePercent = 0.5f;
 static const float s_maxDiskSpaceMBLarge = 1024.0f * 1024.0f * 10.0f;


### PR DESCRIPTION
- Add option to LogInspector to toggle X-axis from timeOfWeek to message index to better identify system reset(s).
- Increase  csv output file size from 5MB to 50MB in EvalTool log conversion tool.  
