### PR TITLE
SN-6129 fix raw gps data drop

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -169,14 +169,7 @@ void is_comm_init(is_comm_instance_t* c, uint8_t *buffer, int bufferSize)
     c->rxBuf.head = c->rxBuf.tail = c->rxBuf.scan = buffer;
     
     // Set parse enable flags
-    c->config.enabledMask = 
-        ENABLE_PROTOCOL_ISB
-        | ENABLE_PROTOCOL_NMEA
-        | ENABLE_PROTOCOL_UBLOX
-        | ENABLE_PROTOCOL_RTCM3
-        // | ENABLE_PROTOCOL_SONY
-        // | ENABLE_PROTOCOL_SPARTN
-        ;
+    c->config.enabledMask = DEFAULT_PROTO_MASK;
     
     c->rxPkt.data.ptr = c->rxBuf.start;
     c->rxErrorState = 1;
@@ -187,23 +180,16 @@ int is_comm_check(is_comm_instance_t* c, uint8_t *buffer, int bufferSize)
 {
     // Clear buffer and initialize buffer pointers
     if (c->rxBuf.size != (uint32_t)bufferSize) { return -1; }
-    if (c->rxBuf.start != buffer) { return -1; }
-    if (c->rxBuf.end != buffer + bufferSize) { return -1; }
-    if (c->rxBuf.head < c->rxBuf.start || c->rxBuf.head > c->rxBuf.end) { return -1; }
-    if (c->rxBuf.tail < c->rxBuf.start || c->rxBuf.tail > c->rxBuf.end) { return -1; }
-    if (c->rxBuf.scan < c->rxBuf.start || c->rxBuf.scan > c->rxBuf.end) { return -1; }
+    if (c->rxBuf.start != buffer) { return -2; }
+    if (c->rxBuf.end != buffer + bufferSize) { return -3; }
+    if (c->rxBuf.head < c->rxBuf.start || c->rxBuf.head > c->rxBuf.end) { return -4; }
+    if (c->rxBuf.tail < c->rxBuf.start || c->rxBuf.tail > c->rxBuf.end) { return -5; }
+    if (c->rxBuf.scan < c->rxBuf.start || c->rxBuf.scan > c->rxBuf.end) { return -6; }
     
     // Set parse enable flags
-    if (c->config.enabledMask != 
-        (ENABLE_PROTOCOL_ISB
-        | ENABLE_PROTOCOL_NMEA
-        | ENABLE_PROTOCOL_UBLOX
-        | ENABLE_PROTOCOL_RTCM3
-        // | ENABLE_PROTOCOL_SONY
-        // | ENABLE_PROTOCOL_SPARTN 
-        )) { return -1; }
+    if ((c->config.enabledMask & DEFAULT_PROTO_MASK) != DEFAULT_PROTO_MASK) { return -7; }
     
-    if (c->rxPkt.data.ptr != NULL && (c->rxPkt.data.ptr < c->rxBuf.start || c->rxPkt.data.ptr > c->rxBuf.end)) { return -1; }
+    if (c->rxPkt.data.ptr != NULL && (c->rxPkt.data.ptr < c->rxBuf.start || c->rxPkt.data.ptr > c->rxBuf.end)) { return -8; }
 
     // Everything matches
     return 0;

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -90,6 +90,8 @@ typedef enum
     _PTYPE_LAST_DATA            = _PTYPE_SONY
 } protocol_type_t;
 
