### PR TITLE
Example Project for ISDevice and port_handle_t

### DIFF
--- a/ExampleProjects/Minimal_ISDevice/CMakeLists.txt
+++ b/ExampleProjects/Minimal_ISDevice/CMakeLists.txt
@@ -1,0 +1,26 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.21.0)
+
+project(ISDeviceBasics1)
+
+set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
+include(${IS_SDK_DIR}/include_is_sdk_find_library.cmake)
+
+# Include InertialSenseSDK header files
+include_directories(
+    ${IS_SDK_DIR}/src
+    ${IS_SDK_DIR}/src/libusb/libusb
+)
+
+# Link the InertialSenseSDK static library 
+link_directories(${IS_SDK_DIR})
+
+# Define the executable
+add_executable(${PROJECT_NAME} ISDeviceExample1.cpp)
+
+# Build using C11 and CXX20
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 17)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)
+set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# Link IS-SDK libraries to the executable
+include(${IS_SDK_DIR}/include_is_sdk_target_link_libraries.cmake)

--- a/ExampleProjects/Minimal_ISDevice/ISDeviceExample1.cpp
+++ b/ExampleProjects/Minimal_ISDevice/ISDeviceExample1.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file ISDeviceExample1.cpp 
+ * @brief An application that demonstrates to mode basic C++ example of connecting to an Inertial Sense device and streaming data from it.
+ *
+ * @author Kyle Mallory on 6/3/25.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include <iostream>
+
+#include "PortFactory.h"
+#include "ISDevice.h"
+#include "ISDisplay.h"
+
+
+/** this is a global instance of a utility class that handles printing/formatting of various data sets received from the device */
+cInertialSenseDisplay isDisplay = cInertialSenseDisplay(cInertialSenseDisplay::DMODE_PRETTY);
+
+/**
+ * This is a callback handler that we will register with the ISDevice once its created, and which will be called every time data arrives from the device
+ * @param ctx this is an opaque context pointer for this message - in this example, it will be the ISDevice* that received it the message - the ISDevice
+ *   still need to process the data that it receives, so we dereference this, and call OnIsbDataHandler()
+ * @param data a pointer to a p_data_t struct, which represents the buffer of data received from the device, including the data ID, associated flags,
+ *   and the actual data payload
+ * @param port the port_handle_t that this data was received from
+ * @returns 0 if this message was successfully processed by a protocol-specific handler, and should not be further processed, otherwise return !0
+ */
+int isbDataHandler(void* ctx, p_data_t* data, port_handle_t port) {
+    if (ctx) ((ISDevice*)ctx)->onIsbDataHandler(data, port);
+
+    std::cout << isDisplay.DataToString((const p_data_t*)data);
+    return 0;
+}
+
+/**
+ * This is the "explained" example, it exposes a few more aspects of the SDK but is essentially functionally equivalent to the
+ * "minimal" example below.  Both usages bind a port_handle_t to the named port. With the handle, the port is opened, and an
+ * ISDevice is created using that handle.  With the resulting device we validate its connectivity and configure it to stream
+ * DID_SYS_PARAMS messages every 5 seconds.  Data is output to the console, and the application loops until the port is closed.
+ */
+int main_explained(const char* portStr) {
+
+    // First, we need to get a port_handle_t that the Device is connected to...
+
+    // Assuming we know the name of the port we want to use, we will create a port_handle_t from its name.
+    // PortFactory::bindPort() is used to allocate and initialize the underlying port_handle_t.
+    // Note that here we are using SerialPortFactory because we KNOW we want a serial port
+    port_handle_t port = SerialPortFactory::getInstance().bindPort(portStr);
+
+    // For the sake of demonstration, let's check that the port is valid...
+    //    portIsValid(...) returns true if the port is properly initialized (as opposed to a invalid/null pointer)
+    if (!portIsValid(port)) {
+        std::cerr << "Port is NOT valid!" << std::endl; // NOTE that if the port is invalid, we cannot safely call any other port*() functions using the handle.
+        exit(1);
+    }
+
+    // and open it, if it's not already opened (probably not)
+    //    portIsOpened(...) returns true if the port is already opened,
+    //    portOpen(...) attempts to open the port, and returns PORT_ERROR__NONE if successful
+    //      for future simplicity, portOpen() will both validate, and open, so the above portIsValid() and portIsOpened() aren't actually necessary here - we just wanted to show their usage.
+    if (!portIsOpened(port) && (portOpen(port) != PORT_ERROR__NONE)) {
+        std::cerr << "Unable to open the port " << portName(port) << std::endl;   // since we have a valid port, we can get the name of the port if we want, using portName(...).
+        exit(2);
+    }
+
+    // With a valid, opened port, we can instance an ISDevice - in this case, an IMX-5.0 and associate the port to it.
+    ISDevice* device = new ISDevice(IS_HARDWARE_IMX_5_0, port);
+
+    if (!device->isConnected())
+        exit(3); // this is another way we can confirm the connected status of the device
+
+    // At this point, we have an unknown device associated with our port.
+    // we can view (and confirm) that its 'unknown' by outputting the device description
+    std::cout << "Allocated device " << device->getDescription() << std::endl;
+
+    // However, we want to communicate with the device and do things with it...
+
+    // ISDevice::validate(timeoutMs) will block until the device can be validated, devInfo fetched and flash configuration synchronized
+    if (!device->validate(3000)) {
+        std::cerr << "Timeout occurred while attempting to validate the device on port " << portName(port) << std::endl;
+        exit(3);
+    }
+
+    // for demonstration purposes, let's print our device description now that we've validated
+    std::cout << "Validated device " << device->getDescription() << std::endl;
+
+    // Now that we have the device, and all its information has been validated, we can start to do real work with it...
+
+    // Before we can get useful data from the device, we need to tell the SDK where to send the data it received from the device...
+    // Let's use the function created at the stop of this source file
+    device->registerIsbDataHandler(isbDataHandler);
+
+    // Devices can be configured to stream data by default on powerup - lets stop all other messages before enabling ours
+    device->StopBroadcasts(true);
+
+    // Next, we need to indicate the specific data that we are interested in receiving, and how frequently we'd like to receive it.
+    // Let's get the System Status (SYS_PARAMS) including uptime
+    device->BroadcastBinaryData(DID_SYS_PARAMS, 5000);   // DID_SYS_PARAMS has a normal period of 1ms, so every 5000 * 1ms (5 seconds)
+
+    // Finally, operate in a communications loop (this could be a thread, etc) and call ISDevice::step() periodically (ideally about every 1ms),
+    // allowing the SDK to exchange and parse data with the connected device.
+    while (portIsOpened(device->port)) {
+        device->step();
+        SLEEP_MS(1);
+    }
+    return 0;
+}
+
+/**
+ * This is the "minimal" example, it demonstrates the most direct and basic interfaces to connect to a known device, and stream
+ * data from it. This example binds a port_handle_t to the named port, and then creates an ISDevice instance bound to that port.
+ * The device instances is connected, all default data streaming is disabled, and then subsequently configured to stream
+ * DID_SYS_PARAMS messages every 5 seconds.  Data is output to the console, and the application loops until the port is closed.
+ */
+int main_minimal(const char* portStr) {
+    // get a port handle for the specified serial port
+    port_handle_t port = SerialPortFactory::getInstance().bindPort(portStr);
+
+    // create a new IMX-5.0 device and bind the associated port
+    ISDevice* device = new ISDevice(IS_HARDWARE_IMX_5_0, port);
+
+    // connect to the device
+    if (!device->connect()) {
+        std::cerr << "Could not connect to device on port " << device->getPortName() << std::endl;
+        exit(1);
+    }
+
+    p_data_hdr_t hdr = { .id = DID_SYS_PARAMS };        // just a little hack to make isDisplay.DataToStringSysParams() work nicely for the demo
+
+    //device->validate();
+    // device->StopBroadcasts(true);                       // stop all other messages
+    // device->registerIsbDataHandler(isbDataHandler);     // register our data handler
+    device->BroadcastBinaryData(DID_SYS_PARAMS, 5000);  // request the data of interest at the specified interval
+    while (portIsOpened(device->port)) {                // and then spin as long as the port is open
+        device->step();                                 // this processes all incoming data, and calls out handler, etc
+        std::cout << isDisplay.DataToStringSysParams(device->sysParams, hdr);
+        SLEEP_MS(5000);
+    }
+    return 0;
+}
+
+/**
+ * The main entry point for the application - note that this calls one of two examples, both do the same thing with slight differences.
+ * @param argc
+ * @param argv
+ * @return
+ */
+int main(int argc, const char** argv) {
+
+#if PLATFORM_IS_LINUX
+    const char* portArg = "/dev/ttyACM0";
+#else
+    const char* portArg = "COMM1";
+#endif
+    if (argc > 1)
+        portArg = argv[1];     // take the first argument as the port to connect with
+
+#ifdef EXPLAINED
+    return main_explained(portArg);
+#else
+    return main_minimal(portArg);
+#endif
+}

