### PR TITLE
SN-5868 Address smaller page size on last page of STM32L4 (IMX-5.0)

### DIFF
--- a/src/ISBootloaderISB.cpp
+++ b/src/ISBootloaderISB.cpp
@@ -588,16 +588,24 @@ is_operation_result cISBootloaderISB::fill_current_page(int* currentPage, int* c
 {
     (void)currentPage;
 
+    if (*currentPage >= 7)
+    {
+        int i = 0;
+        i++;
+    }
+
     if (*currentOffset < FLASH_PAGE_SIZE)
     {
         unsigned char hexData[256];
         memset(hexData, 'F', 256);
 
-        // FIXME: This isn't okay... We have about 32k of additional flash that we can't access because is not the 65k "logical" page size.
-        //  This function should recognize when we are on the last page, and how many bytes are in that page if its not a full page and handle things accordingly.
-        //  until then, we'll return OK in the error condition below, because the bootloader won't let us write out of bounds anyway...
         while (*currentOffset < FLASH_PAGE_SIZE)
         {
+            if (*currentPage == 7 && *currentOffset >= 36592)
+            {   // The last (7th) page of flash memory on the IMX-5.0 (STM32L4) is restricted to 36592 bytes.  We should fill beyond this point on the 7th page.
+                break;
+            }
+
             int byteCount = (FLASH_PAGE_SIZE - *currentOffset) * 2;
             if (byteCount > 256)
             {
@@ -608,7 +616,7 @@ is_operation_result cISBootloaderISB::fill_current_page(int* currentPage, int* c
             if (upload_hex_page(hexData, byteCount / 2, currentOffset, totalBytes, verifyCheckSum) != IS_OP_OK)
             {
                 status_update("(ISB) Failed to fill page with bytes", IS_LOG_LEVEL_ERROR);
-                return IS_OP_OK; // FIXME - this should actually be an error
+                return IS_OP_ERROR ;
             }
         }
     }


### PR DESCRIPTION
Fix IMX firmware update error "Failed to fill page with bytes" by preventing SDK from writing beyond the limited size (36592 bytes) of the last (7th) page in flash memory on the IMX-5.0 (STM32L4).