### PR TITLE
SN-6720: NMEA source selection added defines

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -422,6 +422,8 @@ enum eSysStatusFlags
     SYS_STATUS_TBED3_LEDS_ENABLED				    = (int)0x00000001,
 
     SYS_STATUS_DMA_FAULT_DETECT                     = (int)0x00000002,
+
+    SYS_STATUS_PRIMARY_NMEA_GNSS_SOURCE        = (int)0x00000004, // 0 = GPS1 is the primary NMEA GNSS source 1 = GPS2 is the primary NMEA GNSS source
 };
 
 // Used to validate GPS position (and velocity)

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -423,7 +423,8 @@ enum eSysStatusFlags
 
     SYS_STATUS_DMA_FAULT_DETECT                     = (int)0x00000002,
 
-    SYS_STATUS_PRIMARY_NMEA_GNSS_SOURCE        = (int)0x00000004, // 0 = GPS1 is the primary NMEA GNSS source 1 = GPS2 is the primary NMEA GNSS source
+    SYS_STATUS_PRIMARY_NMEA_GNSS_SOURCE             = (int)0x00000004, // 0 = GPS1 is the primary NMEA GNSS source 1 = GPS2 is the primary NMEA GNSS source
+    SYS_STATUS_PRIMARY_NMEA_GNSS_SOURCE_offest      = 2,
 };
 
 // Used to validate GPS position (and velocity)

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -423,8 +423,8 @@ enum eSysStatusFlags
 
     SYS_STATUS_DMA_FAULT_DETECT                     = (int)0x00000002,
 
-    SYS_STATUS_PRIMARY_NMEA_GNSS_SOURCE             = (int)0x00000004, // 0 = GPS1 is the primary NMEA GNSS source 1 = GPS2 is the primary NMEA GNSS source
-    SYS_STATUS_PRIMARY_NMEA_GNSS_SOURCE_offest      = 2,
+    SYS_STATUS_PRIMARY_GNSS_SOURCE_IS_GNSS2         = (int)0x00000004, // 0 = GPS1 is the primary NMEA GNSS source 1 = GPS2 is the primary NMEA GNSS source
+    SYS_STATUS_PRIMARY_GNSS_SOURCE_IS_GNSS2_offest  = 2,
 };
 
 // Used to validate GPS position (and velocity)


### PR DESCRIPTION
- (SDK, IMX) (SN-6720) Added ability to select primary source for NMEA GNSS output via DID_SYS_PARAMS.sysStatus.SYS_STATUS_PRIMARY_NMEA_GNSS_SOURCE (where 0 is GNSS1, 1 is GNSS2).