### PR TITLE
SN-6405 Added slow rate logging of DID_IMU3_RAW to PPD

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1834,7 +1834,8 @@ typedef struct PACKED
 #define RMC_BITS_INTERNAL_PPD           0x4000000000000000      // 
 #define RMC_BITS_PRESET                 0x8000000000000000		// Indicate BITS is a preset.  This sets the rmc period multiple and enables broadcasting.
 
-#define RMC_PRESET_PPD_NAV_PERIOD_MULT_MS	100
+#define RMC_PRESET_PPD_NAV_PERIOD_MULT_MS   100
+#define RMC_PRESET_PPD_IMU3_PERIOD_MULT     1000
 
 // Preset: Post Processing Data
 #define RMC_PRESET_IMX_PPD_NO_IMU           (RMC_BITS_PRESET \


### PR DESCRIPTION
Add DID_IMU3_RAW at slow rate when DID_PIMU is present to PPD logs for triple IMU analysis.  This increases the PPD log stream about 1.5%.