### PR TITLE
Add runtime test for NMEA $INTEL

### DIFF
--- a/tests/runtime/device_runtime_tests.cpp
+++ b/tests/runtime/device_runtime_tests.cpp
@@ -140,6 +140,7 @@ void DeviceRuntimeTests::ProcessNMEA(const uint8_t* msg, int msgSize)
     {
     case NMEA_MSG_ID_GNGGA:     TestNmeaGga(msg, msgSize);      break;
     case NMEA_MSG_ID_GNZDA:     TestNmeaZda(msg, msgSize);      break;
+    case NMEA_MSG_ID_INTEL:     TestNmeaIntel(msg, msgSize);    break;
     }
 }
 
@@ -174,6 +175,24 @@ void DeviceRuntimeTests::TestNmeaZda(const uint8_t* msg, int msgSize)
     // WriteStatus("NMEA ZDA (%d ms): %.*s", gpsTowMs, msgSize, msg);
 
     CheckGpsTime("NMEA ZDA Error", m_errorCount.nmeaZdaTime, hist);
+}
+
+/**
+ * @brief Test messages for duplicates, reversed order, or irregular timestamps.
+ */
+void DeviceRuntimeTests::TestNmeaIntel(const uint8_t* msg, int msgSize)
+{
+    dev_info_t info;
+    gps_pos_t pos;
+    gps_vel_t vel;
+    float ppsPhase[2];
+    uint32_t ppsNoiseNs[1];
+    nmea_parse_intel((char*)msg, msgSize, info, pos, vel, ppsPhase, ppsNoiseNs);
+    std::deque<msg_history_t> &hist = AddMsgHistory(m_hist.nmea.intel, msg_history_t(&pos, (uint8_t*)msg, msgSize));
+
+    // WriteStatus("NMEA INTEL (%d ms): %.*s", gpsTowMs, msgSize, msg);
+
+    CheckGpsTime("NMEA INTEL Error", m_errorCount.nmeaZdaTime, hist);
 }
 
 std::string printfToString(const char* format, ...)

--- a/tests/runtime/device_runtime_tests.h
+++ b/tests/runtime/device_runtime_tests.h
@@ -110,6 +110,7 @@ private:
     void TestIsbGps(const p_data_hdr_t &dataHdr, const uint8_t *dataBuf);
     void TestNmeaGga(const uint8_t* msg, int msgSize);
     void TestNmeaZda(const uint8_t* msg, int msgSize);
+    void TestNmeaIntel(const uint8_t* msg, int msgSize);
     bool CheckGpsTime(const char* description, int &count, std::deque<msg_history_t> &hist);
     bool CheckGpsTimeDuplicate(const char* description, int &count, std::deque<msg_history_t> &hist);
     bool CheckGpsTimeReversed(const char* description, int &count, std::deque<msg_history_t> &hist);
@@ -143,8 +144,9 @@ private:
 
         struct
         {
-            std::deque<msg_history_t>   zda;
             std::deque<msg_history_t>   gga;
+            std::deque<msg_history_t>   intel;
+            std::deque<msg_history_t>   zda;
         } nmea;
     } m_hist = {};
     


### PR DESCRIPTION
Add a runtime test for $INTEL, looking for anomalies in the timestamp and periodicity. 