### PR TITLE
SN-6066 zda skips 1s

### DIFF
--- a/python/supernpp/supernpp.py
+++ b/python/supernpp/supernpp.py
@@ -7,6 +7,7 @@ from os.path import normpath, basename
 from threading import Thread
 import time
 from pathlib import Path
+import shutil
 import sys
 import threading
 
@@ -32,6 +33,7 @@ class SuperNPP():
         print("  Directory: ", self.directory)
         print("  config_serials:", self.config_serials)
         print("  startMode: ", self.startMode)
+        self.remove_post_processed_dirs(self.directory)
         self.findLogFiles(self.directory)
             
     def getSerialNumbers(self):
@@ -57,6 +59,23 @@ class SuperNPP():
             if "post_processed" in subdir:
                 continue
             self.findLogFiles(subdir2)
+
+    def remove_post_processed_dirs(self, base_dir):
+        """
+        Recursively remove all directories named 'post_processed' in the specified base directory.
+
+        Args:
+            base_dir (str): The path to the base directory to search within.
+        """
+        for root, dirs, files in os.walk(base_dir, topdown=False):
+            for dir_name in dirs:
+                if dir_name == "post_processed":
+                    dir_path = os.path.join(root, dir_name)
+                    try:
+                        shutil.rmtree(dir_path)
+                        print(f"Removed directory: {dir_path}")
+                    except Exception as e:
+                        print(f"Failed to remove {dir_path}: {e}")
 
     def print_file_contents(self, file_path):
         with open(file_path, 'r') as file:

--- a/scripts/build_all.py
+++ b/scripts/build_all.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import build_manager
 import build_log_inspector
+import sys
 
 sdk_dir = Path(__file__).resolve().parent.parent
 bm = build_manager.BuildTestManager()
@@ -30,4 +31,5 @@ bm.test_exec("IS-SDK Unit Tests",    sdk_dir / "tests", "IS-SDK_unit-tests")
 
 bm.print_summary()
 
-
+# Return error code
+sys.exit(bm.result)

--- a/scripts/build_manager.py
+++ b/scripts/build_manager.py
@@ -27,6 +27,7 @@ class BuildTestManager:
         self.run_build = True
         self.run_clean = False
         self.run_test = False
+        self.result = 0
 
         # Parse command-line arguments
         self.args = sys.argv[1:]
@@ -165,6 +166,8 @@ class BuildTestManager:
         self.build_header(project_name)
         result = callback(self.args)
         self.build_footer(result)
+        if result:
+            self.result = result
         return result
     
     def test_callback(self, project_name, callback):
@@ -173,6 +176,8 @@ class BuildTestManager:
             self.test_header(project_name)
             result = callback()
             self.test_footer(result)
+        if result:
+            self.result = result
         return result
 
     def build_script(self, project_name, script_path, args=[]):
@@ -195,6 +200,8 @@ class BuildTestManager:
             result = e.returncode
             
         self.build_footer(result)
+        if result:
+            self.result = result
         return result
 
     def build_cmake(self, project_name, project_dir):
@@ -203,6 +210,8 @@ class BuildTestManager:
         self.build_header(project_name)
         result = self.static_build_cmake(project_name, project_dir, self.build_type, self.run_clean)
         self.build_footer(result)
+        if result:
+            self.result = result
         return result
 
     @staticmethod
@@ -270,6 +279,8 @@ class BuildTestManager:
             print(f"Error building {test_name}!")
             result = e.returncode
         self.test_footer(result)
+        if result:
+            self.result = result
         return result
     
     def clean_rm(self, path):

--- a/scripts/install_python_dependencies.sh
+++ b/scripts/install_python_dependencies.sh
@@ -2,4 +2,4 @@
 cd "$(dirname "$(realpath $0)")" > /dev/null
 source lib/activate_python_venv.sh
 
-python3 -m pip install gitpython requests ruamel.yaml semver 
+python3 -m pip install gitpython pybind11 requests ruamel.yaml semver setuptools

--- a/scripts/windows/build_tools.cmd
+++ b/scripts/windows/build_tools.cmd
@@ -27,8 +27,10 @@
 	pause
 
 :found_msbuild_executable
-
 	:: Locate nmake.exe
+	set NMAKE_EXECUTABLE="C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.42.34433\bin\Hostx64\x64\nmake.exe"
+    if exist %NMAKE_EXECUTABLE% goto found_nmake_executable
+
 	set NMAKE_EXECUTABLE="C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.41.34120\bin\Hostx64\x64\nmake.exe"
     if exist %NMAKE_EXECUTABLE% goto found_nmake_executable
 
@@ -48,6 +50,9 @@
     if exist %NMAKE_EXECUTABLE% goto found_nmake_executable
 
 	set NMAKE_EXECUTABLE="C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.32.31326\bin\Hostx64\x64\nmake.exe"
+    if exist %NMAKE_EXECUTABLE% goto found_nmake_executable
+
+	set NMAKE_EXECUTABLE="C:\Program Files\Microsoft Visual Studio\2022\VC\Tools\MSVC\14.42.34433\bin\Hostx64\x64\nmake.exe"
     if exist %NMAKE_EXECUTABLE% goto found_nmake_executable
 
 	set NMAKE_EXECUTABLE="C:\Program Files\Microsoft Visual Studio\2022\VC\Tools\MSVC\14.41.34120\bin\Hostx64\x64\nmake.exe"
@@ -77,7 +82,7 @@
 :found_nmake_executable
 
     REM set MSBUILD_OPTIONS=/maxcpucount:7 /p:MP=7 /t:Build /p:Configuration=Release /p:Platform=x64
