### PR TITLE
SN-6188 Cltool now only stops broadcasting on current port, not all ports

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -305,7 +305,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     // Stop streaming any messages, wait for buffer to clear, and enable Rx callback
     if (!g_commandLineOptions.listenMode)
     {   
-        inertialSenseInterface.StopBroadcasts();
+        inertialSenseInterface.StopBroadcasts(false);
     }
     SLEEP_MS(100);
     g_enableDataCallback = true;

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -638,7 +638,7 @@ void InertialSense::Close()
     EnableLogger(false);
     if (m_disableBroadcastsOnClose)
     {
-        StopBroadcasts();
+        StopBroadcasts(false);
         SLEEP_MS(100);
     }
     CloseSerialPorts(true); // allow all opened ports to transmit all buffered data


### PR DESCRIPTION
Change Cltool and InertialSense class to only stop broadcasts on current port and not all ports, to not interrupt communications on other ports.