### PR TITLE
Convert version dirty character from * to ^

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -90,7 +90,7 @@ static void PopulateMapDeviceInfo(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddArray("protocolVer", &dev_info_t::protocolVer, DATA_TYPE_UINT8, 4, "", "Communications protocol version", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("repoRevision", &dev_info_t::repoRevision, DATA_TYPE_UINT32, "", "Repo revision", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember("manufacturer", &dev_info_t::manufacturer, DATA_TYPE_STRING, "", "manufacturer", DATA_FLAGS_READ_ONLY);
-    mapper.AddMember("buildType", &dev_info_t::buildType, DATA_TYPE_UINT8, "", "'a'(97)=ALPHA, 'b'(98)=BETA, 'c'(99)=CANDIDATE, 'r'(114)=PRODUCTION, 'd'(100)=develop, 's'(115)=snapshot, '*'(42)=dirty", DATA_FLAGS_READ_ONLY);
+    mapper.AddMember("buildType", &dev_info_t::buildType, DATA_TYPE_UINT8, "", "'a'(97)=ALPHA, 'b'(98)=BETA, 'c'(99)=CANDIDATE, 'r'(114)=PRODUCTION, 'd'(100)=develop, 's'(115)=snapshot, '^'(94)=dirty", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("buildYear", &dev_info_t::buildYear, DATA_TYPE_UINT8, "", "Build year-2000", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("buildMonth", &dev_info_t::buildMonth, DATA_TYPE_UINT8, "", "Build month", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("buildDay", &dev_info_t::buildDay, DATA_TYPE_UINT8, "", "Build day", DATA_FLAGS_READ_ONLY);

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1608,7 +1608,7 @@ string cInertialSenseDisplay::DataToStringDevInfo(const dev_info_t &info, bool f
         case 'c': ptr += SNPRINTF(ptr, ptrEnd - ptr, "-rc");        break;
         case 'd': ptr += SNPRINTF(ptr, ptrEnd - ptr, "-devel");     break;
         case 's': ptr += SNPRINTF(ptr, ptrEnd - ptr, "-snap");      break;
-        case '*': ptr += SNPRINTF(ptr, ptrEnd - ptr, "-snap");      break;
+        case '^': ptr += SNPRINTF(ptr, ptrEnd - ptr, "-snap");      break;
         default : break;
     }
 
@@ -1617,8 +1617,8 @@ string cInertialSenseDisplay::DataToStringDevInfo(const dev_info_t &info, bool f
     }
 
     char dirty = 0;
-    if (info.buildType == '*') {
-        dirty = '*';
+    if (info.buildType == '^') {
+        dirty = '^';
     }
 
     ptr += SNPRINTF(ptr, ptrEnd - ptr, " %08x%c (%05X.%d)",


### PR DESCRIPTION
Convert version string dirty character from `*` to `^` for NMEA message compatiblity.