-    set MSBUILD_OPTIONS=/maxcpucount:7 /p:MP=7 /t:Build /p:Configuration=Release
+    set MSBUILD_OPTIONS=/maxcpucount:7 /p:MP=7 /t:Build /p:Configuration=Release /p:std=c++17
 
 	:: Setup terminal for multi-colored text
 	for /F "tokens=1,2 delims=#" %%a in ('"prompt #$H#$E# & echo on & for %%b in (1) do rem"') do (

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -769,7 +769,7 @@ static void PopulateMapEvbFlashCfg(data_set_t data_set[DID_COUNT], uint32_t did)
 static void PopulateMapDebugArray(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<debug_array_t> mapper(data_set, did);
-    mapper.AddArray("i", &debug_array_t::i, DATA_TYPE_UINT32, DEBUG_I_ARRAY_SIZE);
+    mapper.AddArray("i", &debug_array_t::i, DATA_TYPE_INT32, DEBUG_I_ARRAY_SIZE);
     mapper.AddArray("f", &debug_array_t::f, DATA_TYPE_F32, DEBUG_F_ARRAY_SIZE, "", "", DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddArray("lf", &debug_array_t::lf, DATA_TYPE_F64, DEBUG_LF_ARRAY_SIZE, "", "", DATA_FLAGS_FIXED_DECIMAL_9);
 }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -957,6 +957,7 @@ static void PopulateMapGpsRtkMisc(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<gps_rtk_misc_t> mapper(data_set, did);
     mapper.AddMember("timeOfWeekMs", &gps_rtk_misc_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddMember("timeToFirstFixMs", &gps_rtk_misc_t::timeToFirstFixMs, DATA_TYPE_UINT32, "ms", "Time to first RTK fix", DATA_FLAGS_READ_ONLY);
     mapper.AddArray("accuracyPos", &gps_rtk_misc_t::accuracyPos, DATA_TYPE_F32, 3, "m", "Accuracy in meters north, east, up (standard deviation)", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddArray("accuracyCov", &gps_rtk_misc_t::accuracyCov, DATA_TYPE_F32, 3, "m", "Absolute value of means square root of estimated covariance NE, EU, UN", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("arThreshold", &gps_rtk_misc_t::arThreshold, DATA_TYPE_F32, "", "Ambiguity resolution threshold for validation", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
@@ -997,7 +998,6 @@ static void PopulateMapGpsRtkMisc(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("ionUtcAlmCount", &gps_rtk_misc_t::ionUtcAlmCount, DATA_TYPE_UINT32, "int", "Ion model / utc / alm element counter", DATA_FLAGS_READ_ONLY);
 
     mapper.AddMember("correctionChecksumFailures", &gps_rtk_misc_t::correctionChecksumFailures, DATA_TYPE_UINT32, "int", "Correction input checksum failures", DATA_FLAGS_READ_ONLY);
-    mapper.AddMember("timeToFirstFixMs", &gps_rtk_misc_t::timeToFirstFixMs, DATA_TYPE_UINT32, "ms", "Time to first RTK fix", DATA_FLAGS_READ_ONLY);
 }
 
 static void PopulateMapGpsRaw(data_set_t data_set[DID_COUNT], uint32_t did)

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -769,56 +769,59 @@ void nmea_GPSTimeToUTCTimeMsPrecision_ZDA_debug(char* a, int aSize, int &offset,
 
     // Check for irregular update timing
     int32_t cpuDtMs = cpuMs - lastCpuMs;
-    g_debug.f[5] += (float)cpuDtMs;
     if (cpuDtMs < C_MILLISECONDS_PER_WEEK/2)
     {   // No time wrap
         if (cpuDtMs < 750)
         {   // Less than 1s
             nmea_report_fault(1);
+            g_debug.f[5] = (float)cpuDtMs;
         }
         if (cpuDtMs > 1250)
         {   // More than 1s
             nmea_report_fault(-1);
+            g_debug.f[5] = (float)cpuDtMs;
         }
     }
 
     // Check for skip in ZDA time
     int32_t utcDtMs = utcMs - lastUtcMs;
-    g_debug.f[6] += utcDtMs;
     if (t.hour >= lastUtcHour)
     {   // No time wrap
         if (utcDtMs > 1000)
         {   // Skip forward
             nmea_report_fault(2);
+            g_debug.f[6] = utcDtMs;
         }
         if (utcDtMs < 1000)
         {   // Skip backward
             nmea_report_fault(-2);
+            g_debug.f[6] = utcDtMs;
         }
     }
 
     // Check for skip in GPS time of week
     int32_t gpsDtMs = gpsMs - lastGpsMs;
-    g_debug.f[7] += (float)gpsDtMs;
     if (lastWeek == pos.week)
     {   // No time wrap
         if (gpsDtMs > 1000)
         {   // Skip forward
             nmea_report_fault(3);
+            g_debug.f[7] = (float)gpsDtMs;
         }
         if (gpsDtMs < 1000)
         {   // Skip backward
             nmea_report_fault(-3);
+            g_debug.f[7] = (float)gpsDtMs;
         }
     }
 
     // Ensure time increments linearly
     int32_t ddtMs = utcDtMs - cpuDtMs;
-    g_debug.i[3] += ddtMs;
     if ((cpuDtMs < C_MILLISECONDS_PER_WEEK/2) &&
         (t.hour >= lastUtcHour))
     {   // No time wrap
         utcOffsetSec = millisecondsToSeconds(ddtMs);
+        g_debug.i[3] = ddtMs;
         g_debug.i[4] = utcOffsetSec;
         if (_ABS(utcOffsetSec) > 2)
         {   // Offset exceeded limit

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -710,7 +710,7 @@ void nmea_GPSTimeToUTCTimeMsPrecision(char* a, int aSize, int &offset, gps_pos_t
 }
 
 // TODO: Remove after ZDA issue is resolved.
-#if defined(SDK_UNIT_TEST)
+#if defined(IMX_5) || defined(SDK_UNIT_TEST)
 extern uint32_t g_time_msec;
 extern sys_params_t g_sysParams;
 extern debug_array_t g_debug;
@@ -723,11 +723,13 @@ int millisecondsToSeconds(int milliseconds)
 
 void nmea_report_fault(int fault_code)
 {
+#if defined(IMX_5) || defined(SDK_UNIT_TEST)
     g_sysParams.genFaultCode |= GFC_GNSS_TIME_FAULT;
 #if PLATFORM_IS_EMBEDDED
     g_gnssTimeFaultTimeMs = g_timeMs;
 #endif
     g_debug.i[6] |= 1<<fault_code;
+#endif
 }
 
 // TODO: Remove after ZDA issue is resolved.
@@ -742,10 +744,10 @@ void nmea_GPSTimeToUTCTimeMsPrecision_ZDA_debug(char* a, int aSize, int &offset,
     ///////////////////////////////////////////////////////////////////////
     // TODO: (WHJ) ZDA debug.  Remove after ZDA time skip issue is resolved. (SN-6066)
 
-#if defined(SDK_UNIT_TEST)
-    int32_t cpuMs = (int32_t)g_time_msec;
-#else
+#if defined(IMX_5)
     int32_t cpuMs = (int32_t)time_msec();
+#else
+    int32_t cpuMs = (int32_t)g_time_msec;
 #endif
     int32_t utcMs = 
         t.hour*C_MILLISECONDS_PER_HOUR + 

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -8,6 +8,11 @@
 #include "data_sets.h"
 #include "util/md5.h"
 
+#if defined(IMX_5)
+#include "drivers/d_time.h"
+#include "globals.h"
+#endif
+
 static int s_protocol_version = 0;
 static uint8_t s_gnssId = SAT_SV_GNSS_ID_GNSS;
 
@@ -704,6 +709,165 @@ void nmea_GPSTimeToUTCTimeMsPrecision(char* a, int aSize, int &offset, gps_pos_t
     offset += ssnprintf(a, aSize, ",%02u%02u%02u.%03u", t.hour, t.minute, t.second, t.millisecond);
 }
 
+// TODO: Remove after ZDA issue is resolved.
+#if defined(SDK_UNIT_TEST)
+extern uint32_t g_time_msec;
+extern sys_params_t g_sysParams;
+extern debug_array_t g_debug;
+#endif
+
+int millisecondsToSeconds(int milliseconds) 
+{
+    return (milliseconds + 500) / 1000;
+}
+
+void nmea_report_fault(int fault_code)
+{
+    g_sysParams.genFaultCode |= GFC_GNSS_TIME_FAULT;
+#if PLATFORM_IS_EMBEDDED
+    g_gnssTimeFaultTimeMs = g_timeMs;
+#endif
+    g_debug.i[6] |= 1<<fault_code;
+}
+
+// TODO: Remove after ZDA issue is resolved.
+void nmea_GPSTimeToUTCTimeMsPrecision_ZDA_debug(char* a, int aSize, int &offset, gps_pos_t &pos)
+{
+    aSize -= offset;
+    a += offset;
+    utc_time_t t;
+    gpsTowMsToUtcTime(pos.timeOfWeekMs, pos.leapS, &t);
+
+#if defined(IMX_5) || defined(SDK_UNIT_TEST)
+    ///////////////////////////////////////////////////////////////////////
+    // TODO: (WHJ) ZDA debug.  Remove after ZDA time skip issue is resolved. (SN-6066)
+
+#if defined(SDK_UNIT_TEST)
+    int32_t cpuMs = (int32_t)g_time_msec;
+#else
+    int32_t cpuMs = (int32_t)time_msec();
+#endif
+    int32_t utcMs = 
+        t.hour*C_MILLISECONDS_PER_HOUR + 
+        t.minute*C_MILLISECONDS_PER_MINUTE + 
+        t.second*C_MILLISECONDS_PER_SECOND + 
+        t.millisecond;
+    int32_t gpsMs = (int32_t)pos.timeOfWeekMs;
+
+    g_debug.i[0] = cpuMs;
+    g_debug.i[1] = utcMs;
+    g_debug.i[2] = gpsMs;
+
+    static int32_t lastCpuMs = cpuMs - 1000;
+    static int32_t lastUtcMs = utcMs - 1000;
+    static int lastUtcHour = t.hour;
+    static int lastGpsMs = gpsMs - 1000;
+    static uint32_t lastWeek = pos.week;
+    static int32_t utcOffsetSec = 0;
+
+    // Check for irregular update timing
+    int32_t cpuDtMs = cpuMs - lastCpuMs;
+    g_debug.f[5] += (float)cpuDtMs;
+    if (cpuDtMs < C_MILLISECONDS_PER_WEEK/2)
+    {   // No time wrap
+        if (cpuDtMs < 750)
+        {   // Less than 1s
+            nmea_report_fault(1);
+        }
+        if (cpuDtMs > 1250)
+        {   // More than 1s
+            nmea_report_fault(-1);
+        }
+    }
+
+    // Check for skip in ZDA time
+    int32_t utcDtMs = utcMs - lastUtcMs;
+    g_debug.f[6] += utcDtMs;
+    if (t.hour >= lastUtcHour)
+    {   // No time wrap
+        if (utcDtMs > 1000)
+        {   // Skip forward
+            nmea_report_fault(2);
+        }
+        if (utcDtMs < 1000)
+        {   // Skip backward
+            nmea_report_fault(-2);
+        }
+    }
+
+    // Check for skip in GPS time of week
+    int32_t gpsDtMs = gpsMs - lastGpsMs;
+    g_debug.f[7] += (float)gpsDtMs;
+    if (lastWeek == pos.week)
+    {   // No time wrap
+        if (gpsDtMs > 1000)
+        {   // Skip forward
+            nmea_report_fault(3);
+        }
+        if (gpsDtMs < 1000)
+        {   // Skip backward
+            nmea_report_fault(-3);
+        }
+    }
+
+    // Ensure time increments linearly
+    int32_t ddtMs = utcDtMs - cpuDtMs;
+    g_debug.i[3] += ddtMs;
+    if ((cpuDtMs < C_MILLISECONDS_PER_WEEK/2) &&
+        (t.hour >= lastUtcHour))
+    {   // No time wrap
+        utcOffsetSec = millisecondsToSeconds(ddtMs);
+        g_debug.i[4] = utcOffsetSec;
+        if (_ABS(utcOffsetSec) > 2)
+        {   // Offset exceeded limit
+            utcOffsetSec = 0;
+            nmea_report_fault(5);
+        }
+        g_debug.i[5] = utcOffsetSec;
+    }
+
+    // Update history
+    lastCpuMs = cpuMs;
+    lastUtcMs = utcMs;
+    lastUtcHour = t.hour;
+    lastGpsMs = gpsMs;            
+    lastWeek = pos.week;
+
+    // Apply correction offset
+    if (utcOffsetSec)
+    {
+        nmea_report_fault(4);
+
+        t.second += utcOffsetSec;
+        if (t.second >= 60)
+        {   // Wrap 
+            t.second -= 60;
+            t.minute++;
+            if (t.minute >= 60)
+            {   // Wrap
+                t.minute -= 60;
+                t.hour++;
+            }
+        }
+        if (t.second < 0)
+        {   // Wrap 
+            t.second += 60;
+            t.minute--;
+            if (t.minute < 0)
+            {   // Wrap
+                t.minute += 60;
+                t.hour--;
+            }
+        }
+    }
+
+    // TODO: (WHJ) End of debug section
+    ///////////////////////////////////////////////////////////////////////
+#endif
+
+    offset += ssnprintf(a, aSize, ",%02u%02u%02u.%03u", t.hour, t.minute, t.second, t.millisecond);
+}
+
 static void nmea_GPSDateOfLastFix(char* a, int aSize, int &offset, gps_pos_t &pos)
 {
     aSize -= offset;
@@ -943,7 +1107,7 @@ int nmea_zda(char a[], const int aSize, gps_pos_t &pos)
 
     int n = nmea_talker(a, aSize);
     nmea_sprint(a, aSize, n, "ZDA");
-    nmea_GPSTimeToUTCTimeMsPrecision(a, aSize, n, pos);								// 1
+    nmea_GPSTimeToUTCTimeMsPrecision_ZDA_debug(a, aSize, n, pos);								// 1
     nmea_GPSDateOfLastFixCSV(a, aSize, n, pos);										// 2,3,4
     nmea_sprint(a, aSize, n, ",00,00");												// 5,6
     

--- a/src/protocol_nmea.h
+++ b/src/protocol_nmea.h
@@ -41,6 +41,7 @@ char *ASCII_to_vec3d(double vec[], char *ptr);
 double ddmm2deg(double ddmm);
 void set_gpsPos_status_mask(uint32_t *status, uint32_t state, uint32_t mask);
 void nmea_GPSTimeToUTCTimeMsPrecision(char* a, int aSize, int &offset, gps_pos_t &pos);
+void nmea_GPSTimeToUTCTimeMsPrecision_ZDA_debug(char* a, int aSize, int &offset, gps_pos_t &pos);
 int ssnprintf(char buf[], int bufSize, const char *fmt, ...);
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/time_conversion.h
+++ b/src/time_conversion.h
@@ -79,7 +79,7 @@ void stdUtcDateTimeToGpsTime(const std::tm &utcTime, int leapSeconds, uint32_t &
  * @param gpsTowMs output GPS time of week in milliseconds 
  * @param gpsWeek output GPS week number
  */
-void UtcDateTimeToGpsTime(const double *datetime, int leapSeconds, uint32_t &gpsTowMs, uint32_t &gpsWeek);
+void UtcDateTimeToGpsTime(const double datetime[6], int leapSeconds, uint32_t &gpsTowMs, uint32_t &gpsWeek);
 
 /** Convert Julian Date to calendar date. */
 void julianToDate(double julian, uint32_t* year, uint32_t* month, uint32_t* day, uint32_t* hour, uint32_t* minute, uint32_t* second, uint32_t* millisecond);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,8 @@ endif()
 
 project(IS-SDK_unit-tests)
 
+add_definitions(-DSDK_UNIT_TEST)
+
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 include(${IS_SDK_DIR}/include_is_sdk_find_library.cmake)
 

--- a/tests/test_data_utils.cpp
+++ b/tests/test_data_utils.cpp
@@ -86,7 +86,19 @@ void CurrentGpsTimeMs(uint32_t &gpsTimeOfWeekMs, uint32_t &gpsWeek)
     gpsTimeOfWeekMs *= 1000;
 }
 
-void PrintUtcTime(std::tm &utcTime, uint32_t milliseconds)
+void PrintUtcDateTime(utc_date_t &utcDate, utc_time_t &utcTime)
+{
+    printf( "UTC Time: %04d-%02d-%02d %02d:%02d:%02d.%03d\n", 
+        utcDate.year + 1900,    // year is since 1900
+        utcDate.month,          // month is since January (0-11)
+        utcDate.day,
+        utcTime.hour,
+        utcTime.minute,
+        utcTime.second,
+        utcTime.millisecond );
+}
+
+void PrintUtcStdTm(std::tm &utcTime, uint32_t milliseconds)
 {
     printf( "UTC Time: %04d-%02d-%02d %02d:%02d:%02d.%03d\n", 
         utcTime.tm_year + 1900,   // tm_year is year since 1900

--- a/tests/test_data_utils.cpp
+++ b/tests/test_data_utils.cpp
@@ -13,7 +13,6 @@
 #include "ISFileManager.h"
 #include "protocol_nmea.h"
 #include "test_data_utils.h"
-#include "time_conversion.h"
 
 #define MIN_VALUE 		-1000
 #define MAX_VALUE 		 1000

--- a/tests/test_data_utils.h
+++ b/tests/test_data_utils.h
@@ -12,6 +12,7 @@
 #include "data_sets.h"
 #include "ISComm.h"
 #include "ISLogger.h"
+#include "time_conversion.h"
 
 typedef struct
 {

--- a/tests/test_data_utils.h
+++ b/tests/test_data_utils.h
@@ -32,7 +32,8 @@ enum eTestGenDataOptions
 };
 
 void CurrentGpsTimeMs(uint32_t &gpsTimeOfWeekMs, uint32_t &gpsWeek);
-void PrintUtcTime(std::tm &utcTime, uint32_t milliseconds=0);
+void PrintUtcDateTime(utc_date_t &utcDate, utc_time_t &utcTime);
+void PrintUtcStdTm(std::tm &utcTime, uint32_t milliseconds=0);
 bool GenerateMessage(test_message_t &msg, protocol_type_t ptype=_PTYPE_NONE);
 void GenerateDataLogFiles(int numDevices, std::string directory, cISLogger::eLogType logType, float logSizeMB=20, eTestGenDataOptions options=GEN_LOG_OPTIONS_NONE);
 int GenerateDataStream(uint8_t *buffer, int bufferSize, eTestGenDataOptions options=GEN_LOG_OPTIONS_NONE);

--- a/tests/test_protocol_nmea.cpp
+++ b/tests/test_protocol_nmea.cpp
@@ -1443,718 +1443,114 @@ TEST(protocol_nmea, checksum)
 }
 #endif
 
-
 void init_sat_and_sig(gps_sat_t* gpsSat, gps_sig_t* gpsSig)
 {
-    gpsSat->numSats = 33;
+    // Satellite data array
+    static const gps_sat_sv_t sat_data[] = 
+    {
+        {SAT_SV_GNSS_ID_GPS, 2, 40, 310, 43, 95},
+        {SAT_SV_GNSS_ID_GPS, 8, 7, 324, 31, 95},
+        {SAT_SV_GNSS_ID_GPS, 10, 48, 267, 45, 31},
+        {SAT_SV_GNSS_ID_GPS, 15, 37, 53, 45, 31},
+        {SAT_SV_GNSS_ID_GPS, 16, 12, 268, 37, 95},
+        {SAT_SV_GNSS_ID_GPS, 18, 69, 78, 41, 31},
+        {SAT_SV_GNSS_ID_GPS, 23, 74, 336, 41, 31},
+        {SAT_SV_GNSS_ID_GPS, 24, 15, 111, 37, 31},
+        {SAT_SV_GNSS_ID_GPS, 26, 2, 239, 31, 31},
+        {SAT_SV_GNSS_ID_GPS, 27, 35, 307, 41, 95},
+        {SAT_SV_GNSS_ID_GPS, 29, 12, 162, 36, 31},
+        {SAT_SV_GNSS_ID_GPS, 32, 14, 199, 40, 95},
+        {SAT_SV_GNSS_ID_SBS, 131, 43, 188, 43, 95},
+        {SAT_SV_GNSS_ID_SBS, 133, 40, 206, 43, 95},
+        {SAT_SV_GNSS_ID_SBS, 138, 43, 173, 35, 95},
+        {SAT_SV_GNSS_ID_GAL, 5, 65, 145, 41, 31},
+        {SAT_SV_GNSS_ID_GAL, 9, 39, 53, 43, 31},
+        {SAT_SV_GNSS_ID_GAL, 34, 71, 340, 42, 31},
+        {SAT_SV_GNSS_ID_GAL, 36, 47, 104, 40, 31},
+        {SAT_SV_GNSS_ID_BEI, 11, 9, 141, 36, 23},
+        {SAT_SV_GNSS_ID_BEI, 14, 52, 47, 44, 31},
+        {SAT_SV_GNSS_ID_BEI, 27, 31, 313, 38, 31},
+        {SAT_SV_GNSS_ID_BEI, 28, 79, 267, 44, 31},
+        {SAT_SV_GNSS_ID_BEI, 33, 82, 40, 42, 31},
+        {SAT_SV_GNSS_ID_BEI, 41, 43, 230, 43, 31},
+        {SAT_SV_GNSS_ID_BEI, 43, 34, 148, 43, 31},
+        {SAT_SV_GNSS_ID_BEI, 58, 0, 0, 43, 39},
+        {SAT_SV_GNSS_ID_GLO, 1, 85, 252, 31, 23},
+        {SAT_SV_GNSS_ID_GLO, 2, 28, 217, 29, 31},
+        {SAT_SV_GNSS_ID_GLO, 8, 37, 34, 35, 31},
+        {SAT_SV_GNSS_ID_GLO, 17, 19, 324, 19, 19},
+        {SAT_SV_GNSS_ID_GLO, 23, 48, 126, 36, 31},
+        {SAT_SV_GNSS_ID_GLO, 24, 72, 349, 32, 28}
+    };
+
+    // Signal data array
+    static const gps_sig_sv_t sig_data[] = 
+    {
+        {SAT_SV_GNSS_ID_GPS, 2, SAT_SV_SIG_ID_GPS_L1CA, 43, 7, 361},
+        {SAT_SV_GNSS_ID_GPS, 8, SAT_SV_SIG_ID_GPS_L1CA, 31, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 10, SAT_SV_SIG_ID_GPS_L1CA, 45, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 15, SAT_SV_SIG_ID_GPS_L1CA, 45, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 16, SAT_SV_SIG_ID_GPS_L1CA, 37, 7, 361},
+        {SAT_SV_GNSS_ID_GPS, 18, SAT_SV_SIG_ID_GPS_L1CA, 41, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 23, SAT_SV_SIG_ID_GPS_L1CA, 41, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 24, SAT_SV_SIG_ID_GPS_L1CA, 37, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 26, SAT_SV_SIG_ID_GPS_L1CA, 31, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 27, SAT_SV_SIG_ID_GPS_L1CA, 41, 7, 361},
+        {SAT_SV_GNSS_ID_GPS, 29, SAT_SV_SIG_ID_GPS_L1CA, 36, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 32, SAT_SV_SIG_ID_GPS_L1CA, 40, 7, 361},
+        {2, 131, 0, 43, 7, 361}, 
+        {2, 133, 0, 43, 7, 361}, 
+        {2, 138, 0, 35, 7, 361},
+        {SAT_SV_GNSS_ID_GPS, 10, SAT_SV_SIG_ID_GPS_L2CL, 45, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 15, SAT_SV_SIG_ID_GPS_L2CL, 27, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 18, SAT_SV_SIG_ID_GPS_L2CL, 33, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 23, SAT_SV_SIG_ID_GPS_L2CL, 34, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 27, SAT_SV_SIG_ID_GPS_L2CL, 23, 7, 9},
+        {SAT_SV_GNSS_ID_GPS, 29, SAT_SV_SIG_ID_GPS_L2CL, 25, 7, 41},
+        {SAT_SV_GNSS_ID_GPS, 32, SAT_SV_SIG_ID_GPS_L5, 28, 7, 41},
+        {SAT_SV_GNSS_ID_GAL, 5, SAT_SV_SIG_ID_Galileo_E1C2, 41, 7, 41},
+        {SAT_SV_GNSS_ID_GAL, 9, SAT_SV_SIG_ID_Galileo_E1C2, 43, 7, 41},
+        {SAT_SV_GNSS_ID_GAL, 34, SAT_SV_SIG_ID_Galileo_E1C2, 42, 7, 41},
+        {SAT_SV_GNSS_ID_GAL, 36, SAT_SV_SIG_ID_Galileo_E1C2, 40, 7, 41},
+        {SAT_SV_GNSS_ID_GAL, 5, 6, 30, 7, 41}, 
+        {SAT_SV_GNSS_ID_GAL, 9, 6, 30, 7, 41},
+        {SAT_SV_GNSS_ID_GAL, 34, 6, 26, 7, 41}, 
+        {SAT_SV_GNSS_ID_GAL, 36, 6, 31, 7, 41},
+        {SAT_SV_GNSS_ID_BEI, 11, SAT_SV_SIG_ID_BeiDou_B1D1, 36, 7, 1},
+        {SAT_SV_GNSS_ID_BEI, 14, SAT_SV_SIG_ID_BeiDou_B1D1, 44, 7, 41},
+        {SAT_SV_GNSS_ID_BEI, 27, SAT_SV_SIG_ID_BeiDou_B1D1, 38, 7, 41},
+        {SAT_SV_GNSS_ID_BEI, 28, SAT_SV_SIG_ID_BeiDou_B1D1, 44, 7, 41},
+        {SAT_SV_GNSS_ID_BEI, 33, SAT_SV_SIG_ID_BeiDou_B1D1, 42, 7, 41},
+        {SAT_SV_GNSS_ID_BEI, 41, SAT_SV_SIG_ID_BeiDou_B1D1, 43, 7, 41},
+        {SAT_SV_GNSS_ID_BEI, 43, SAT_SV_SIG_ID_BeiDou_B1D1, 43, 7, 41},
+        {SAT_SV_GNSS_ID_BEI, 58, SAT_SV_SIG_ID_BeiDou_B1D1, 43, 7, 2},
+        {SAT_SV_GNSS_ID_BEI, 11, 2, 21, 7, 1}, 
+        {SAT_SV_GNSS_ID_BEI, 14, 2, 30, 7, 41},
+        {SAT_SV_GNSS_ID_GLO, 1, SAT_SV_SIG_ID_GLONASS_L1OF, 31, 7, 1},
+        {SAT_SV_GNSS_ID_GLO, 2, SAT_SV_SIG_ID_GLONASS_L1OF, 29, 7, 41},
+        {SAT_SV_GNSS_ID_GLO, 8, SAT_SV_SIG_ID_GLONASS_L1OF, 35, 7, 41},
+        {SAT_SV_GNSS_ID_GLO, 17, SAT_SV_SIG_ID_GLONASS_L1OF, 19, 7, 1},
+        {SAT_SV_GNSS_ID_GLO, 23, SAT_SV_SIG_ID_GLONASS_L1OF, 36, 7, 41},
+        {SAT_SV_GNSS_ID_GLO, 24, SAT_SV_SIG_ID_GLONASS_L1OF, 32, 7, 41}
+    };
+
+    // Initialize gpsSat
     gpsSat->timeOfWeekMs = 436693200;
-    gps_sat_sv_t *sat = &(gpsSat->sat[0]);
-    sat->azim = 310;
-    sat->cno = 43;
-    sat->elev = 40;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 95;
-    sat->svId = 2;
-    sat++;
-    sat->azim = 324;
-    sat->cno = 31;
-    sat->elev = 07;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 95;
-    sat->svId = 8;
-    sat++;
-    sat->azim = 267;
-    sat->cno = 45;
-    sat->elev = 48;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 31;
-    sat->svId = 10;
-    sat++;
-    sat->azim = 53;
-    sat->cno = 45;
-    sat->elev = 37;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 31;
-    sat->svId = 15;
-    sat++;
-    sat->azim = 268;
-    sat->cno = 37;
-    sat->elev = 12;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 95;
-    sat->svId = 16;
-    sat++;
-    sat->azim = 78;
-    sat->cno = 41;
-    sat->elev = 69;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 31;
-    sat->svId = 18;
-    sat++;
-    sat->azim = 336;
-    sat->cno = 41;
-    sat->elev = 74;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 31;
-    sat->svId = 23;
-    sat++;
-    sat->azim = 111;
-    sat->cno = 37;
-    sat->elev = 15;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 31;
-    sat->svId = 24;
-    sat++;
-    sat->azim = 239;
-    sat->cno = 31;
-    sat->elev = 02;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 31;
-    sat->svId = 26;
-    sat++;
-    sat->azim = 307;
-    sat->cno = 41;
-    sat->elev = 35;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 95;
-    sat->svId = 27;
-    sat++;
-    sat->azim = 162;
-    sat->cno = 36;
-    sat->elev = 12;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 31;
-    sat->svId = 29;
-    sat++;
-    sat->azim = 199;
-    sat->cno = 40;
-    sat->elev = 14;
-    sat->gnssId = SAT_SV_GNSS_ID_GPS;
-    sat->status = 95;
-    sat->svId = 32;
-    sat++;
-    sat->azim = 188;
-    sat->cno = 43;
-    sat->elev = 43;
-    sat->gnssId = 2;
-    sat->status = 95;
-    sat->svId = 131;
-    sat++;
-    sat->azim = 206;
-    sat->cno = 43;
-    sat->elev = 40;
-    sat->gnssId = 2;
-    sat->status = 95;
-    sat->svId = 133;
-    sat++;
-    sat->azim = 173;
-    sat->cno = 35;
-    sat->elev = 43;
-    sat->gnssId = 2;
-    sat->status = 95;
-    sat->svId = 138;
-    sat++;
-    sat->azim = 145;
-    sat->cno = 41;
-    sat->elev = 65;
-    sat->gnssId = SAT_SV_GNSS_ID_GAL;
-    sat->status = 31;
-    sat->svId = 5;
-    sat++;
-    sat->azim = 53;
-    sat->cno = 43;
-    sat->elev = 39;
-    sat->gnssId = SAT_SV_GNSS_ID_GAL;
-    sat->status = 31;
-    sat->svId = 9;
-    sat++;
-    sat->azim = 340;
-    sat->cno = 42;
-    sat->elev = 71;
-    sat->gnssId = SAT_SV_GNSS_ID_GAL;
-    sat->status = 31;
-    sat->svId = 34;
-    sat++;
-    sat->azim = 104;
-    sat->cno = 40;
-    sat->elev = 47;
-    sat->gnssId = SAT_SV_GNSS_ID_GAL;
-    sat->status = 31;
-    sat->svId = 36;
-    sat++;
-    sat->azim = 141;
-    sat->cno = 36;
-    sat->elev = 9;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 23;
-    sat->svId = 11;
-    sat++;
-    sat->azim = 47;
-    sat->cno = 44;
-    sat->elev = 52;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 31;
-    sat->svId = 14;
-    sat++;
-    sat->azim = 313;
-    sat->cno = 38;
-    sat->elev = 31;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 31;
-    sat->svId = 27;
-    sat++;
-    sat->azim = 267;
-    sat->cno = 44;
-    sat->elev = 79;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 31;
-    sat->svId = 28;
-    sat++;
-    sat->azim = 40;
-    sat->cno = 42;
-    sat->elev = 82;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 31;
-    sat->svId = 33;
-    sat++;
-    sat->azim = 230;
-    sat->cno = 43;
-    sat->elev = 43;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 31;
-    sat->svId = 41;
-    sat++;
-    sat->azim = 148;
-    sat->cno = 43;
-    sat->elev = 34;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 31;
-    sat->svId = 43;
-    sat++;
-    sat->azim = 0;
-    sat->cno = 43;
-    sat->elev = 0;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 39;
-    sat->svId = 58;
-    sat++;
-    sat->azim = 252;
-    sat->cno = 31;
-    sat->elev = 85;
-    sat->gnssId = SAT_SV_GNSS_ID_GLO;
-    sat->status = 23;
-    sat->svId = 1;
-    sat++;
-    sat->azim = 217;
-    sat->cno = 29;
-    sat->elev = 28;
-    sat->gnssId = SAT_SV_GNSS_ID_GLO;
-    sat->status = 31;
-    sat->svId = 2;
-    sat++;
-    sat->azim = 34;
-    sat->cno = 35;
-    sat->elev = 37;
-    sat->gnssId = SAT_SV_GNSS_ID_GLO;
-    sat->status = 31;
-    sat->svId = 8;
-    sat++;
-    sat->azim = 324;
-    sat->cno = 19;
-    sat->elev = 19;
-    sat->gnssId = SAT_SV_GNSS_ID_GLO;
-    sat->status = 19;
-    sat->svId = 17;
-    sat++;
-    sat->azim = 126;
-    sat->cno = 36;
-    sat->elev = 48;
-    sat->gnssId = SAT_SV_GNSS_ID_GLO;
-    sat->status = 31;
-    sat->svId = 23;
-    sat++;
-    sat->azim = 349;
-    sat->cno = 32;
-    sat->elev = 72;
-    sat->gnssId = SAT_SV_GNSS_ID_GLO;
-    sat->status = 28;
-    sat->svId = 24;
-    sat++;
-    sat->azim = 0;
-    sat->cno = 1;
-    sat->elev = 1;
-    sat->gnssId = SAT_SV_GNSS_ID_BEI;
-    sat->status = 0;
-    sat->svId = 0;
-    sat++;
-    sat->azim = 0;
-    sat->cno = 2;
-    sat->elev = 0;
-    sat->gnssId = 0;
-    sat->status = 0;
-    sat->svId = 0;
+    gpsSat->numSats = sizeof(sat_data)/sizeof(gps_sat_sv_t);
+    for (size_t i = 0; i < gpsSat->numSats; i++) 
+    {
+        gpsSat->sat[i] = sat_data[i];
+    }
 
-    // Check array out of bounds
-    ASSERT_TRUE( sat < &(gpsSat->sat[MAX_NUM_SATELLITES]) );
-
-    gpsSig->numSigs = 46;
+    // Initialize gpsSig
     gpsSig->timeOfWeekMs = 436693200;
-    gps_sig_sv_t *sig = &(gpsSig->sig[0]);
-    sig->cno = 43;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 361;
-    sig->svId = 2;   
-    sig++;
-    sig->cno = 31;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 41;
-    sig->svId = 8;
-    sig++;
-    sig->cno = 45;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 41;
-    sig->svId = 10;
-    sig++;
-    sig->cno = 45;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 41;
-    sig->svId = 15;
-    sig++;
-    sig->cno = 37;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 361;
-    sig->svId = 16;
-    sig++;
-    sig->cno = 41;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 41;
-    sig->svId = 18;
-    sig++;
-    sig->cno = 41;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 41;
-    sig->svId = 23;
-    sig++;
-    sig->cno = 37;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 41;
-    sig->svId = 24;
-    sig++;
-    sig->cno = 31;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 41;
-    sig->svId = 26;
-    sig++;
-    sig->cno = 41;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 361;
-    sig->svId = 27;
-    sig++;
-    sig->cno = 36;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 41;
-    sig->svId = 29;
-    sig++;
-    sig->cno = 40;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 361;
-    sig->svId = 32;
-    sig++;
-    sig->cno = 43;
-    sig->gnssId = 2;
-    sig->quality = 7;
-    sig->sigId = 0;
-    sig->status = 361;
-    sig->svId = 131;
-    sig++;
-    sig->cno = 43;
-    sig->gnssId = 2;
-    sig->quality = 7;
-    sig->sigId = 0;
-    sig->status = 361;
-    sig->svId = 133;
-    sig++;
-    sig->cno = 35;
-    sig->gnssId = 2;
-    sig->quality = 7;
-    sig->sigId = 0;
-    sig->status = 361;
-    sig->svId = 138;
-    sig++;
-    sig->cno = 45;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L2CL;
-    sig->status = 41;
-    sig->svId = 10;
-    sig++;
-    sig->cno = 27;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L2CL;
-    sig->status = 41;
-    sig->svId = 15;
-    sig++;
-    sig->cno = 33;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L2CL;
-    sig->status = 41;
-    sig->svId = 18;
-    sig++;
-    sig->cno = 34;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L2CL;
-    sig->status = 41;
-    sig->svId = 23;
-    sig++;
-    sig->cno = 23;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L2CL;
-    sig->status = 9;
-    sig->svId = 27;
-    sig++;
-    sig->cno = 25;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L2CL;
-    sig->status = 41;
-    sig->svId = 29;
-    sig++;
-    sig->cno = 28;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L5;
-    sig->status = 41;
-    sig->svId = 32;
-    sig++;
-    sig->cno = 41;
-    sig->gnssId = SAT_SV_GNSS_ID_GAL;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_Galileo_E1C2;
-    sig->status = 41;
-    sig->svId = 5;
-    sig++;
-    sig->cno = 43;
-    sig->gnssId = SAT_SV_GNSS_ID_GAL;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_Galileo_E1C2;
-    sig->status = 41;
-    sig->svId = 9;
-    sig++;
-    sig->cno = 42;
-    sig->gnssId = SAT_SV_GNSS_ID_GAL;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_Galileo_E1C2;
-    sig->status = 41;
-    sig->svId = 34;
-    sig++;
-    sig->cno = 40;
-    sig->gnssId = SAT_SV_GNSS_ID_GAL;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_Galileo_E1C2;
-    sig->status = 41;
-    sig->svId = 36;
-    sig++;
-    sig->cno = 30;
-    sig->gnssId = SAT_SV_GNSS_ID_GAL;
-    sig->quality = 7;
-    sig->sigId = 6;
-    sig->status = 41;
-    sig->svId = 5;
-    sig++;
-    sig->cno = 30;
-    sig->gnssId = SAT_SV_GNSS_ID_GAL;
-    sig->quality = 7;
-    sig->sigId = 6;
-    sig->status = 41;
-    sig->svId = 9;
-    sig++;
-    sig->cno = 26;
-    sig->gnssId = SAT_SV_GNSS_ID_GAL;
-    sig->quality = 7;
-    sig->sigId = 6;
-    sig->status = 41;
-    sig->svId = 34;
-    sig++;
-    sig->cno = 31;
-    sig->gnssId = SAT_SV_GNSS_ID_GAL;
-    sig->quality = 7;
-    sig->sigId = 6;
-    sig->status = 41;
-    sig->svId = 36;
-    sig++;
-    sig->cno = 36;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_BeiDou_B1D1;
-    sig->status = 1;
-    sig->svId = 11;
-    sig++;
-    sig->cno = 44;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_BeiDou_B1D1;
-    sig->status = 41;
-    sig->svId = 14;
-    sig++;
-    sig->cno = 38;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_BeiDou_B1D1;
-    sig->status = 41;
-    sig->svId = 27;
-    sig++;
-    sig->cno = 44;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_BeiDou_B1D1;
-    sig->status = 41;
-    sig->svId = 28;
-    sig++;
-    sig->cno = 42;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_BeiDou_B1D1;
-    sig->status = 41;
-    sig->svId = 33;
-    sig++;
-    sig->cno = 43;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_BeiDou_B1D1;
-    sig->status = 41;
-    sig->svId = 41;
-    sig++;
-    sig->cno = 43;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_BeiDou_B1D1;
-    sig->status = 41;
-    sig->svId = 43;
-    sig++;
-    sig->cno = 43;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_BeiDou_B1D1;
-    sig->status = 2;
-    sig->svId = 58;
-    sig++;
-    sig->cno = 21;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = 2;
-    sig->status = 1;
-    sig->svId = 11;
-    sig++;
-    sig->cno = 30;
-    sig->gnssId = SAT_SV_GNSS_ID_BEI;
-    sig->quality = 7;
-    sig->sigId = 2;
-    sig->status = 41;
-    sig->svId = 14;
-    sig++;
-    sig->cno = 31;
-    sig->gnssId = SAT_SV_GNSS_ID_GLO;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GLONASS_L1OF;
-    sig->status = 1;
-    sig->svId = 1;
-    sig++;
-    sig->cno = 29;
-    sig->gnssId = SAT_SV_GNSS_ID_GLO;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GLONASS_L1OF;
-    sig->status = 41;
-    sig->svId = 2;
-    sig++;
-    sig->cno = 35;
-    sig->gnssId = SAT_SV_GNSS_ID_GLO;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GLONASS_L1OF;
-    sig->status = 41;
-    sig->svId = 8;
-    sig++;
-    sig->cno = 19;
-    sig->gnssId = SAT_SV_GNSS_ID_GLO;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GLONASS_L1OF;
-    sig->status = 1;
-    sig->svId = 17;
-    sig++;
-    sig->cno = 36;
-    sig->gnssId = SAT_SV_GNSS_ID_GLO;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GLONASS_L1OF;
-    sig->status = 41;
-    sig->svId = 23;
-    sig++;
-    sig->cno = 32;
-    sig->gnssId = SAT_SV_GNSS_ID_GLO;
-    sig->quality = 7;
-    sig->sigId = SAT_SV_SIG_ID_GLONASS_L1OF;
-    sig->status = 41;
-    sig->svId = 24;
-    sig++;
-    sig->cno = 208;
-    sig->gnssId = 0;
-    sig->quality = 233;
-    sig->sigId = 0;
-    sig->status = 8978;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 1;
-    sig->gnssId = 107;
-    sig->quality = 0;
-    sig->sigId = 133;
-    sig->status = 256;
-    sig->svId = 33;
-    sig++;
-    sig->cno = 15;
-    sig->gnssId = 0;
-    sig->quality = 35;
-    sig->sigId = 0;
-    sig->status = 389;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 236;
-    sig->gnssId = 0;
-    sig->quality = 18;
-    sig->sigId = 0;
-    sig->status = 34083;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 112;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 0;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 0;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 35;
-    sig->gnssId = 160;
-    sig->quality = 133;
-    sig->sigId = 18;
-    sig->status = 1;
-    sig->svId = 234;
-    sig++;
-    sig->cno = 235;
-    sig->gnssId = 0;
-    sig->quality = 18;
-    sig->sigId = 48;
-    sig->status = 34083;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 208;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 235;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 8978;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 1;
-    sig->gnssId = 107;
-    sig->quality = 0;
-    sig->sigId = 133;
-    sig->status = 10240;
-    sig->svId = 33;
-    sig++;
-    sig->cno = 1;
-    sig->gnssId = 243;
-    sig->quality = 0;
-    sig->sigId = 118;
-    sig->status = 0;
-    sig->svId = 186;
-    sig++;
-    sig->cno = 33;
-    sig->gnssId = 100;
-    sig->quality = 133;
-    sig->sigId = 107;
-    sig->status = 1;
-    sig->svId = 7;
-    sig++;
-    sig->cno = 15;
-    sig->gnssId = 0;
-    sig->quality = 35;
-    sig->sigId = 0;
-    sig->status = 389;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 235;
-    sig->gnssId = 0;
-    sig->quality = 18;
-    sig->sigId = 64;
-    sig->status = 34083;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 52;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 0;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 0;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 107;
-    sig->gnssId = 0;
-    sig->quality = 33;
-    sig->sigId = 0;
-    sig->status = 389;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 234;
-    sig->gnssId = 0;
-    sig->quality = 18;
-    sig->sigId = 176;
-    sig->status = 34083;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 74;
-    sig->gnssId = SAT_SV_GNSS_ID_GPS;
-    sig->quality = 0;
-    sig->sigId = SAT_SV_SIG_ID_GPS_L1CA;
-    sig->status = 19972;
-    sig->svId = 0;
-    sig++;
-    sig->cno = 33;
-    sig->gnssId = 90;
-    sig->quality = 133;
-    sig->sigId = 107;
-    sig->status = 1;
-    sig->svId = 7;
-    sig++;
-    sig->cno = 186;
-    sig->gnssId = 0;
-    sig->quality = 118;
-    sig->sigId = 242;
-    sig->status = 1;
-    sig->svId = 48;
+    gpsSig->numSigs = sizeof(sig_data)/sizeof(gps_sig_sv_t);
+    for (size_t i = 0; i < gpsSig->numSigs; i++) 
+    {
+        gpsSig->sig[i] = sig_data[i];
+    }
 
-    // Check array out of bounds
-    ASSERT_TRUE( sig < &(gpsSig->sig[MAX_NUM_SAT_SIGNALS]) );
+    // Array bounds checks
+    ASSERT_TRUE(gpsSat->numSats <= MAX_NUM_SATELLITES);
+    ASSERT_TRUE(gpsSig->numSigs <= MAX_NUM_SAT_SIGNALS);
 }


### PR DESCRIPTION
- Fixed signedness of debug integer array (debug_array_t) in ISDataMappings.cpp.
- Added ZDA timestamp skip debug code.
- Added corrective offset for ZDA tmestamp skip.
- Fixed UtcDateTimeToGpsTime() leap second offset issue that caueded 1ms rounding error.
- Fixed rounding error in julianToDate() used in nmea_zda() output generation.