### PR TITLE
Change dirty character from * to ^

### DIFF
--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -291,7 +291,7 @@ std::string ISDevice::getFirmwareInfo(const dev_info_t& devInfo, int detail, eHd
             case 'c': out +="-rc";          break;
             case 'd': out +="-devel";       break;
             case 's': out +="-snap";        break;
-            case '*': out +="-snap";        break;
+            case '^': out +="-snap";        break;
             default : out +="";             break;
         }
         if (devInfo.firmwareVer[3] != 0)
@@ -299,8 +299,8 @@ std::string ISDevice::getFirmwareInfo(const dev_info_t& devInfo, int detail, eHd
 
         if (detail > 0) {
             out += utils::string_format(" %08x", devInfo.repoRevision);
-            if (devInfo.buildType == '*') {
-                out += "*";
+            if (devInfo.buildType == '^') {
+                out += "^";
             }
 
             if (detail > 1) {

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -241,7 +241,7 @@ std::string utils::getFirmwareAsString(const dev_info_t& devInfo) {
         case 'c': out +="-rc";          break;
         case 'd': out +="-devel";       break;
         case 's': out +="-snap";        break;
-        case '*': out +="-snap";        break;
+        case '^': out +="-snap";        break;
         default : out +="";             break;
     }
     if (devInfo.firmwareVer[3] != 0)
@@ -255,8 +255,8 @@ std::string utils::getBuildAsString(const dev_info_t &devInfo, uint16_t flags) {
 
     if ((flags & DV_BIT_BUILD_COMMIT) && devInfo.repoRevision) {
         out += utils::string_format("%08x", devInfo.repoRevision);
-        if (devInfo.buildType == '*') {
-            out += "*";
+        if (devInfo.buildType == '^') {
+            out += "^";
         }
     }
 
@@ -435,8 +435,8 @@ uint16_t utils::devInfoFromString(const std::string& str, dev_info_t& devInfo) {
                         break;
                     case 8:  // repo hash & build status
                         devInfo.repoRevision = std::stol(match[1].str(), NULL, 16);
-                        if (match[2].matched && (match[2].str()[0] == '*')) {
-                            devInfo.buildType = '*';
+                        if (match[2].matched && (match[2].str()[0] == '^')) {
+                            devInfo.buildType = '^';
                         }
                         componentsParsed |= DV_BIT_BUILD_COMMIT;
                         break;


### PR DESCRIPTION
Fix areas missed in develop for switching the dirty character in our version string from '*" to '^'. 