--- a/src/DeviceFactory.h
+++ b/src/DeviceFactory.h
@@ -34,7 +34,7 @@ public:
      * @param port an associated port (optional) that this device should be bound to.
      * @return a ISDevice pointer to the newly allocated ISDevice or null of not allocated
      */
-    virtual ISDevice* allocateDevice(const dev_info_t &devInfo, port_handle_t port = nullptr) = 0;
+    virtual ISDevice* allocateDevice(const dev_info_t &devInfo, port_handle_t port = nullptr) { return new ISDevice(devInfo, port); };
 
     /**
      * A function responsible for freeing the allocated memory of the ISDevice instance.

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -573,17 +573,18 @@ typedef struct
 
 typedef protocol_type_t (*pFnProcessPkt)(void*);
 
-// raw packet handler function with is_comm_instance_t
-typedef int(*pfnIsCommHandler)(void* ctx, protocol_type_t ptype, packet_t *pkt, port_handle_t port);
-
-// InertialSense binary (ISB) data message handler function
-typedef int(*pfnIsCommIsbDataHandler)(void* ctx, p_data_t* data, port_handle_t port);
-
 // broadcast message handler
 // typedef int(*pfnIsCommAsapMsg)(p_data_get_t* req, port_handle_t port);
 
-// Generic message handler function with message pointer and size
+// InertialSense binary (ISB) data message handler function   - returns 0 if this message was successfully processed by a protocol-specific handler; Do not process it again with the raw callback
+typedef int(*pfnIsCommIsbDataHandler)(void* ctx, p_data_t* data, port_handle_t port);
+
+// Generic message handler function with message pointer and size   - returns 0 if this message was successfully processed by a protocol-specific handler; Do not process it again with the raw callback
 typedef int(*pfnIsCommGenMsgHandler)(void* ctx, const unsigned char* msg, int msgSize, port_handle_t port);
+
+// raw packet handler function with is_comm_instance_t
+typedef int(*pfnIsCommHandler)(void* ctx, protocol_type_t ptype, packet_t *pkt, port_handle_t port);
+
 
 // Callback functions are called when the specific message is received and callback pointer is not null:
 typedef struct

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -642,7 +642,6 @@ static const uint8_t COMM_PORT_FLAG__EXPLICIT_READ  = 0x01;     //! When set, IS
 
 typedef struct {
     base_port_t base;
-    // port_monitor_set_t* stats;          //! stats associated with this port
     is_comm_instance_t comm;            //! Comm instance
 #if defined(GPX_1)
     #define GPX_COM_BUFFER_SIZE 2800

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -87,6 +87,7 @@ public:
         flashCfgUploadTimeMs = src.flashCfgUploadTimeMs;
         flashCfgUpload = src.flashCfgUpload;
         evbFlashCfg = src.evbFlashCfg;
+        sysParams = src.sysParams;
         sysCmd = src.sysCmd;
         // devLogger = src.devLogger.get();
         closeStatus = src.closeStatus;
@@ -124,6 +125,7 @@ public:
         flashCfgUploadTimeMs = src.flashCfgUploadTimeMs;
         flashCfgUpload = src.flashCfgUpload;
         evbFlashCfg = src.evbFlashCfg;
+        sysParams = src.sysParams;
         sysCmd = src.sysCmd;
         // devLogger = src.devLogger.get();
         closeStatus = src.closeStatus;
@@ -159,14 +161,21 @@ public:
      * Connects the bound port to the device, if the port is valid and of PORT_TYPE__COMM
      * Can be overridden to provide custom configuration, etc on connection - just remember
      *  to call back into ISDevice::connect() in your new method.
+     * @param dontValidate if true (default), skips device validation after successfully connecting
      * @return true if the connection is made/port opened, otherwise false
      */
