### PR TITLE
SN-6105: Fix IMX's GNSS1_INIT_FAULT reporting.

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -681,10 +681,10 @@ static void PopulateMapGpxStatus(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("rtkMode", &gpx_status_t::rtkMode, DATA_TYPE_UINT32, "", str, DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
     for (int i=0; i<GNSS_RECEIVER_COUNT; i++)
     {
-        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".reserved",      i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].reserved),      DATA_TYPE_UINT8, "", "");
-        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".fwUpdateState", i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].fwUpdateState), DATA_TYPE_UINT8, "", "GNSS FW update status (see FirmwareUpdateState)");
-        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".initState",     i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].initState),     DATA_TYPE_UINT8, "", "GNSS init status (see InitSteps)");
-        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".runState",      i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].runState),      DATA_TYPE_UINT8, "", "GNSS run status (see eGPXGnssRunState)");
+        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".lastRstCause", i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].lastRstCause), DATA_TYPE_UINT8, "", "GNSS last reset cause (see eGnssResetCause)");
+        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".fwUpdateState",  i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].fwUpdateState),  DATA_TYPE_UINT8, "", "GNSS FW update status (see FirmwareUpdateState)");
+        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".initState",      i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].initState),      DATA_TYPE_UINT8, "", "GNSS init status (see InitSteps)");
+        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".runState",       i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].runState),       DATA_TYPE_UINT8, "", "GNSS run status (see eGPXGnssRunState)");
     }
     mapper.AddMember("gpxSourcePort", &gpx_status_t::gpxSourcePort, DATA_TYPE_UINT8, "", "Port", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("upTime", &gpx_status_t::upTime, DATA_TYPE_F64, "s", "Local time since startup.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_1);

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4578,19 +4578,19 @@ enum eGPXHdwStatusFlags
 };
 
 typedef enum {
-    cxdRst_PowerOn = 0,
-    cxdRst_Watchdog,
-    cxdRst_ErrOpCode,
-    cxdRst_ErrOpCode_FW,
-    cxdRst_ErrOpCode_init,
-    cxdRst_UserRequested,
-    cxdRst_FWUpdate,
-    cxdRst_SysCmd,
-    cxdRst_InitTimeout,
-    cxdRst_Status5,
-    cxdRst_StatusNot0,
-    cxdRst_flashUpdate,
-    cxdRst_RTKEphMissing,
+    cxdRst_PowerOn =        0,
+    cxdRst_Watchdog =       1,
+    cxdRst_ErrOpCode =      2,
+    cxdRst_ErrOpCode_FW =   3,
+    cxdRst_ErrOpCode_init = 4,
+    cxdRst_UserRequested =  5,
+    cxdRst_FWUpdate =       6,
+    cxdRst_SysCmd =         7,
+    cxdRst_InitTimeout =    8,
+    cxdRst_Status5 =        9,
+    cxdRst_StatusNot0 =     10,
+    cxdRst_flashUpdate =    11,
+    cxdRst_RTKEphMissing =  12,
     cxdRst_Max
 } eGNSSDriverRstCause;
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4578,6 +4578,23 @@ enum eGPXHdwStatusFlags
 };
 
 typedef enum {
+    cxdRst_PowerOn = 0,
+    cxdRst_Watchdog,
+    cxdRst_ErrOpCode,
+    cxdRst_ErrOpCode_FW,
+    cxdRst_ErrOpCode_init,
+    cxdRst_UserRequested,
+    cxdRst_FWUpdate,
+    cxdRst_SysCmd,
+    cxdRst_InitTimeout,
+    cxdRst_Status5,
+    cxdRst_StatusNot0,
+    cxdRst_flashUpdate,
+    cxdRst_RTKEphMissing,
+    cxdRst_Max
+} eGNSSDriverRstCause;
+
+typedef enum {
     kReset = 0,
     kInit,
     kRun,
@@ -4594,10 +4611,10 @@ typedef enum {
 
 typedef struct 
 {
-    uint8_t reserved;
-    uint8_t fwUpdateState;      /** GNSS FW update status (see FirmwareUpdateState) **/
-    uint8_t initState;          /** GNSS status (see InitSteps) **/
-    uint8_t runState;           /** GNSS run status (see eGPXGnssRunState) **/
+    uint8_t lastRstCause;   /** Last reset cause (see eGNSSDriverRstCause) **/
+    uint8_t fwUpdateState;  /** GNSS FW update status (see FirmwareUpdateState) **/
+    uint8_t initState;      /** GNSS init status (see InitSteps) **/
+    uint8_t runState;       /** GNSS run status (see eGPXGnssRunState) **/
 } gpx_gnss_status_t;
 
 /**


### PR DESCRIPTION
(IMX) Fixes a bug when IMX does not report GNSS1_INIT_FAULT reporting. (SN-6105)
(GPX) In DID_GPX_STATUS a field was added to report GNSS last reset reason. (SN-6105)