### PR TITLE
Remove DeviceLogBySerialNum

### DIFF
--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -653,7 +653,8 @@ void cISLogger::ShowParseErrors(bool show)
 
 uint64_t cISLogger::LogSize(uint32_t devSerialNo)
 {
-    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->LogSize() : 0);
+    auto device = DeviceLogBySerialNumber(devSerialNo);
+    return (device ? device->LogSize() : 0);
 }
 
 uint64_t cISLogger::LogSizeAll()
@@ -673,22 +674,26 @@ float cISLogger::LogSizeAllMB()
 
 float cISLogger::LogSizeMB(uint32_t devSerialNo)
 {
-    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->LogSize() * 0.000001f : 0);
+    auto device = DeviceLogBySerialNumber(devSerialNo);
+    return (device ? device->LogSize() * 0.000001f : 0);
 }
 
 float cISLogger::FileSizeMB(uint32_t devSerialNo)
 {
-    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->FileSize() * 0.000001f : 0);
+    auto device = DeviceLogBySerialNumber(devSerialNo);
+    return (device ? device->FileSize() * 0.000001f : 0);
 }
 
 uint32_t cISLogger::FileCount(uint32_t devSerialNo)
 {
-    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->FileCount() : 0);
+    auto device = DeviceLogBySerialNumber(devSerialNo);
+    return (device ? device->FileCount() : 0);
 }
 
 std::string cISLogger::GetNewFileName(uint32_t devSerialNo, uint32_t fileCount, const char *suffix)
 {
-    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->GetNewFileName(devSerialNo, fileCount, suffix) : "");
+    auto device = DeviceLogBySerialNumber(devSerialNo);
+    return (device ? device->GetNewFileName(devSerialNo, fileCount, suffix) : "");
 }
 
 int g_copyReadCount;

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -319,11 +319,6 @@ std::shared_ptr<cDeviceLog> cISLogger::registerDevice(uint16_t hdwId, uint32_t s
     return deviceLog;
 }
 
-bool cISLogger::DeviceLogBySerialNum(int serialNum)
-{   // Device is in the map
-    return m_devices.find(serialNum) != m_devices.end();
-}
-
 bool cISLogger::InitDevicesForWriting(std::vector<ISDevice>& devices)
 {
     // Remove all devices
@@ -658,7 +653,7 @@ void cISLogger::ShowParseErrors(bool show)
 
 uint64_t cISLogger::LogSize(uint32_t devSerialNo)
 {
-    return (DeviceLogBySerialNum(devSerialNo) ? m_devices[devSerialNo]->LogSize() : 0);
+    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->LogSize() : 0);
 }
 
 uint64_t cISLogger::LogSizeAll()
@@ -678,22 +673,22 @@ float cISLogger::LogSizeAllMB()
 
 float cISLogger::LogSizeMB(uint32_t devSerialNo)
 {
-    return (DeviceLogBySerialNum(devSerialNo) ? m_devices[devSerialNo]->LogSize() * 0.000001f : 0);
+    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->LogSize() * 0.000001f : 0);
 }
 
 float cISLogger::FileSizeMB(uint32_t devSerialNo)
 {
-    return (DeviceLogBySerialNum(devSerialNo) ? m_devices[devSerialNo]->FileSize() * 0.000001f : 0);
+    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->FileSize() * 0.000001f : 0);
 }
 
 uint32_t cISLogger::FileCount(uint32_t devSerialNo)
 {
-    return (DeviceLogBySerialNum(devSerialNo) ? m_devices[devSerialNo]->FileCount() : 0);
+    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->FileCount() : 0);
 }
 
 std::string cISLogger::GetNewFileName(uint32_t devSerialNo, uint32_t fileCount, const char *suffix)
 {
-    return (DeviceLogBySerialNum(devSerialNo) ? m_devices[devSerialNo]->GetNewFileName(devSerialNo, fileCount, suffix) : "");
+    return (DeviceLogBySerialNumber(devSerialNo) ? m_devices[devSerialNo]->GetNewFileName(devSerialNo, fileCount, suffix) : "");
 }
 
 int g_copyReadCount;

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -243,7 +243,6 @@ private:
     cISLogger(const cISLogger& copy); // Disable copy constructors
 #endif
 
-    bool DeviceLogBySerialNum(int serialNum);
     bool InitDevicesForWriting(std::vector<ISDevice>& devices);
     void Cleanup();
     void PrintProgress();


### PR DESCRIPTION
Delete cISLogger::DeviceLogBySerialNum() and use cISLogger::DeviceLogBySerialNumber() instead. 