### PR TITLE
SN5953 allow latest allantools in loginspector

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -136,7 +136,7 @@ setup(
     packages=find_packages(where='../inertialsense'),
 
     install_requires=[
-        'allantools<=2019.9',
+        'allantools',
         'matplotlib',
         'numpy',
         'pandas',


### PR DESCRIPTION
Removed requirement for Allantools to be below v. 2019