-    virtual bool connect() {
+    virtual bool connect(bool dontValidate = true) {
         if (!portIsValid(port) || !(portType(port) & PORT_TYPE__COMM))
             return false;
         if (portIsOpened(port))
             return true;
-        return (portOpen(port) == PORT_ERROR__NONE);
+        bool result = (portOpen(port) == PORT_ERROR__NONE);
+
+        if (!dontValidate && result) {
+            SLEEP_MS(15);
+            result = validate();
+        }
+        return result;
     }
 
     /**

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -257,11 +257,6 @@ public:
         return (devLog && logInstance->LogData(devLog, len, buf)) ? 1 : -1;
     }
 
-    static int logPortWrite(port_handle_t port, const uint8_t* buf, unsigned int len) {
-        // FIXME: We currently aren't interested in logging data that we have SENT (portWrite) to the device, only the response back from the device
-        return -1;
-    }
-
 private:
 #if CPP11_IS_ENABLED
     cISLogger(const cISLogger& copy) = delete;

--- a/src/PortFactory.cpp
+++ b/src/PortFactory.cpp
@@ -162,7 +162,7 @@ int SerialPortFactory::getComPorts(std::vector<std::string>& portNames)
         snprintf(comPort, sizeof(comPort), "COM%d", i);
         if (QueryDosDeviceA(comPort, targetPath, 256))
         {
-            ports.push_back(comPort);
+            portNames.push_back(comPort);
         }
     }
 

--- a/src/PortFactory.cpp
+++ b/src/PortFactory.cpp
@@ -26,7 +26,10 @@
 
 
 
-port_handle_t SerialPortFactory::bindPort(uint16_t pType, const std::string& pName) {
+port_handle_t SerialPortFactory::bindPort(const std::string& pName, uint16_t pType) {
+    if (!validatePort(pName, pType))
+        return nullptr;
+
     serial_port_t* serialPort = new serial_port_t;
     port_handle_t port = (port_handle_t)serialPort;
 
@@ -59,7 +62,7 @@ bool SerialPortFactory::releasePort(port_handle_t port) {
     return true;
 }
 
-bool SerialPortFactory::validatePort(uint16_t pType, const std::string& pName) {
+bool SerialPortFactory::validatePort(const std::string& pName, uint16_t pType) {
 #if PLATFORM_IS_WINDOWS
     char targetPath[256];
     return (QueryDosDeviceA(pName.c_str(), targetPath, sizeof(targetPath)) != 0);
@@ -70,11 +73,11 @@ bool SerialPortFactory::validatePort(uint16_t pType, const std::string& pName) {
 
 void SerialPortFactory::locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern, uint16_t pType) {
     std::regex matchPattern(pattern);
-    getComPorts(ports);
-    for (auto& np : ports) {
-        auto match = std::regex_match(np, matchPattern);
-        if (validatePort(PORT_TYPE__UART, np) && match)
-            portCallback(this, PORT_TYPE__UART, np);
+    getComPorts(portNames);
+    for (auto& name : portNames) {
+        auto match = std::regex_match(name, matchPattern);
+        if (validatePort(name, PORT_TYPE__UART) && match)
+            portCallback(this, PORT_TYPE__UART, name);
     }
 }
 
@@ -142,12 +145,12 @@ int SerialPortFactory::onPortError(port_handle_t port, int errCode, const char *
  * Populates a vector of string identifiers for all available Serial/TTY/UART devices on the host system.
  * This does not open, access, or configure the devices, nor does it make any guarantee about the availability
  * of the ports (only that the OS has registered/enumerated it).
- * @param ports a reference to a vector of strings, which will be populated with available serial ports
+ * @param portNames a reference to a vector of strings, which will be populated with names identifiers of available ports
  * @return the number of ports found on the host
  */
-int SerialPortFactory::getComPorts(std::vector<std::string>& ports)
+int SerialPortFactory::getComPorts(std::vector<std::string>& portNames)
 {
-    ports.clear();
+    portNames.clear();
 
 #if PLATFORM_IS_WINDOWS
 
@@ -177,7 +180,7 @@ int SerialPortFactory::getComPorts(std::vector<std::string>& ports)
             {
                 if (!std::filesystem::is_directory(i->path()) && std::filesystem::is_character_file(i->path()))
                 {
-                    ports.push_back(i->path().string());
+                    portNames.push_back(i->path().string());
                 }
             }
         } catch (const std::filesystem::filesystem_error&) {}
@@ -200,7 +203,7 @@ int SerialPortFactory::getComPorts(std::vector<std::string>& ports)
                 devicedir += namelist[n]->d_name;
 
                 // Register the device
-                register_comport__linux(ports, comList8250, devicedir);
+                register_comport__linux(portNames, comList8250, devicedir);
             }
             free(namelist[n]);
             namelist[n] = nullptr;
