### PR TITLE
SN-6250 Fix RTK Queue

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4506,8 +4506,6 @@ enum eGpxStatus
 
     /** RTK buffer filled causing data loss */
     GPX_STATUS_FAULT_RTK_QUEUE_LIMITED                  = (int)0x00010000,
-    /** RTK data access blocked by mutex */
-    GPX_STATUS_FAULT_RTK_QUEUE_MUTEX                    = (int)0x00020000,
 
     /** GNSS receiver time fault **/
     GPX_STATUS_FAULT_GNSS_RCVR_TIME                     = (int)0x00100000,


### PR DESCRIPTION
Fixes issue in RTK queue introduced in 2.3.1 refactor where raw data would be lost if the RTK RTOS task runs consistently longer than 500ms.