### PR TITLE
Remove CXD5610 from IO_CONFIG_GPS_TYPE

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3114,10 +3114,8 @@ enum eIoConfig
     IO_CONFIG_GPS_TYPE_NMEA						= (int)2,
     /** GPS type - InertialSense GPX */
     IO_CONFIG_GPS_TYPE_GPX						= (int)3,
-    /** GPS type - Sony CXD5610 */
-    IO_CONFIG_GPS_TYPE_CXD5610					= (int)4,
     /** GPS type - last type */
-    IO_CONFIG_GPS_TYPE_LAST						= IO_CONFIG_GPS_TYPE_CXD5610,		// Set to last type
+    IO_CONFIG_GPS_TYPE_LAST						= IO_CONFIG_GPS_TYPE_GPX,		// Set to last type
 
 #define IO_CONFIG_GPS1_SOURCE(ioConfig)     (((ioConfig)>>IO_CONFIG_GPS1_SOURCE_OFFSET)&IO_CONFIG_GPS_SOURCE_MASK)
 #define IO_CONFIG_GPS2_SOURCE(ioConfig)     (((ioConfig)>>IO_CONFIG_GPS2_SOURCE_OFFSET)&IO_CONFIG_GPS_SOURCE_MASK)


### PR DESCRIPTION
Remove CXD5610 from IO_CONFIG_GPS_TYPE because it is not an option.