@@ -211,11 +214,11 @@ int SerialPortFactory::getComPorts(std::vector<std::string>& ports)
 
     // Only non-serial8250 has been added to comList without any further testing
     // serial8250-devices must be probe to check for validity
-    probe_serial8250_comports__linux(ports, comList8250);
+    probe_serial8250_comports__linux(portNames, comList8250);
 
 #endif
 
-    return ports.size();
+    return portNames.size();
 }
 
 

--- a/src/PortFactory.h
+++ b/src/PortFactory.h
@@ -95,16 +95,6 @@ private:
     ~SerialPortFactory() = default;
 
     /**
-     * An internal static function which identifies all available serial ports on the host device. It populates a referenced
-     * std::vector<std::string> with their names, as suitable identifiers. This does NOT do any port_handle allocation, validation,
-     * or other operations necessary to USE the port - it merely identifies them.
-     * @param portNames a reference to a vector of strings which will be cleared, and populated with UART/Serial ports known to
-     *  the host operating system.
-     * @return the number of port names populated into the vector.
-     */
-    static int getComPorts(std::vector<std::string>& portNames);
-
-    /**
      * A static function which is used to report errors that occur on a port created by this factory
      * @param port the port the error occurred on
      * @param errCode the error code (usually errno) of the error that occurred
@@ -114,6 +104,17 @@ private:
     static int onPortError(port_handle_t port, int errCode, const char *errMsg);
 
     std::vector<std::string> portNames = {};
+
+    /**
+     * An internal static function which identifies all available serial ports on the host device. It populates a referenced
+     * std::vector<std::string> with their names, as suitable identifiers. This does NOT do any port_handle allocation, validation,
+     * or other operations necessary to USE the port - it merely identifies them.
+     * @param portNames a reference to a vector of strings which will be cleared, and populated with UART/Serial ports known to
+     *  the host operating system.
+     * @return the number of port names populated into the vector.
+     */
+    static int getComPorts(std::vector<std::string>& portNames);
+
 
 #if PLATFORM_IS_LINUX
     static std::string get_driver__linux(const std::string& tty);

