### PR TITLE
SN-5908 - Add RTOS info to Grafana

### DIFF
--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -415,7 +415,7 @@ int ISDevice::SetEventFilter(int target, uint32_t msgTypeIdMask, uint8_t portMas
     else if (target == 2)
         event.msgTypeID = EVENT_MSG_TYPE_ID_ENA_GNSS2_FILTER;
     else
-        return;
+        return 0;
 
     memcpy(data, &event, DID_EVENT_HEADER_SIZE);
     memcpy((void*)(data+DID_EVENT_HEADER_SIZE), &filter, _MIN(sizeof(did_event_filter_t), EVENT_MAX_SIZE-DID_EVENT_HEADER_SIZE));

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -361,14 +361,14 @@ bool ISDevice::verifyFlashConfigUpload() {
     return success;
 }
 
-void ISDevice::SetSysCmd(const uint32_t command) {
+int ISDevice::SetSysCmd(const uint32_t command) {
     sysCmd.command = command;
     sysCmd.invCommand = ~command;
     // [C COMM INSTRUCTION]  Update the entire DID_SYS_CMD data set in the IMX.
-    comManagerSendData(port, &sysCmd, DID_SYS_CMD, sizeof(system_command_t), 0);
+    return comManagerSendData(port, &sysCmd, DID_SYS_CMD, sizeof(system_command_t), 0);
 }
 
-void ISDevice::SendNmea(const std::string& nmeaMsg)
+int ISDevice::SendNmea(const std::string& nmeaMsg)
 {
     uint8_t buf[1024] = {0};
     int n = 0;
@@ -376,7 +376,7 @@ void ISDevice::SendNmea(const std::string& nmeaMsg)
     memcpy(&buf[n], nmeaMsg.c_str(), nmeaMsg.size());
     n += nmeaMsg.size();
     nmea_sprint_footer((char*)buf, sizeof(buf), n);
-    SendRaw(buf, n);
+    return SendRaw(buf, n);
 }
 
 
@@ -389,7 +389,7 @@ void ISDevice::SendNmea(const std::string& nmeaMsg)
  *       port: Send in target COM port.
  *                If arg is < 0 default port will be used
 */
-void ISDevice::SetEventFilter(int target, uint32_t msgTypeIdMask, uint8_t portMask, int8_t priorityLevel)
+int ISDevice::SetEventFilter(int target, uint32_t msgTypeIdMask, uint8_t portMask, int8_t priorityLevel)
 {
     #define EVENT_MAX_SIZE (1024 + DID_EVENT_HEADER_SIZE)
     uint8_t data[EVENT_MAX_SIZE] = {0};
@@ -420,7 +420,7 @@ void ISDevice::SetEventFilter(int target, uint32_t msgTypeIdMask, uint8_t portMa
     memcpy(data, &event, DID_EVENT_HEADER_SIZE);
     memcpy((void*)(data+DID_EVENT_HEADER_SIZE), &filter, _MIN(sizeof(did_event_filter_t), EVENT_MAX_SIZE-DID_EVENT_HEADER_SIZE));
 
-    SendData(DID_EVENT, data, DID_EVENT_HEADER_SIZE + event.length, 0);
+    return SendData(DID_EVENT, data, DID_EVENT_HEADER_SIZE + event.length, 0);
 }
 
 // This method uses DID_SYS_PARAMS.flashCfgChecksum to determine if the local flash config is synchronized.
@@ -502,6 +502,7 @@ bool ISDevice::SetFlashConfig(nvm_flash_cfg_t& flashCfg_) {
 
     // Exclude updateIoConfig bit from flash config and keep track of it separately so it does not affect whether the platform config gets uploaded
     flashCfg.platformConfig &= ~PLATFORM_CFG_UPDATE_IO_CONFIG;
+    flashCfg.RTKCfgBits &= ~RTK_CFG_BITS_RTK_BASE_IS_IDENTICAL_TO_ROVER;
 
     flashCfg.checksum = flashChecksum32(&flashCfg, sizeof(nvm_flash_cfg_t));
 
@@ -528,8 +529,10 @@ bool ISDevice::SetFlashConfig(nvm_flash_cfg_t& flashCfg_) {
             }
 
             const data_info_t* fieldInfo = cISDataMappings::FieldInfoByOffset(DID_FLASH_CONFIG, offset);
-            printf("%s :: Sending DID_FLASH_CONFIG.%s (offset %d, size %d)\n", getIdAsString().c_str(), (fieldInfo ? fieldInfo->name.c_str() : "<UNKNOWN>"), offset, size);
-            int fail = comManagerSendData(port, head, DID_FLASH_CONFIG, size, offset);
+            std::string fieldName = (fieldInfo ? fieldInfo->name.c_str() : "<UNKNOWN>");
+            std::string fieldValue = "??"; // (fieldInfo ? cISDataMappings::DataToString(fieldInfo, )->);
+            printf("%s :: Sending DID_FLASH_CONFIG.%s = %s (offset %d, size %d)\n", getIdAsString().c_str(), fieldName.c_str(), fieldValue.c_str(), offset, size);
+            int fail = SendData(DID_FLASH_CONFIG, head, size, offset);
             failure = failure || fail;
             flashCfgUploadTimeMs = current_timeMs();        // non-zero indicates upload in progress
         }

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -92,15 +92,17 @@ public:
     bool BroadcastBinaryData(uint32_t dataId, int periodMultiple);
     void BroadcastBinaryDataRmcPreset(uint64_t rmcPreset, uint32_t rmcOptions) { comManagerGetDataRmc(port, rmcPreset, rmcOptions); }
     void GetData(eDataIDs dataId, uint16_t length=0, uint16_t offset=0, uint16_t period=0) { comManagerGetData(port, dataId, length, offset, period); }
-    void QueryDeviceInfo() { comManagerSendRaw(port, (uint8_t*)NMEA_CMD_QUERY_DEVICE_INFO, NMEA_CMD_SIZE); }
-    void SavePersistent() { comManagerSendRaw(port, (uint8_t*)NMEA_CMD_SAVE_PERSISTENT_MESSAGES_TO_FLASH, NMEA_CMD_SIZE); }
-    void SoftwareReset() { comManagerSendRaw(port, (uint8_t*)NMEA_CMD_SOFTWARE_RESET, NMEA_CMD_SIZE); }
-    void SendData(eDataIDs dataId, const uint8_t* data, uint32_t length, uint32_t offset = 0) { comManagerSendData(port, data, dataId, length, offset); }
-    void SendRaw(const uint8_t* data, uint32_t length) { comManagerSendRaw(port, data, length); }
-    void SendNmea(const std::string& nmeaMsg);
-    void SetEventFilter(int target, uint32_t msgTypeIdMask, uint8_t portMask, int8_t priorityLevel);
-    void SetSysCmd(const uint32_t command);
-    void StopBroadcasts(bool allPorts = false) { comManagerSendRaw(port, (uint8_t*)(allPorts ? NMEA_CMD_STOP_ALL_BROADCASTS_ALL_PORTS : NMEA_CMD_STOP_ALL_BROADCASTS_CUR_PORT), NMEA_CMD_SIZE); }
+    int SendData(eDataIDs dataId, const uint8_t* data, uint32_t length, uint32_t offset = 0) { return comManagerSendData(port, data, dataId, length, offset); }
+    int SendRaw(const uint8_t* data, uint32_t length) { return comManagerSendRaw(port, data, length); }
+
+    int SendNmea(const std::string& nmeaMsg);
+    int QueryDeviceInfo() { return SendRaw((uint8_t*)NMEA_CMD_QUERY_DEVICE_INFO, NMEA_CMD_SIZE); }
+    int SavePersistent() { return SendRaw((uint8_t*)NMEA_CMD_SAVE_PERSISTENT_MESSAGES_TO_FLASH, NMEA_CMD_SIZE); }
+    int SoftwareReset() { return SendRaw((uint8_t*)NMEA_CMD_SOFTWARE_RESET, NMEA_CMD_SIZE); }
+
+    int SetEventFilter(int target, uint32_t msgTypeIdMask, uint8_t portMask, int8_t priorityLevel);
+    int SetSysCmd(const uint32_t command);
+    int StopBroadcasts(bool allPorts = false) { return SendRaw((uint8_t*)(allPorts ? NMEA_CMD_STOP_ALL_BROADCASTS_ALL_PORTS : NMEA_CMD_STOP_ALL_BROADCASTS_CUR_PORT), NMEA_CMD_SIZE); }
 
     /**
      * @returns true is the device is indicated that a reset is required; this state SHOULD be acted on by resetting the device to ensure that it is operating as expected

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -479,7 +479,7 @@ static int serialPortClosePlatform(port_handle_t port)
 
 #endif
 
-    free(handle);
+    free(serialPort->handle);
     serialPort->handle = 0;
 
     return 1;


### PR DESCRIPTION
- Removed some RTK config bits from ISDevice flashConfig validation (which may be set programatically).
- ISDevice helper functions SendData(), SendRaw() and others which make port-write() calls return the port-write result for proper error checking.