### PR TITLE
Change logger time format from seconds to h:mm:ss

### DIFF
--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -243,12 +243,18 @@ string cInertialSenseDisplay::Connected()
 
 	unsigned int timeMs = current_timeMs();
 
-	// cltool runtime
-	double runtime = 0.001 * (timeMs - m_startMs);
+	// cltool elapsed
+	unsigned int elapsedMs = timeMs - m_startMs;
+	unsigned int totalSeconds = elapsedMs / 1000;
+	unsigned int hours = totalSeconds / 3600;
+	unsigned int minutes = (totalSeconds % 3600) / 60;
+	unsigned int seconds = totalSeconds % 60;
 
 	std::ostringstream stream;
 	stream << Header() << "Connected.  ";
-    stream << std::fixed << std::setprecision(1) << runtime << "s";
+	stream << hours << ':'
+		<< std::setw(2) << std::setfill('0') << minutes << ':'
+		<< std::setw(2) << std::setfill('0') << seconds << 's';
 	stream << ", Tx " << (m_comm ? std::to_string(m_comm->txPktCount) : "--");
 	stream << ", Rx " << (m_comm ? std::to_string(m_comm->rxPktCount) : "--");
 	if (m_port)

--- a/src/ISLogger.cpp
+++ b/src/ISLogger.cpp
@@ -177,6 +177,7 @@ bool cISLogger::InitSave(const string &directory, const sSaveOptions &options)
     m_logType = options.logType;
     m_timeStamp = (options.timeStamp.empty() ? CreateCurrentTimestamp() : options.timeStamp);
     m_rootDirectory = m_directory = (directory.empty() ? DEFAULT_LOGS_DIRECTORY : directory);
+    m_logStartTime = GetTime();
 
     // Drive usage limit
     m_maxDiskSpace = 0;                 // disable log file culling
@@ -843,10 +844,17 @@ void cISLogger::PrintIsCommStatus()
 void cISLogger::PrintLogDiskUsage()
 {
     float logSize = LogSizeAll();
+
+    // Compute elapsed time since logging started
+    time_t elapsed = GetTime() - m_logStartTime;
+    int hours = elapsed / 3600;
+    int minutes = (elapsed % 3600) / 60;
+    int seconds = elapsed % 60;
+
     if (logSize < 0.5e6f)
-        printf("\nLogging %5.1f KB to: %s", logSize * 1.0e-3f, LogDirectory().c_str());
+        printf("\nLogging %d:%02d:%02ds %5.1f KB to: %s", hours, minutes, seconds, logSize * 1.0e-3f, LogDirectory().c_str());
     else
-        printf("\nLogging %5.2f MB to: %s", logSize * 1.0e-6f, LogDirectory().c_str());
+        printf("\nLogging %d:%02d:%02ds %5.2f MB to: %s", hours, minutes, seconds, logSize * 1.0e-6f, LogDirectory().c_str());
 
     // Disk usage
     if (MaxDiskSpaceMB() > 0.0f)

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -284,6 +284,7 @@ private:
     bool					m_showPath = false;
     bool					m_showTimeStamp = false;
     double					m_iconUpdatePeriodSec = false;
+    time_t                  m_logStartTime = 0;
     time_t					m_lastCommTime = 0;
     time_t					m_timeoutFlushSeconds = 0;
     time_t					m_timeoutFileCullingSeconds = 10;


### PR DESCRIPTION
Display elapsed runtime in cltool as `h:mm:ss` rather than `ss.s`.