### PR TITLE
SN-6595 Do not convert units and reduce precision for CSV logs

### DIFF
--- a/src/DataCSV.cpp
+++ b/src/DataCSV.cpp
@@ -226,12 +226,6 @@ bool cDataCSV::DataToStringCSV(const p_data_hdr_t& hdr, const uint8_t* buf, stri
 	hdrCopy.offset = 0;
 	hdrCopy.size = size;
 
-    if (hdr.id == DID_IMU3_RAW)
-    {
-        int k = 0;
-        k++;
-    }
-
 	for (map_name_to_info_t::const_iterator offset = offsetMap->begin(); offset != offsetMap->end(); offset++)
 	{
 		const data_info_t &info = offset->second;

--- a/src/DataCSV.cpp
+++ b/src/DataCSV.cpp
@@ -182,8 +182,8 @@ bool cDataCSV::StringCSVToData(string& s, p_data_hdr_t& hdr, uint8_t* buf, uint3
 			// end field
 			columnData = string(start + foundQuotes, i - foundQuotes);
 			start = i + 1;
-			const data_info_t& data = columnHeaders[index++];
-            if (data.offset < MAX_DATASET_SIZE && !cISDataMappings::StringToData(columnData.c_str(), (int)columnData.length(), &hdr, buf, data))
+			const data_info_t& info = columnHeaders[index++];
+            if (info.offset < MAX_DATASET_SIZE && !cISDataMappings::StringToData(columnData.c_str(), (int)columnData.length(), &hdr, buf, info, 0, false, false))
 			{
 				return false;
 			}
@@ -226,6 +226,12 @@ bool cDataCSV::DataToStringCSV(const p_data_hdr_t& hdr, const uint8_t* buf, stri
 	hdrCopy.offset = 0;
 	hdrCopy.size = size;
 
+    if (hdr.id == DID_IMU3_RAW)
+    {
+        int k = 0;
+        k++;
+    }
+
 	for (map_name_to_info_t::const_iterator offset = offsetMap->begin(); offset != offsetMap->end(); offset++)
 	{
 		const data_info_t &info = offset->second;
@@ -233,14 +239,14 @@ bool cDataCSV::DataToStringCSV(const p_data_hdr_t& hdr, const uint8_t* buf, stri
 		{	// Array
 			for (uint32_t i=0; i<info.arraySize; i++)
 			{
-				cISDataMappings::DataToString(offset->second, &hdrCopy, bufPtr, tmp, i);
+				cISDataMappings::DataToString(info, &hdrCopy, bufPtr, tmp, i, false, false);
 				csv += ",";
 				csv += tmp;
 			}
 		}
 		else
 		{	// Single element
-			cISDataMappings::DataToString(offset->second, &hdrCopy, bufPtr, tmp);
+			cISDataMappings::DataToString(info, &hdrCopy, bufPtr, tmp, 0, false, false);
 			csv += ",";
 			csv += tmp;
 		}

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1763,6 +1763,9 @@ bool cISDataMappings::StringToData(const char* stringBuffer, int stringLength, c
 
 bool cISDataMappings::StringToVariable(const char* stringBuffer, int stringLength, const uint8_t* dataBuffer, eDataType dataType, uint32_t dataSize, int radix, double conversion, bool json)
 {
+    // Reset errno before calling strtol/strtoul/strtod.  There are cases in which it only gets set and not reset.
+    errno = 0;
+
     float valuef32;
     double valuef64;
     switch (dataType)

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1756,7 +1756,7 @@ bool cISDataMappings::StringToData(const char* stringBuffer, int stringLength, c
     int radix = ((stringBuffer[0] == '0' && stringBuffer[1] == 'x') == 0 ? 16 : 10);
 #endif
 
-    double conversion = useConversion ? info.conversion : 1.0;      // Don't convert units.  Used for CSV logs. (WHJ)
+    double conversion = useConversion ? info.conversion : 1.0;      // When useConversion is false, don't convert units.  Used for CSV logs. (WHJ)
 
     return StringToVariable(stringBuffer, stringLength, ptr, info.type, info.size, radix, conversion, json);
 }

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -626,6 +626,14 @@ protected:
 
 	data_set_t m_data_set[DID_COUNT];
 
+#if PLATFORM_IS_EMBEDDED
+	// on embedded we cannot new up C++ runtime until after free rtos has started
+	static cISDataMappings* s_map;
+#else
+	static cISDataMappings s_map;
+#endif
+
+private:
     #define PROTECT_UNALIGNED_ASSIGNS
     template<typename T>
     static inline void protectUnalignedAssign(void* out, T in) {
@@ -651,13 +659,6 @@ protected:
         return *(T*)in;
     #endif
     }
-
-#if PLATFORM_IS_EMBEDDED
-	// on embedded we cannot new up C++ runtime until after free rtos has started
-	static cISDataMappings* s_map;
-#else
-	static cISDataMappings s_map;
-#endif
 
 };
 

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -555,7 +555,7 @@ public:
 	* @param json true if json, false if csv
 	* @return true if success, false if error
 	*/
-	static bool StringToData(const char* stringBuffer, int stringLength, const p_data_hdr_t* hdr, uint8_t* datasetBuffer, const data_info_t& info, unsigned int arrayIndex = 0, bool json = false);
+	static bool StringToData(const char* stringBuffer, int stringLength, const p_data_hdr_t* hdr, uint8_t* datasetBuffer, const data_info_t& info, unsigned int arrayIndex = 0, bool json = false, bool useConversion = true);
 
 	/**
 	* Convert a string to a variable.
@@ -580,7 +580,7 @@ public:
 	* @param json true if json, false if csv
 	* @return true if success, false if error
 	*/
-	static bool DataToString(const data_info_t& info, const p_data_hdr_t* hdr, const uint8_t* datasetBuffer, data_mapping_string_t stringBuffer, unsigned int arrayIndex = 0, bool json = false);
+	static bool DataToString(const data_info_t& info, const p_data_hdr_t* hdr, const uint8_t* datasetBuffer, data_mapping_string_t stringBuffer, unsigned int arrayIndex = 0, bool json = false, bool useConversion = true);
 
 	/**
 	* Convert a variable to a string


### PR DESCRIPTION
This corrects an issue introduced in release 2.2.0 in which the CSV units for angles was converted to degrees and reduced precision.  The reverts to radians and provides full precision.