--- a/src/PortFactory.h
+++ b/src/PortFactory.h
@@ -43,11 +43,11 @@ public:
      * actually exists and can be operated on (ie, does the device exist in the OS, or does the target host respond to a ping?).
      * Note that this is a factory-specific function typically called by the PortManager in order to determine if a port is
      * no longer viable as a precursory check
-     * @param pType the type of port to validate
-     * @param pName the string identifier of the port
+     * @param pName the string identifier of the port - this must be unique and is required
+     * @param pType the type of port to validate - this is optional, but maybe modified by the underlying implementation
      * @return true if the port is viable/valid, otherwise false
      */
-    virtual bool validatePort(uint16_t pType, const std::string& pName) = 0;
+    virtual bool validatePort(const std::string& pName, uint16_t pType = 0) = 0;
 
     /**
      * A function responsible for allocating the underlying port type and returning a port_handle_t to it
@@ -56,7 +56,7 @@ public:
      * @param pName the binding name of the port to be allocated.
      * @return a port_handle_t to the allocated port
      */
-    virtual port_handle_t bindPort(uint16_t pType, const std::string& pName) = 0;
+    virtual port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) = 0;
 
     /**
      * A function responsible for freeing the allocated memory of the underlying port.
@@ -84,9 +84,9 @@ public:
 
     void locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern, uint16_t pType) override;
 
-    bool validatePort(uint16_t pType, const std::string& pName) override;
+    bool validatePort(const std::string& pName, uint16_t pType = 0) override;
 
-    port_handle_t bindPort(uint16_t pType, const std::string& pName) override;
+    port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) override;
 
     bool releasePort(port_handle_t port) override;
 
@@ -94,14 +94,26 @@ private:
     SerialPortFactory() = default;
     ~SerialPortFactory() = default;
 
-    static int validate_port(port_handle_t port) { return SerialPortFactory::getInstance().validatePort(portType(port), portName(port)); }
-    static int open_port(port_handle_t port) {
-        if (!portIsValid(port)) return PORT_ERROR__INVALID;
-        serial_port_t* serialPort = (serial_port_t*)port;
-        return serialPortOpen(port, serialPort->portName, serialPort->baudRate, serialPort->blocking) == 1 ? PORT_ERROR__NONE : PORT_ERROR__OPEN_FAILURE;
-    }
+    /**
+     * An internal static function which identifies all available serial ports on the host device. It populates a referenced
+     * std::vector<std::string> with their names, as suitable identifiers. This does NOT do any port_handle allocation, validation,
+     * or other operations necessary to USE the port - it merely identifies them.
+     * @param portNames a reference to a vector of strings which will be cleared, and populated with UART/Serial ports known to
+     *  the host operating system.
+     * @return the number of port names populated into the vector.
+     */
+    static int getComPorts(std::vector<std::string>& portNames);
 
