### PR TITLE
SN-6062: Refactor ISConstants.h::socket_t

### DIFF
--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -53,7 +53,7 @@ extern "C" {
     #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
     #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #elif defined(__APPLE__)
-    typedef is_socket_t     int
+    typedef int is_socket_t
 
     #define PLATFORM_IS_APPLE 1
     #define PLATFORM_IS_EMBEDDED 0
@@ -74,7 +74,7 @@ extern "C" {
 
     #define PLATFORM_IS_LINUX 1
     #define PLATFORM_IS_EMBEDDED 0
-    typedef is_socket_t     int
+    typedef int is_socket_t
     #define CPU_IS_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
     #define CPU_IS_BIG_ENDIAN (__BYTE_ORDER == __BIG_ENDIAN)
 #elif defined(__INERTIAL_SENSE_EVB_2__)

--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -53,7 +53,7 @@ extern "C" {
     #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
     #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #elif defined(__APPLE__)
-    typedef int is_socket_t
+    typedef int is_socket_t;
 
     #define PLATFORM_IS_APPLE 1
     #define PLATFORM_IS_EMBEDDED 0
@@ -74,7 +74,7 @@ extern "C" {
 
     #define PLATFORM_IS_LINUX 1
     #define PLATFORM_IS_EMBEDDED 0
-    typedef int is_socket_t
+    typedef int is_socket_t;
     #define CPU_IS_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
     #define CPU_IS_BIG_ENDIAN (__BYTE_ORDER == __BIG_ENDIAN)
 #elif defined(__INERTIAL_SENSE_EVB_2__)

--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -46,14 +46,14 @@ extern "C" {
     #include <winsock2.h>
     #include <WS2tcpip.h>
     #include <windows.h>
-    #define socket_t SOCKET
+    #define is_socket_t SOCKET
 
     #define CPU_IS_LITTLE_ENDIAN (REG_DWORD == REG_DWORD_LITTLE_ENDIAN)
     #define CPU_IS_BIG_ENDIAN (REG_DWORD == REG_DWORD_BIG_ENDIAN)
     #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
     #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #elif defined(__APPLE__)
-    #define socket_t int
+    typedef is_socket_t     int
 
     #define PLATFORM_IS_APPLE 1
     #define PLATFORM_IS_EMBEDDED 0
@@ -74,7 +74,7 @@ extern "C" {
 
     #define PLATFORM_IS_LINUX 1
     #define PLATFORM_IS_EMBEDDED 0
-    #define socket_t int
+    typedef is_socket_t     int
     #define CPU_IS_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
     #define CPU_IS_BIG_ENDIAN (__BYTE_ORDER == __BIG_ENDIAN)
 #elif defined(__INERTIAL_SENSE_EVB_2__)

--- a/src/ISTcpClient.cpp
+++ b/src/ISTcpClient.cpp
@@ -75,7 +75,7 @@ void ISSocketFrameworkShutdown()
 
 }
 
-int ISSocketCanWrite(socket_t socket, int timeoutMilliseconds)
+int ISSocketCanWrite(is_socket_t socket, int timeoutMilliseconds)
 {
     struct timeval tv = { timeoutMilliseconds / 1000, (timeoutMilliseconds % 1000) * 1000 };
     fd_set ws;
@@ -85,7 +85,7 @@ int ISSocketCanWrite(socket_t socket, int timeoutMilliseconds)
     return (numberOfSocketsThatCanWrite > 0);
 }
 
-int ISSocketCanRead(socket_t socket, int timeoutMilliseconds)
+int ISSocketCanRead(is_socket_t socket, int timeoutMilliseconds)
 {
 	struct timeval tv = { timeoutMilliseconds / 1000, (timeoutMilliseconds % 1000) * 1000 };
 	fd_set rs;
@@ -95,7 +95,7 @@ int ISSocketCanRead(socket_t socket, int timeoutMilliseconds)
 	return (numberOfSocketsThatCanRead > 0);
 }
 
-int ISSocketWrite(socket_t socket, const uint8_t* data, int dataLength)
+int ISSocketWrite(is_socket_t socket, const uint8_t* data, int dataLength)
 {
     int totalWriteCount = 0;
     int writeCount;
@@ -122,7 +122,7 @@ int ISSocketWrite(socket_t socket, const uint8_t* data, int dataLength)
     return totalWriteCount;
 }
 
-int ISSocketRead(socket_t socket, uint8_t* data, int dataLength)
+int ISSocketRead(is_socket_t socket, uint8_t* data, int dataLength)
 {
 	int count = recv(socket, (char*)data, dataLength, 0);
 	if (count < 0)
@@ -149,7 +149,7 @@ int ISSocketRead(socket_t socket, uint8_t* data, int dataLength)
 	return count;
 }
 
-int ISSocketSetBlocking(socket_t socket, bool blocking)
+int ISSocketSetBlocking(is_socket_t socket, bool blocking)
 {
 
 #if PLATFORM_IS_WINDOWS
@@ -171,7 +171,7 @@ int ISSocketSetBlocking(socket_t socket, bool blocking)
 
 }
 
-int ISSocketSetReadTimeout(socket_t socket, int timeoutMilliseconds)
+int ISSocketSetReadTimeout(is_socket_t socket, int timeoutMilliseconds)
 {
 
 #if PLATFORM_IS_WINDOWS
@@ -190,7 +190,7 @@ int ISSocketSetReadTimeout(socket_t socket, int timeoutMilliseconds)
 
 }
 
-int ISSocketClose(socket_t& socket)
+int ISSocketClose(is_socket_t& socket)
 {
 	int status = 0;
 	if (socket != 0)

--- a/src/ISTcpClient.h
+++ b/src/ISTcpClient.h
@@ -101,7 +101,7 @@ public:
 private:
 	cISTcpClient(const cISTcpClient& copy); // Disable copy constructor
 
-	socket_t m_socket;
+	is_socket_t m_socket;
 	std::string m_host;
 	int m_port;
 	bool m_blocking;
@@ -123,7 +123,7 @@ void ISSocketFrameworkShutdown();
 * @param timeoutMilliseconds the number of milliseconds to wait before aborting
 * @return non-zero if the socket can be written to, otherwise zero
 */
-int ISSocketCanWrite(socket_t socket, int timeoutMilliseconds = IS_SOCKET_DEFAULT_TIMEOUT_MS);
+int ISSocketCanWrite(is_socket_t socket, int timeoutMilliseconds = IS_SOCKET_DEFAULT_TIMEOUT_MS);
 
 /**
 * Determines if a socket can be read from
@@ -131,7 +131,7 @@ int ISSocketCanWrite(socket_t socket, int timeoutMilliseconds = IS_SOCKET_DEFAUL
 * @param timeoutMilliseconds the number of milliseconds to wait before aborting
 * @return non-zero if the socket can be read from, otherwise zero
 */
-int ISSocketCanRead(socket_t socket, int timeoutMilliseconds = IS_SOCKET_DEFAULT_TIMEOUT_MS);
+int ISSocketCanRead(is_socket_t socket, int timeoutMilliseconds = IS_SOCKET_DEFAULT_TIMEOUT_MS);
 
 /**
 * Write data to a socket
@@ -140,7 +140,7 @@ int ISSocketCanRead(socket_t socket, int timeoutMilliseconds = IS_SOCKET_DEFAULT
 * @param dataLength the number of bytes in data
 * @return the number of bytes written or less than 0 if error, in which case the socket is probably disconnected
 */
-int ISSocketWrite(socket_t socket, const uint8_t* data, int dataLength);
+int ISSocketWrite(is_socket_t socket, const uint8_t* data, int dataLength);
 
 /**
 * Read data from a socket
@@ -149,7 +149,7 @@ int ISSocketWrite(socket_t socket, const uint8_t* data, int dataLength);
 * @param dataLength the number of bytes available in data
 * @return the number of bytes read or less than 0 if error, in which case the socket is probably disconnected
 */
-int ISSocketRead(socket_t socket, uint8_t* data, int dataLength);
+int ISSocketRead(is_socket_t socket, uint8_t* data, int dataLength);
 
 /**
 * Sets whether a socket is blocking. When reading, a blocking socket waits for the specified amount of data until the timeout is reached, a non-blocking socket returns immediately with the number of bytes read.
@@ -157,7 +157,7 @@ int ISSocketRead(socket_t socket, uint8_t* data, int dataLength);
 * @param blocking whether the socket is blocking
 * @return 0 if success otherwise an error code
 */
-int ISSocketSetBlocking(socket_t socket, bool blocking);
+int ISSocketSetBlocking(is_socket_t socket, bool blocking);
 
 /**
 * Set a read timeout on a socket. This function is only useful for blocking sockets, where it is highly recommended.
@@ -165,13 +165,13 @@ int ISSocketSetBlocking(socket_t socket, bool blocking);
 * @param timeoutMilliseconds the timeout in milliseconds
 * @return 0 if success otherwise an error code
 */
-int ISSocketSetReadTimeout(socket_t socket, int timeoutMilliseconds);
+int ISSocketSetReadTimeout(is_socket_t socket, int timeoutMilliseconds);
 
 /**
 * Close a socket and zero it out
 * @param socket the socket to close, this will be zeroed out
 * @return 0 if success otherwise an error code
 */
-int ISSocketClose(socket_t& socket);
+int ISSocketClose(is_socket_t& socket);
 
 #endif // __ISTCPCLIENT__H__

--- a/src/ISTcpServer.cpp
+++ b/src/ISTcpServer.cpp
@@ -134,7 +134,7 @@ void cISTcpServer::Update()
 		{
 			m_delegate->OnClientConnecting(this);
 		}
-		socket_t socket = accept(m_socket, NULLPTR, NULLPTR);
+		is_socket_t socket = accept(m_socket, NULLPTR, NULLPTR);
 		if (socket != 0)
 		{
 			ISSocketSetBlocking(socket, false);

--- a/src/ISTcpServer.h
+++ b/src/ISTcpServer.h
@@ -31,7 +31,7 @@ protected:
 	* @param data the data received
 	* @param dataLength the number of bytes received
 	*/
-    virtual void OnClientDataReceived(cISTcpServer* server, socket_t socket, uint8_t* data, int dataLength)
+    virtual void OnClientDataReceived(cISTcpServer* server, is_socket_t socket, uint8_t* data, int dataLength)
     {
 		(void)server;
         (void)socket;
@@ -53,7 +53,7 @@ protected:
 	* @param server the server the client connected to
 	* @param socket the connected socket
 	*/
-	virtual void OnClientConnected(cISTcpServer* server, socket_t socket)
+	virtual void OnClientConnected(cISTcpServer* server, is_socket_t socket)
 	{
 		(void)server;
 		(void)socket;
@@ -73,7 +73,7 @@ protected:
 	* @param server the server the client disconnected from
 	* @param socket the socket that disconnected
 	*/
-    virtual void OnClientDisconnected(cISTcpServer* server, socket_t socket)
+    virtual void OnClientDisconnected(cISTcpServer* server, is_socket_t socket)
     {
 		(void)server;
         (void)socket;
@@ -143,8 +143,8 @@ public:
 private:
 	cISTcpServer(const cISTcpServer& copy); // Disable copy constructor
 
-	socket_t m_socket;
-	std::vector<socket_t> m_clients;
+	is_socket_t m_socket;
+	std::vector<is_socket_t> m_clients;
 	std::string m_ipAddress;
 	int32_t m_port;
 	iISTcpServerDelegate* m_delegate;

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1359,7 +1359,7 @@ void InertialSense::OnClientConnecting(cISTcpServer* server)
     // cout << endl << "Client connecting..." << endl;
 }
 
-void InertialSense::OnClientConnected(cISTcpServer* server, socket_t socket)
+void InertialSense::OnClientConnected(cISTcpServer* server, is_socket_t socket)
 {
     // cout << endl << "Client connected: " << (int)socket << endl;
     m_clientConnectionsCurrent++;
@@ -1371,7 +1371,7 @@ void InertialSense::OnClientConnectFailed(cISTcpServer* server)
     // cout << endl << "Client connection failed!" << endl;
 }
 
-void InertialSense::OnClientDisconnected(cISTcpServer* server, socket_t socket)
+void InertialSense::OnClientDisconnected(cISTcpServer* server, is_socket_t socket)
 {
     // cout << endl << "Client disconnected: " << (int)socket << endl;
     m_clientConnectionsCurrent--;

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -606,9 +606,9 @@ public:
 protected:
     bool OnClientPacketReceived(const uint8_t* data, uint32_t dataLength);
     void OnClientConnecting(cISTcpServer* server) OVERRIDE;
-    void OnClientConnected(cISTcpServer* server, socket_t socket) OVERRIDE;
+    void OnClientConnected(cISTcpServer* server, is_socket_t socket) OVERRIDE;
     void OnClientConnectFailed(cISTcpServer* server) OVERRIDE;
-    void OnClientDisconnected(cISTcpServer* server, socket_t socket) OVERRIDE;
+    void OnClientDisconnected(cISTcpServer* server, is_socket_t socket) OVERRIDE;
 
 private:
     uint32_t m_timeMs;


### PR DESCRIPTION
Refactor ISConstants.h::socket_t to is_socket_t to avoid conflict with external definition.