+#define DEFAULT_PROTO_MASK (ENABLE_PROTOCOL_ISB | ENABLE_PROTOCOL_NMEA | ENABLE_PROTOCOL_UBLOX | ENABLE_PROTOCOL_RTCM3)
+
 /** The maximum allowable dataset size */
 #define MAX_DATASET_SIZE        1024
 

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1871,11 +1871,11 @@ string cInertialSenseDisplay::DataToStringEvent(const did_event_t &event, const 
     ptr += SNPRINTF(ptr, ptrEnd - ptr, "Dev upTime: %dms\n", event.time);
 
     // print Serial number */
-    event.senderSN;
+    // event.senderSN;
     ptr += SNPRINTF(ptr, ptrEnd - ptr, "Sender SN:%d\n", event.senderSN);
   
     /** Hardware: 0=Host, 1=uINS, 2=EVB, 3=IMX, 4=GPX (see "Product Hardware ID") */
-    event.senderHdwId;
+    // event.senderHdwId;
     switch (event.senderHdwId)
     {
         case IS_HARDWARE_TYPE_IMX:  ptr += SNPRINTF(ptr, ptrEnd - ptr, "HDW Type: IMX\n"); break;

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -5081,7 +5081,7 @@ typedef struct
 
 } did_event_filter_t;
 
-#define EVENT_MEM_REQ_SIZE  128
+#define EVENT_MEM_REQ_SIZE  16
 
 typedef struct
 {

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3588,8 +3588,8 @@ typedef struct PACKED
 
     //uint8_t obs_pairs_filtered;   // number of satellites used to compute float solution [nu, nr in relpos() after selsat()]. Min is 0, max is number of common pairs between obs_rover_avail and obs_base_avail.
     uint8_t reserved2;
-    uint8_t raw_ptr_queue_overrun;
-    uint8_t raw_dat_queue_overrun;
+    uint8_t raw_ptr_queue_limited;
+    uint8_t raw_dat_queue_limited;
     uint8_t obs_unhealthy;          // number of satellites marked as "unhealthy" by rover (nonzero terms in svh)
 
     uint8_t obs_rover_avail;        // nu - total number of satellites with observations to rover in relpos() before selsat()

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1454,8 +1454,8 @@ enum eGenFaultCodes
     GFC_INS_STATE_ORUN_ALT				= 0x00000004,
     /*! Unhandled interrupt */
     GFC_UNHANDLED_INTERRUPT				= 0x00000010,
-    /*! GNSS system runtime fault */
-    GFC_GNSS_SYS_FAULT					= 0x00000020,
+    /*! GNSS receiver critical fault. See the corresponding GPS status fault flags (i.e. GPX_STATUS_FATAL_MASK) */
+    GFC_GNSS_CRITICAL_FAULT             = 0x00000020,
     /*! GNSS Tx limited */
     GFC_GNSS_TX_LIMITED				    = 0x00000040,
     /*! GNSS Rx overrun */
@@ -1483,7 +1483,7 @@ enum eGenFaultCodes
     /*! Sensor(s) saturated */
     GFC_SENSOR_SATURATION 				= 0x00040000,
     /*! Fault: GPS receiver time fault */
-    GFC_SER_CHECK_INIT             = 0x00080000,
+    GFC_SER_CHECK_INIT                  = 0x00080000,
     /*! Fault: IMU initialization */
     GFC_INIT_IMU						= 0x00100000,
     /*! Fault: Barometer initialization */
@@ -1492,15 +1492,17 @@ enum eGenFaultCodes
     GFC_INIT_MAGNETOMETER				= 0x00400000,
     /*! Fault: I2C initialization */
     GFC_INIT_I2C						= 0x00800000,
-    /*! Fault: Chip erase line toggled but did not meet required hold time.  This is caused by noise/transient on chip erase pin.  */
+    /*! Fault: Chip erase line toggled but did not meet required hold time.  This is caused by noise/transient on chip erase pin. */
     GFC_CHIP_ERASE_INVALID				= 0x01000000,
     /*! Fault: EKF GPS time fault */
     GFC_EKF_GNSS_TIME_FAULT             = 0x02000000,
     /*! Fault: GPS receiver time fault */
     GFC_GNSS_RECEIVER_TIME              = 0x04000000,
+    /*! Fault: GNSS reciever ceneral fault. See the corresponding GPS status fault flags (i.e. GPX_STATUS_GENERAL_FAULT_MASK) */
+    GFC_GNSS_GENERAL_FAULT              = 0x08000000,
 
     /*! IMX GFC flags that relate to GPX status flags */
-    GFC_GPX_STATUS_COMMON_MASK = GFC_GNSS1_INIT | GFC_GNSS2_INIT | GFC_GNSS_TX_LIMITED | GFC_GNSS_RX_OVERRUN | GFC_GNSS_SYS_FAULT | GFC_GNSS_RECEIVER_TIME,
+    GFC_GPX_STATUS_COMMON_MASK = GFC_GNSS1_INIT | GFC_GNSS2_INIT | GFC_GNSS_TX_LIMITED | GFC_GNSS_RX_OVERRUN | GFC_GNSS_CRITICAL_FAULT | GFC_GNSS_RECEIVER_TIME | GFC_GNSS_GENERAL_FAULT,
 };
 
 
@@ -4499,21 +4501,26 @@ enum eGpxStatus
     GPX_STATUS_COM1_RX_TRAFFIC_NOT_DECTECTED            = (int)0x00000020,
     GPX_STATUS_COM2_RX_TRAFFIC_NOT_DECTECTED            = (int)0x00000040,
 
-    /** Reserved */
-    GPX_STATUS_RESERVED_1                               = (int)0x00010000,
+    /** General Fault mask */
+    GPX_STATUS_GENERAL_FAULT_MASK                       = (int)0xFFFF0000,
+
+    /** RTK buffer filled causing data loss */
+    GPX_STATUS_FAULT_RTK_QUEUE_LIMITED                  = (int)0x00010000,
+    /** RTK data access blocked by mutex */
+    GPX_STATUS_FAULT_RTK_QUEUE_MUTEX                    = (int)0x00020000,
 
     /** GNSS receiver time fault **/
-    GPX_STATUS_GNSS_RCVR_TIME_FAULT                     = (int)0x00100000,
+    GPX_STATUS_FAULT_GNSS_RCVR_TIME                     = (int)0x00100000,
 
     /** DMA Fault detected **/
-    GPX_STATUS_DMA_FAULT                                = (int)0x00800000,
+    GPX_STATUS_FAULT_DMA                                = (int)0x00800000,
 
-    /** Fatal event */
-    GPX_STATUS_FATAL_MASK                               = (int)0xFF000000,
+    /** Fatal faults - critical failure resulting in CPU reset */
+    GPX_STATUS_FATAL_MASK                               = (int)0x1F000000,
     GPX_STATUS_FATAL_OFFSET                             = 24,
-    GPX_STATUS_FATAL_RESET_LOW_POW                      = (int)1,   // reset from low power
-    GPX_STATUS_FATAL_RESET_BROWN                        = (int)2,   // reset from brown out
-    GPX_STATUS_FATAL_RESET_WATCHDOG                     = (int)3,   // reset from watchdog
+    GPX_STATUS_FATAL_RESET_LOW_POW                      = (int)1,       // reset from low power
+    GPX_STATUS_FATAL_RESET_BROWN                        = (int)2,       // reset from brown out
+    GPX_STATUS_FATAL_RESET_WATCHDOG                     = (int)3,       // reset from watchdog
     GPX_STATUS_FATAL_CPU_EXCEPTION                      = (int)4,                     
     GPX_STATUS_FATAL_UNHANDLED_INTERRUPT                = (int)5,
     GPX_STATUS_FATAL_STACK_OVERFLOW                     = (int)6,
@@ -4521,12 +4528,16 @@ enum eGpxStatus
     GPX_STATUS_FATAL_KERNEL_PANIC                       = (int)8,
     GPX_STATUS_FATAL_UNALIGNED_ACCESS                   = (int)9,
     GPX_STATUS_FATAL_MEMORY_ERROR                       = (int)10,
-    GPX_STATUS_FATAL_BUS_ERROR                          = (int)11,  // bad pointer or malloc
+    GPX_STATUS_FATAL_BUS_ERROR                          = (int)11,      // bad pointer or malloc
     GPX_STATUS_FATAL_USAGE_ERROR                        = (int)12,
     GPX_STATUS_FATAL_DIV_ZERO                           = (int)13,
     GPX_STATUS_FATAL_SER0_REINIT                        = (int)14,
-
     GPX_STATUS_FATAL_UNKNOWN                            = (int)0x1F,    // TODO: Temporarily set to (5 bits). Reset to 0xFF when gpx_flash_cfg.debug is no longer used with fault reporting. (WHJ) 
+
+    /** Internal use */
+    GPX_STATUS_FAULT_RP                                 = (int)0x20000000,
+    /** Reserved for future fault status */
+    GPX_STATUS_FAULT_UNUSED                             = (int)0xC0000000,
 };
 
 /** Hardware status flags */

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -90,7 +90,7 @@ PYBIND11_NUMPY_DTYPE(rtk_debug_t, time, rej_ovfl, code_outlier, phase_outlier, c
                         lack_of_valid_sats, divergent_pnt_pos_iteration, chi_square_error, cycle_slips, ubx_error, 
                         solStatus, rescode_err_marker, error_count, error_code, dist2base, reserved1, gdop_error, 
                         warning_count, warning_code, double_debug, debug, obs_count_bas, obs_count_rov, 
-                        /*obs_pairs_filtered*/ reserved2, raw_ptr_queue_overrun, raw_dat_queue_overrun, 
+                        /*obs_pairs_filtered*/ reserved2, raw_ptr_queue_limited, raw_dat_queue_limited, 
                         obs_unhealthy, obs_rover_avail, obs_base_avail, obs_pairs_used_float, obs_pairs_used_ar, 
                         obs_eph_avail, obs_low_snr_rover, obs_low_snr_base, obs_high_snr_parity, obs_zero_L1_rover, 
                         obs_zero_L1_base, obs_low_elev_rover, obs_low_elev_base, eph1RxCnt, eph2RxCnt, reserved);


### PR DESCRIPTION
- Fix raw gps data drop on GPX.
- Add general fault status mask to GPX so any error is easily identifiable. 