-    std::vector<std::string> ports = {};
+    /**
+     * A static function which is used to report errors that occur on a port created by this factory
+     * @param port the port the error occurred on
+     * @param errCode the error code (usually errno) of the error that occurred
+     * @param errMsg an optional string message which describes the error the occurred
+     * @return
+     */
+    static int onPortError(port_handle_t port, int errCode, const char *errMsg);
+
+    std::vector<std::string> portNames = {};
 
 #if PLATFORM_IS_LINUX
     static std::string get_driver__linux(const std::string& tty);
@@ -112,10 +124,15 @@ private:
 #elif PLATFORM_IS_WINDOWS
 #endif
 
-    int getComPorts(std::vector<std::string>& ports);
+    // THESE ARE LOCALIZED HELPER FUNCTIONS to provide basic functionality that is not normally provided by the original SerialPort/SerialPortPlatform implementation
+    // TODO: at some point, these should be moved into the implementation directly, and removed from the factory
+    static int validate_port(port_handle_t port) { return SerialPortFactory::getInstance().validatePort(portName(port), portType(port)); }
+    static int open_port(port_handle_t port) {
+        if (!portIsValid(port)) return PORT_ERROR__INVALID;
+        serial_port_t* serialPort = (serial_port_t*)port;
+        return serialPortOpen(port, serialPort->portName, serialPort->baudRate, serialPort->blocking) == 1 ? PORT_ERROR__NONE : PORT_ERROR__OPEN_FAILURE;
+    }
 
