### PR TITLE
Fix windows build_test_all.bat

### DIFF
--- a/python/supernpp/supernpp.py
+++ b/python/supernpp/supernpp.py
@@ -289,6 +289,10 @@ if __name__ == "__main__":
     npp_build_folder = "../../../cpp/NavPostProcess/build"
     # buildNPP(npp_build_folder)
 
+    print("Arguments passed to the script:")
+    for i, arg in enumerate(sys.argv):
+        print(f"arg[{i}] = {arg}")
+        
     # 2nd argument: Log directory list file
     if len(sys.argv) < 2:
         exit(1)

--- a/scripts/build_manager.py
+++ b/scripts/build_manager.py
@@ -177,7 +177,7 @@ class BuildTestManager:
         result = 0
         if self.run_test:
             self.test_header(project_name)
-            result = callback()
+            result = callback(self.test_name)
             self.test_footer(result)
         if result:
             self.result = result


### PR DESCRIPTION
This fixes issues with running NPP tests from build_test_all script in windows.