### PR TITLE
SN-5988 - Improve EvalTool performance

### DIFF
--- a/src/serialPort.c
+++ b/src/serialPort.c
@@ -107,6 +107,23 @@ int serialPortIsOpen(port_handle_t port)
     return (serialPort->pfnIsOpen ? serialPort->pfnIsOpen(port) : 1);
 }
 
+int serialPortIsOpenQuick(port_handle_t port)
+{
+    serial_port_t* serialPort = (serial_port_t*)port;
+    if ((serialPort == 0) || (serialPort->pfnIsOpen == 0))
+    {
+        if (serialPort && serialPort->pfnError) {
+            serialPort->pfnError(port, -1, "port::IsOpen is not supported on this port.");
+        }
+        return 0;
+    }
+
+    if ((serialPort->handle != NULL) && (serialPort->errorCode == 0))
+        return 1;
+
+    return (serialPort->pfnIsOpen ? serialPort->pfnIsOpen(port) : 1);
+}
+
 int serialPortClose(port_handle_t port)
 {
     serial_port_t* serialPort = (serial_port_t*)port;

--- a/src/serialPort.h
+++ b/src/serialPort.h
@@ -202,6 +202,19 @@ int serialPortOpenRetry(port_handle_t port, const char* portName, int baudRate, 
 int serialPortIsOpen(port_handle_t port);
 
 /**
+ * check if the port is open, but avoids an expensive OS/kernel call is possible.
+ * If the internal handle is NOT null, and there are recent errors on the port
+ * this function will return true, indicating that the port is open.  However,
+ * it should be noted that the port may still be closed by the OS or another
+ * mechanism which may not be reflected in the local state, which could cause
+ * this to report incorrectly and then leading to a future error state when
+ * operating on the closed port.
+ * @param port
+ * @return 1 if open, 0 if not open
+ */
+int serialPortIsOpenQuick(port_handle_t port);
+
+/**
  * close the serial port - this object can be re-used by calling open again
  * @param port
  * @return 1 if closed, 0 if the port was not closed


### PR DESCRIPTION
Initial efforts to refactor EvalTool's Devices and Parcels to improve performance.
Added a serialPortIsOpenQuick() to perform "app-level" check if a serial port was open (minimal kernel/system calls).