-
-    static int onPortError(port_handle_t port, int errCode, const char *errMsg);
 };
 
 

--- a/src/PortManager.cpp
+++ b/src/PortManager.cpp
@@ -75,6 +75,10 @@ void PortManager::portHandler(PortFactory* factory, uint16_t portType, const std
             else {
                 // the port was previously identified, but the port handle is invalid.
                 // we probably should release to port and reallocate a new one
+                // finally, call our handler
+                for (port_listener& l : listeners) {
+                    l(PORT_REMOVED, entry.type, entry.name, port);
+                }
                 entry.factory->releasePort(port);
                 port = nullptr;
                 break;

--- a/src/PortManager.cpp
+++ b/src/PortManager.cpp
@@ -22,7 +22,7 @@ bool PortManager::discoverPorts(const std::string& pattern, uint16_t pType) {
     // look for ports which are no longer valid and remove them
     std::vector<const port_entry_t*> lostPorts; // a vector of ports which no longer are available and need to be cleaned up
     for (auto& [entry, port] : knownPorts) {
-        bool invalid = !(portIsValid(port) && entry.factory->validatePort(entry.type, entry.name));
+        bool invalid = !(portIsValid(port) && entry.factory->validatePort(entry.name, entry.type));
 
         // check if port still exists...
         if (invalid) {
@@ -83,7 +83,7 @@ void PortManager::portHandler(PortFactory* factory, uint16_t portType, const std
     }
 
     // if not, then do we need to allocate it?
-    port_handle_t port = factory->bindPort(portType, portName);
+    port_handle_t port = factory->bindPort(portName, portType);
     knownPorts[portEntry] = port;
     insert(port);
 

--- a/src/core/base_port.h
+++ b/src/core/base_port.h
@@ -83,7 +83,7 @@ typedef struct
 typedef struct base_port_s {
     uint16_t pnum;                          //! an identifier for a specific port that belongs to this device
     uint16_t ptype;                         //! an indicator of the type of port
-    uint16_t pflags;                        //! a bitmask of flags, incidating state of special capabilities for this port
+    uint16_t pflags;                        //! a bitmask of flags, indicating state of special capabilities for this port
     uint16_t perror;                        //! a non-zero value indicating an error for the last operation attempted for this port
 
     pfnPortName portName;                   //! a function which returns an optional name to (ideally) uniquely identify this port
@@ -101,11 +101,8 @@ typedef struct base_port_s {
 
     void *portLoggerData;                   //! an opaque pointer of "user data" associated with the portLogger that is passed whenever the portLogger() callback function is called
     port_stats_t* stats;                    //! if not-null, contains the stats associated with this port (bytes sent/received, etc)
-
 } base_port_t;
-
 #define BASE_PORT(n)        ((base_port_t*)(n))
-
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The main purpose of this PR is to demonstrate the functionality of ISDevice and port_handle_t from the latest `develop` branch of the SDK, for basic discovery/comms to an Inertial Sense device.  ISDeviceExample1.cpp is heavily documented, and you are encouraged to read through it to understand how it operates.  This is as much a review of the code, as it is a review of the documentation for customers and usage of the SDK.

Also,
Adds default implementation for DeviceFactory::allocateDevice()
Misc cleanup/improvements in ISDevice::validate()
Fixed bug where ISDevice::constructors would not initialize/copy sysParams. Added argument to ISDevice::connect() to allow performing validation() on connect (or not, by default). Rearranged PortFactory::bindPort() and PortFactory::validatePort() arguments to make pType optional (individual factories already know their type). Fixed SerialPortFactory::bindPort() to validate the port before allocating it. Light refactor in SerialPortFactory::locatePorts() and other functions. Added doxygen comments for SerialPortFactory private functions.