### PR TITLE
SN-6835 cltool -get -set yaml

### DIFF
--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -2,6 +2,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
 
 project(cltool)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(IS_SDK_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 include(${IS_SDK_DIR}/include_is_sdk_find_library.cmake)
 

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -105,7 +105,20 @@ bool read_get_set_argument(std::string s, YAML::Node &getNode)
     {
         s = "{" + s + "}";
     }
-        
+
+    // Ensure there is a space after each colon
+    for (size_t i = 0; i < s.length(); ++i)
+    {
+        if (s[i] == ':')
+        {
+            // If not followed by space and not end of string
+            if (i + 1 >= s.length() || s[i + 1] != ' ')
+            {
+                s.insert(i + 1, " ");
+            }
+        }
+    }
+
     // Attempt to parse the string as YAML
     try {
         getNode = YAML::Load(s);
@@ -1090,11 +1103,9 @@ void cltool_outputUsage()
 	cout << "OPTIONS (Messages)" << endl;
     cout << "    -get <DID1>,<DID2>,...                  " << boldOff << " Return values of dataset(s). DID may be a name or number." << endlbOn;
     cout << "    -get \"{<DID>: {<FIELD1>,<FIELD2>,...}}\" " << boldOff << " Return values of dataset(s). DID may be a name or number. YAML input format." << endlbOn;
-    cout << "    -get-output-file <FILENAME> <--append>  " << boldOff << " Save output of -get to FILENAME file in current directory. --append to file." << endlbOn;
     cout << "                                            " << boldOff << " Examples: -get 1,4,12,DID_GPS1_POS" << endlbOn;
-    cout << "                                            " << boldOff << "           -get \"{DID_INS_1}\"" << endlbOn;
+    cout << "                                            " << boldOff << "           -get \"{DID_INS_1,DID_GPS1_POS}\"" << endlbOn;
     cout << "                                            " << boldOff << "           -get \"{DID_INS_1: {insStatus, theta}, DID_INS_2: {qn2b}}\"" << endlbOn;
-    cout << "                                            " << boldOff << "           -get \"{DID_INS_1, DID_GPS1_POS}\" -get-output-file out.yaml --append" << endlbOn;
     cout << "    -set \"{<DID>: {<FIELD1>: <VALUE>, ...}}\"" << boldOff << " Set values of dataset(s). DID may be a number or name. YAML input format." << endlbOn;
     cout << "                                            " << boldOff << " Examples: -set \"{DID_FLASH_CONFIG: {gps1AntOffset: [0.8, 0.0, 1.2]}}\"" << endlbOn;
     cout << "                                            " << boldOff << "           -set \"{12: {ioConfig: 0x1a2b012c, ser2BaudRate: 921600}}\"" << endlbOn;

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -124,7 +124,7 @@ void ConvertIndexedKeysToSequences(YAML::Node& node)
         }
 
         std::smatch match;
-        if (std::regex_match(key, match, indexedKeyRegex))
+        if (std::regex_match(static_cast<const std::string&>(key), match, indexedKeyRegex))
         {
             const std::string baseKey = match[1];
             const int index = std::stoi(match[2]);

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -527,6 +527,15 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             g_commandLineOptions.gpxflashCfgSet = true;
             enable_display_mode(cInertialSenseDisplay::eDisplayMode::DMODE_QUIET);
         }
+        else if (startsWith(a, "-get-output-file") && (i + 1) < argc && !startsWith(argv[i + 1], "-"))
+        {
+            g_commandLineOptions.getNodeOutputFilename = argv[++i];    // use next argument
+            if (i+1 < argc && startsWith(argv[i+1], "--append"))
+            {
+                i++;    // use next argument
+                g_commandLineOptions.getNodeOutputFileAppend = true;    // Append to file if "--append" is specified
+            }
+        }
         else if (startsWith(a, "-get") && (i + 1) < argc && !startsWith(argv[i + 1], "-"))
         {
             if (!read_get_set_argument(argv[++i], g_commandLineOptions.getNode))    // use next argument
@@ -1021,7 +1030,7 @@ void cltool_outputUsage()
 	cout << "    " << APP_NAME << APP_EXT << " -c * -baud=921600              "                    << EXAMPLE_SPACE_2 << " # 921600 bps baudrate on all serial ports" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -rp " <<     EXAMPLE_LOG_DIR                                              << " # replay log files from a folder" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -rover=RTCM3:192.168.1.100:7777:mount:user:password         # Connect to RTK NTRIP base" << endlbOff;
-	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -get \"{DID_INS_1}\"                                          # Return entire DID" << endlbOff;
+	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -get \"{DID_INS_1}\" -get-output-file out.yaml                # Return entire DID and save to file" << endlbOff;
     cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -get \"{DID_INS_1: {insStatus, theta}, DID_INS_2: {qn2b}}\"   # Return portion of two DIDs" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -set \"{DID_FLASH_CONFIG: {gps1AntOffset: [0.8, 0.0, 1.2]}}\" # Set values in DID" << endlbOff;
 	cout << endlbOn;
@@ -1082,8 +1091,10 @@ void cltool_outputUsage()
 	cout << endlbOn;
 	cout << "OPTIONS (Messages)" << endl;
     cout << "    -get \"{<DID>: {<FIELD1>,<FIELD2>,...}}\" " << boldOff << " Return values of dataset(s). DID may be a name or number. YAML input format." << endlbOn;
+    cout << "    -get-output-file <FILENAME> <--append>  " << boldOff << " Save output of -get to FILENAME file in current directory. --append to append to file." << endlbOn;
     cout << "                                            " << boldOff << " Examples: -get \"{DID_INS_1}\"" << endlbOn;
     cout << "                                            " << boldOff << "           -get \"{DID_INS_1: {insStatus, theta}, DID_INS_2: {qn2b}}\"" << endlbOn;
+    cout << "                                            " << boldOff << "           -get \"{DID_INS_1, DID_GPS_1}\" -get-output-file out.yaml --append" << endlbOn;
     cout << "    -set \"{<DID>: {<FIELD1>: <VALUE>, ...}}\"" << boldOff << " Set values of dataset(s). DID may be a number or name. YAML input format." << endlbOn;
     cout << "                                            " << boldOff << " Examples: -set \"{DID_FLASH_CONFIG: {gps1AntOffset: [0.8, 0.0, 1.2]}}\"" << endlbOn;
     cout << "                                            " << boldOff << "           -set \"{12: {ioConfig: 0x1a2b012c, ser2BaudRate: 921600}}\"" << endlbOn;

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -110,6 +110,8 @@ bool read_get_did_argument2(std::string s, YAML::Node &getNode)
         return false;
     }
 
+	std::cout << getNode << std::endl;      // Print the YAML node for debugging
+
     g_commandLineOptions.datasets.clear();
     g_commandLineOptions.outputOnceDid.clear();
 
@@ -1058,12 +1060,12 @@ void cltool_outputUsage()
 
 	cout << endlbOn;
 	cout << "OPTIONS (IMX/GPX Messages)" << endl;
-    cout << "    -get {<DID>: [<FIELD1>,<FIELD2>,...]}" << boldOff << " Return value of the specified dataset. DID may be a name or number." << endlbOn;
-    cout << "                                        " << boldOff << "  Examples: `-get {DID_INS_1}`" << endlbOn;
-    cout << "                                        " << boldOff << "  Examples: `-get {DID_INS_1: [{insStatus}, {\"theta[2]\"}], DID_INS_2: [{qn2b}]}`" << endlbOn;
-    cout << "    -set {<DID>: [{<FIELD1>: <VALUE>}, ...]}" << boldOff << "  Set values in the specified dataset. DID may be a number or name." << endlbOn;
-    cout << "                                        " << boldOff << "  Examples: `-set {DID_FLASH_CONFIG: [{\"gps1AntOffset[1]\": 0.8}]}`" << endlbOn;
-    cout << "                                        " << boldOff << "            `-set {12: [{\"ioConfig\": 0x1a2b012c}, {\"ser2BaudRate\": 921600}]}`" << endlbOn;
+    cout << "    -get {<DID>: {<FIELD1>,<FIELD2>,...}} " << boldOff << " Return values of dataset(s). DID may be a name or number. YAML input format." << endlbOn;
+    cout << "                                          " << boldOff << " Examples: `-get {DID_INS_1}`" << endlbOn;
+    cout << "                                          " << boldOff << "           `-get {DID_INS_1: {insStatus, theta}, DID_INS_2: {qn2b}}`" << endlbOn;
+    cout << "    -set {<DID>: {<FIELD1>: <VALUE>, ...}}" << boldOff << " Set values of dataset(s). DID may be a number or name. YAML input format." << endlbOn;
+    cout << "                                          " << boldOff << " Examples: `-set {DID_FLASH_CONFIG: {gps1AntOffset: [0.8, 0.0, 1.2]}}`" << endlbOn;
+    cout << "                                          " << boldOff << "           `-set {12: {ioConfig: 0x1a2b012c, ser2BaudRate: 921600}}`" << endlbOn;
 	cout << "    -did [DID#<=PERIODMULT> DID#<=PERIODMULT> ...]" << boldOff << "  Stream 1 or more datasets and display w/ compact view." << endlbOn;
 	cout << "    -edit [DID#<=PERIODMULT>]                     " << boldOff << "  Stream and edit 1 dataset." << endlbOff;
 	cout << "          Each DID# can be the DID number or name and appended with <=PERIODMULT> to decrease message frequency. " << endlbOff;

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -1157,13 +1157,19 @@ bool cltool_updateImxFlashCfg(InertialSense& inertialSenseInterface, string flas
     nvm_flash_cfg_t imxFlashCfg;
     inertialSenseInterface.ImxFlashConfig(imxFlashCfg);
 
-    bool success = false;
     if (flashCfgString.find('=') != std::string::npos)
     {   // Write to flash config
-        success = cISDataMappings::StringToDidBuffer(DID_FLASH_CONFIG, flashCfgString, (uint8_t*)&imxFlashCfg);
-
-        inertialSenseInterface.SetImxFlashConfig(imxFlashCfg);  
-        inertialSenseInterface.WaitForImxFlashCfgSynced();
+        if (!cISDataMappings::StringToDidBuffer(DID_FLASH_CONFIG, flashCfgString, (uint8_t*)&imxFlashCfg))
+        {
+            cout << "Failed to parse flash config string." << endl;
+            return false;
+        }
+        if (!inertialSenseInterface.SetImxFlashConfig(imxFlashCfg) ||
+            !inertialSenseInterface.WaitForImxFlashCfgSynced())
+        {
+            cout << "Failed to set IMX flash config." << endl;
+            return false;
+        }
     }
     else
     {   // Read from flash config
@@ -1178,7 +1184,7 @@ bool cltool_updateImxFlashCfg(InertialSense& inertialSenseInterface, string flas
         }
     }
 
-    return success;
+    return true;
 }
 
 bool cltool_updateGpxFlashCfg(InertialSense& inertialSenseInterface, string flashCfgString)
@@ -1191,15 +1197,20 @@ bool cltool_updateGpxFlashCfg(InertialSense& inertialSenseInterface, string flas
     gpx_flash_cfg_t gpxFlashCfg;
     inertialSenseInterface.GpxFlashConfig(gpxFlashCfg);
 
-    bool success = false;
-
     if (flashCfgString.find('=') != std::string::npos)
     {   // Write to flash config
-        success = cISDataMappings::StringToDidBuffer(DID_GPX_FLASH_CFG, flashCfgString, (uint8_t*)&gpxFlashCfg);
-
-        inertialSenseInterface.SetGpxFlashConfig(gpxFlashCfg);
+        if (!cISDataMappings::StringToDidBuffer(DID_GPX_FLASH_CFG, flashCfgString, (uint8_t*)&gpxFlashCfg))
+        {
+            cout << "Failed to parse flash config string." << endl;
+            return false;
+        }
         g_gpxFlashCfg_upload = gpxFlashCfg; // Save for later use
-        inertialSenseInterface.WaitForGpxFlashCfgSynced();
+        if (!inertialSenseInterface.SetGpxFlashConfig(gpxFlashCfg) ||
+            !inertialSenseInterface.WaitForGpxFlashCfgSynced())
+        {
+            cout << "Failed to set GPX flash config." << endl;
+            return false;
+        }
     }
     else
     {   // Read from flash config
@@ -1214,5 +1225,5 @@ bool cltool_updateGpxFlashCfg(InertialSense& inertialSenseInterface, string flas
         }
     }
 
-    return success;
+    return true;
 }

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -1097,7 +1097,7 @@ bool cltool_updateImxFlashCfg(InertialSense& inertialSenseInterface, string flas
     bool success = false;
     if (flashCfgString.find('=') != std::string::npos)
     {   // Write to flash config
-        success = cISDataMappings::StringToDid(DID_FLASH_CONFIG, flashCfgString, (uint8_t*)&imxFlashCfg);
+        success = cISDataMappings::StringToDidBuffer(DID_FLASH_CONFIG, flashCfgString, (uint8_t*)&imxFlashCfg);
 
         inertialSenseInterface.SetImxFlashConfig(imxFlashCfg);  
         inertialSenseInterface.WaitForImxFlashCfgSynced();
@@ -1105,7 +1105,7 @@ bool cltool_updateImxFlashCfg(InertialSense& inertialSenseInterface, string flas
     else
     {   // Read from flash config
         string output;
-        if (cISDataMappings::DidToString(DID_FLASH_CONFIG, (uint8_t*)&imxFlashCfg, output, flashCfgString))
+        if (cISDataMappings::DidBufferToString(DID_FLASH_CONFIG, (uint8_t*)&imxFlashCfg, output, flashCfgString))
         {
             cout << output;
         }
@@ -1132,7 +1132,7 @@ bool cltool_updateGpxFlashCfg(InertialSense& inertialSenseInterface, string flas
 
     if (flashCfgString.find('=') != std::string::npos)
     {   // Write to flash config
-        success = cISDataMappings::StringToDid(DID_GPX_FLASH_CFG, flashCfgString, (uint8_t*)&gpxFlashCfg);
+        success = cISDataMappings::StringToDidBuffer(DID_GPX_FLASH_CFG, flashCfgString, (uint8_t*)&gpxFlashCfg);
 
         inertialSenseInterface.SetGpxFlashConfig(gpxFlashCfg);
         g_gpxFlashCfg_upload = gpxFlashCfg; // Save for later use
@@ -1141,7 +1141,7 @@ bool cltool_updateGpxFlashCfg(InertialSense& inertialSenseInterface, string flas
     else
     {   // Read from flash config
         string output;
-        if (cISDataMappings::DidToString(DID_GPX_FLASH_CFG, (uint8_t*)&gpxFlashCfg, output, flashCfgString))
+        if (cISDataMappings::DidBufferToString(DID_GPX_FLASH_CFG, (uint8_t*)&gpxFlashCfg, output, flashCfgString))
         {
             cout << output;
         }

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -128,8 +128,6 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     std::string roverConnection; 			// -rover=type:IP/URL:port:mountpoint:user:password   (server)
     std::string baseConnection; 			// -base=IP:port    (client)	
     
-    uint32_t setDidDid;	
-    std::string setDidString;
     bool imxflashCfgSet;
     bool gpxflashCfgSet;
     std::string imxFlashCfg;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -128,10 +128,13 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     std::string roverConnection; 			// -rover=type:IP/URL:port:mountpoint:user:password   (server)
     std::string baseConnection; 			// -base=IP:port    (client)	
     
+    uint32_t setDidDid;	
+    std::string setDidString;
     std::string imxFlashCfg;
     std::string gpxFlashCfg;
     uint32_t timeoutFlushLoggerSeconds;
     uint32_t outputOnceDid;	
+    std::string outputOnceFields;			// -getdid DID=FIELD
     
     uint32_t sysCommand;
     int32_t platformType;
@@ -167,7 +170,7 @@ void cltool_bootloadUpdateInfo(void* obj, ISBootloader::eLogLevel level, const c
 void cltool_firmwareUpdateInfo(void* obj, ISBootloader::eLogLevel level, const char* str, ...);
 bool cltool_updateImxFlashCfg(InertialSense& inertialSenseInterface, std::string flashCfgString);
 bool cltool_updateGpxFlashCfg(InertialSense& inertialSenseInterface, std::string flashCfgString);
-bool cltool_updateFlashCfg(InertialSense& inertialSenseInterface, std::string flashCfg, uint32_t did, uint8_t* dataPtr);
+bool cltool_setDidFromString(InertialSense& inertialSenseInterface, std::string flashCfg, uint32_t did, uint8_t* dataPtr);
 
 #endif // __CLTOOL_H__
 

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -130,6 +130,8 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     
     uint32_t setDidDid;	
     std::string setDidString;
+    bool imxflashCfgSet;
+    bool gpxflashCfgSet;
     std::string imxFlashCfg;
     std::string gpxFlashCfg;
     uint32_t timeoutFlushLoggerSeconds;
@@ -170,7 +172,6 @@ void cltool_bootloadUpdateInfo(void* obj, ISBootloader::eLogLevel level, const c
 void cltool_firmwareUpdateInfo(void* obj, ISBootloader::eLogLevel level, const char* str, ...);
 bool cltool_updateImxFlashCfg(InertialSense& inertialSenseInterface, std::string flashCfgString);
 bool cltool_updateGpxFlashCfg(InertialSense& inertialSenseInterface, std::string flashCfgString);
-bool cltool_setDidFromString(InertialSense& inertialSenseInterface, std::string flashCfg, uint32_t did, uint8_t* dataPtr);
 
 #endif // __CLTOOL_H__
 

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -134,8 +134,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     std::string gpxFlashCfg;
     uint32_t timeoutFlushLoggerSeconds;
     std::vector<uint32_t> outputOnceDid;	
-    std::vector<uint32_t> setAckDid;	
-    std::string outputOnceFields;			// -getdid DID=FIELD
+    std::vector<uint32_t> setAckDid;
 
     YAML::Node getNode;
     YAML::Node setNode;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -139,6 +139,8 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
 
     YAML::Node getNode;
     YAML::Node setNode;
+    std::string getNodeOutputFilename;		// -get-output-file FILENAME
+    bool getNodeOutputFileAppend;		    // -get-output-file FILENAME --append
     
     uint32_t sysCommand;
     int32_t platformType;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -136,9 +136,11 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     std::string gpxFlashCfg;
     uint32_t timeoutFlushLoggerSeconds;
     std::vector<uint32_t> outputOnceDid;	
+    std::vector<uint32_t> setAckDid;	
     std::string outputOnceFields;			// -getdid DID=FIELD
 
     YAML::Node getNode;
+    YAML::Node setNode;
     
     uint32_t sysCommand;
     int32_t platformType;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -138,8 +138,6 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
 
     YAML::Node getNode;
     YAML::Node setNode;
-    std::string getNodeOutputFilename;		// -get-output-file FILENAME
-    bool getNodeOutputFileAppend;		    // -get-output-file FILENAME --append
     
     uint32_t sysCommand;
     int32_t platformType;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -135,8 +135,10 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     std::string imxFlashCfg;
     std::string gpxFlashCfg;
     uint32_t timeoutFlushLoggerSeconds;
-    uint32_t outputOnceDid;	
+    std::vector<uint32_t> outputOnceDid;	
     std::string outputOnceFields;			// -getdid DID=FIELD
+
+    YAML::Node getNode;
     
     uint32_t sysCommand;
     int32_t platformType;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -262,6 +262,19 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
                         out << output;
                         if (out.good()) {
                             std::cout << out.c_str() << std::endl;
+                            if (!g_commandLineOptions.getNodeOutputFilename.empty())
+                            {   // Write to file
+                                std::ofstream outFile(g_commandLineOptions.getNodeOutputFilename, std::ios::app);
+                                if (outFile.is_open())
+                                {
+                                    outFile << out.c_str() << std::endl;
+                                    outFile.close();
+                                }
+                                else
+                                {
+                                    std::cerr << "Failed to open output file: " << g_commandLineOptions.getNodeOutputFilename << std::endl;
+                                }
+                            }
                         } else {
                             std::cerr << "YAML emitter error: " << out.GetLastError() << std::endl;
                         }
@@ -563,6 +576,11 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
                 g_commandLineOptions.setAckDid.push_back(did);
             }
         }
+    }
+
+    if (!g_commandLineOptions.getNodeOutputFilename.empty() && !g_commandLineOptions.getNodeOutputFileAppend)
+    {
+        std::remove(g_commandLineOptions.getNodeOutputFilename.c_str()); // Silently does nothing if file doesn't exist
     }
 
     bool exitNow = false;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -559,7 +559,11 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         for (auto it = g_commandLineOptions.outputOnceDid.begin(); it != g_commandLineOptions.outputOnceDid.end(); ++it )
         {
             int did = *it;
-            cISDataMappings::YamlToData(did, g_commandLineOptions.setNode, (uint8_t*)&d, &usageVec);
+            if (!cISDataMappings::YamlToData(did, g_commandLineOptions.setNode, (uint8_t*)&d, &usageVec))
+            {
+                cout << "Failed to convert -set input " << g_commandLineOptions.setNode << endl;
+                exit(-1);
+            }
 
             for (auto& usage : usageVec)
             {   // Upload data to device

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -248,7 +248,7 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
         {   
             // Print the data to terminal
             string output;
-            if (!cISDataMappings::DidToString(data->hdr.id, data->ptr, output, g_commandLineOptions.outputOnceFields))
+            if (!cISDataMappings::DidBufferToString(data->hdr.id, data->ptr, output, g_commandLineOptions.outputOnceFields))
             {   // Error parsing
                 output = "Error parsing: " + g_commandLineOptions.outputOnceFields + "\n";
             }
@@ -268,7 +268,7 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
             int size = cISDataMappings::DataSize(data->hdr.id);
             copyDataPToStructP(&dataset, data, size);
             uDatasets newSet = dataset;
-            if (!cISDataMappings::StringToDid(did, g_commandLineOptions.setDidString, (uint8_t*)&newSet))
+            if (!cISDataMappings::StringToDidBuffer(did, g_commandLineOptions.setDidString, (uint8_t*)&newSet))
             {   // Exit cltool now and report success code
                 std::exit(0);
             }

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -243,9 +243,9 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
     }
 
     if (!g_commandLineOptions.outputOnceDid.empty())
-    {   // Prevent processing of data if outputOnceDid is set
+    {
         if (g_commandLineOptions.getNode && !g_commandLineOptions.getNode.IsNull() && g_commandLineOptions.getNode.size() > 0)
-        {
+        {   // Prevent processing of data if outputOnceDid is set
             for (auto it = g_commandLineOptions.outputOnceDid.begin(); it != g_commandLineOptions.outputOnceDid.end(); )
             {
                 if (data->hdr.id == *it)
@@ -288,15 +288,20 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
                     ++it;
                 }
             }
+
+            if (g_commandLineOptions.outputOnceDid.empty() && g_commandLineOptions.setAckDid.empty())
+            {   // Exit cltool now and report success code
+                std::exit(0);
+                return;
+            }
+
+            return; 
         }
 
-        if (g_commandLineOptions.outputOnceDid.empty() && g_commandLineOptions.setAckDid.empty())
-        {   // Exit cltool now and report success code
-            std::exit(0);
+        if (std::find(g_commandLineOptions.outputOnceDid.begin(), g_commandLineOptions.outputOnceDid.end(), data->hdr.id) == g_commandLineOptions.outputOnceDid.end())
+        {   // Return DID is not in the outputOnceDid list
             return;
         }
-
-        return; 
     }
 
     (void)i;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -247,7 +247,12 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
         if (data->hdr.id == g_commandLineOptions.outputOnceDid)
         {   
             // Print the data to terminal
-            cout << cISDataMappings::DidToString(data->hdr.id, data->ptr, g_commandLineOptions.outputOnceFields);
+            string output = cISDataMappings::DidToString(data->hdr.id, data->ptr, g_commandLineOptions.outputOnceFields);
+            if (output.empty())
+            {   // No data to print
+                output = "Error parsing: " + g_commandLineOptions.outputOnceFields + "\n";
+            }
+            cout << output;
             // Exit cltool now and report success code
             std::exit(0);
         }

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -247,9 +247,9 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
         if (data->hdr.id == g_commandLineOptions.outputOnceDid)
         {   
             // Print the data to terminal
-            string output = cISDataMappings::DidToString(data->hdr.id, data->ptr, g_commandLineOptions.outputOnceFields);
-            if (output.empty())
-            {   // No data to print
+            string output;
+            if (!cISDataMappings::DidToString(data->hdr.id, data->ptr, output, g_commandLineOptions.outputOnceFields))
+            {   // Error parsing
                 output = "Error parsing: " + g_commandLineOptions.outputOnceFields + "\n";
             }
             cout << output;
@@ -519,7 +519,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     }
 
     bool exitNow = false;
-    if (g_commandLineOptions.imxFlashCfg.length() != 0)
+    if (g_commandLineOptions.imxflashCfgSet)
     {
         if (!cltool_updateImxFlashCfg(inertialSenseInterface, g_commandLineOptions.imxFlashCfg))
         {   // Exit cltool now and report error code
@@ -527,7 +527,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         }
         exitNow = true;
     }
-    if (g_commandLineOptions.gpxFlashCfg.length() != 0)
+    if (g_commandLineOptions.gpxflashCfgSet)
     {
         if (!cltool_updateGpxFlashCfg(inertialSenseInterface, g_commandLineOptions.gpxFlashCfg))
         {   // Exit cltool now and report error code
@@ -745,12 +745,12 @@ static int cltool_createHost()
         cout << "Failed to open serial port at " << g_commandLineOptions.comPort.c_str() << endl;
         return -1;
     }
-    else if (g_commandLineOptions.imxFlashCfg.length() != 0 && !cltool_updateImxFlashCfg(inertialSenseInterface, g_commandLineOptions.imxFlashCfg))
+    else if (g_commandLineOptions.imxflashCfgSet && !cltool_updateImxFlashCfg(inertialSenseInterface, g_commandLineOptions.imxFlashCfg))
     {
         cout << "Failed to update IMX flash config" << endl;
         return -1;
     }
-    else if (g_commandLineOptions.gpxFlashCfg.length() != 0 && !cltool_updateGpxFlashCfg(inertialSenseInterface, g_commandLineOptions.gpxFlashCfg))
+    else if (g_commandLineOptions.gpxflashCfgSet && !cltool_updateGpxFlashCfg(inertialSenseInterface, g_commandLineOptions.gpxFlashCfg))
     {
         cout << "Failed to update GPX flash config" << endl;
         return -1;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -455,7 +455,8 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         cout << "Sending software reset." << endl;
         inertialSenseInterface.SendRaw((uint8_t*)NMEA_CMD_SOFTWARE_RESET, NMEA_CMD_SIZE);
         SLEEP_MS(XMIT_CLOSE_DELAY_MS);      // Delay to allow transmit time before port closes
-        return false;
+        // return false;
+        exit(0); // Exit cltool now and report success code
     }
     if (g_commandLineOptions.sysCommand != 0)
     {   // Send system command to IMX

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -245,7 +245,7 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
     if (!g_commandLineOptions.outputOnceDid.empty())
     {
         if (g_commandLineOptions.getNode && !g_commandLineOptions.getNode.IsNull() && g_commandLineOptions.getNode.size() > 0)
-        {   // Prevent processing of data if outputOnceDid is set
+        {   
             for (auto it = g_commandLineOptions.outputOnceDid.begin(); it != g_commandLineOptions.outputOnceDid.end(); )
             {
                 if (data->hdr.id == *it)
@@ -295,11 +295,12 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
                 return;
             }
 
+            // Prevent further processing if -get option is set
             return; 
         }
 
         if (std::find(g_commandLineOptions.outputOnceDid.begin(), g_commandLineOptions.outputOnceDid.end(), data->hdr.id) == g_commandLineOptions.outputOnceDid.end())
-        {   // Return DID is not in the outputOnceDid list
+        {   // Prevent further processing if this DID is not in the outputOnceDid list
             return;
         }
     }

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -262,19 +262,6 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
                         out << output;
                         if (out.good()) {
                             std::cout << out.c_str() << std::endl;
-                            if (!g_commandLineOptions.getNodeOutputFilename.empty())
-                            {   // Write to file
-                                std::ofstream outFile(g_commandLineOptions.getNodeOutputFilename, std::ios::app);
-                                if (outFile.is_open())
-                                {
-                                    outFile << out.c_str() << std::endl;
-                                    outFile.close();
-                                }
-                                else
-                                {
-                                    std::cerr << "Failed to open output file: " << g_commandLineOptions.getNodeOutputFilename << std::endl;
-                                }
-                            }
                         } else {
                             std::cerr << "YAML emitter error: " << out.GetLastError() << std::endl;
                         }
@@ -335,7 +322,7 @@ static void cltool_ackCallback(InertialSense* i, p_ack_t* ack, unsigned char pac
         for (auto it = g_commandLineOptions.setAckDid.begin(); it != g_commandLineOptions.setAckDid.end(); )
         {
             if (ack->body.dataHdr.id == *it)
-            {   // Erase the matched DID from the vector and move to next
+            {   // Remove DID from the vector and move to next
                 it = g_commandLineOptions.setAckDid.erase(it);
             }
             else
@@ -345,7 +332,7 @@ static void cltool_ackCallback(InertialSense* i, p_ack_t* ack, unsigned char pac
         }
 
         if (g_commandLineOptions.setAckDid.empty())
-        {   // Exit cltool now and report success code
+        {   // All expected acks have been received. Exit cltool now and report success code
             std::exit(0);
             return;
         }
@@ -582,11 +569,6 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
                 g_commandLineOptions.setAckDid.push_back(did);
             }
         }
-    }
-
-    if (!g_commandLineOptions.getNodeOutputFilename.empty() && !g_commandLineOptions.getNodeOutputFileAppend)
-    {
-        std::remove(g_commandLineOptions.getNodeOutputFilename.c_str()); // Silently does nothing if file doesn't exist
     }
 
     bool exitNow = false;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -242,9 +242,8 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
         return;
     }
 
-    if (g_commandLineOptions.outputOnceDid.size() > 0)
+    if (!g_commandLineOptions.outputOnceDid.empty())
     {   // Prevent processing of data if outputOnceDid is set
-
         if (g_commandLineOptions.getNode && !g_commandLineOptions.getNode.IsNull() && g_commandLineOptions.getNode.size() > 0)
         {
             for (auto it = g_commandLineOptions.outputOnceDid.begin(); it != g_commandLineOptions.outputOnceDid.end(); )
@@ -278,9 +277,8 @@ static void cltool_dataCallback(InertialSense* i, p_data_t* data, int pHandle)
             }
         }
 
-        if (g_commandLineOptions.outputOnceDid.empty())
-        {
-            // Exit cltool now and report success code
+        if (g_commandLineOptions.outputOnceDid.empty() && g_commandLineOptions.setAckDid.empty())
+        {   // Exit cltool now and report success code
             std::exit(0);
             return;
         }
@@ -313,8 +311,8 @@ static void cltool_ackCallback(InertialSense* i, p_ack_t* ack, unsigned char pac
         return;
     }
 
-    if (g_commandLineOptions.setDidDid)
-    {   // Prevent processing of data if setDidDid is set
+    if (!g_commandLineOptions.setAckDid.empty())
+    {   
         for (auto it = g_commandLineOptions.setAckDid.begin(); it != g_commandLineOptions.setAckDid.end(); )
         {
             if (ack->body.dataHdr.id == *it)
@@ -545,8 +543,6 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         }
     }
 
-    bool exitNow = false;
-
     if (g_commandLineOptions.setNode && !g_commandLineOptions.setNode.IsNull() && g_commandLineOptions.setNode.size() > 0)
     {
     	uDatasets d = {};
@@ -561,13 +557,14 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
             for (auto& usage : usageVec)
             {   // Upload data to device
                 uint32_t offset = usage.ptr - (uint8_t*)&d;
-                cout << "Uploading data for DID: " << cISDataMappings::DataName(did) << " at offset: " << offset << ", size: " << usage.size << endl;
+                cout << "Uploading " << cISDataMappings::DataName(did) << ", size: " << usage.size << ", offset: " << offset << endl;
                 inertialSenseInterface.SendData(did, usage.ptr, usage.size, offset);
                 g_commandLineOptions.setAckDid.push_back(did);
             }
         }
     }
 
+    bool exitNow = false;
     if (g_commandLineOptions.imxflashCfgSet)
     {
         if (!cltool_updateImxFlashCfg(inertialSenseInterface, g_commandLineOptions.imxFlashCfg))

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -458,7 +458,11 @@ typedef struct
 typedef struct
 {
     /** Packet info of the received packet */
-    uint16_t            pktInfo;
+    struct ISComm
+    {
+        uint8_t         flags;             //!< Packet flags of received packet (see eISBPacketFlags)
+        uint8_t         id;                //!< DID of received packet
+    }                   pktInfo;
 
     /** Packet counter of the received packet */
     uint16_t            pktCounter;

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2084,7 +2084,7 @@ bool cISDataMappings::YamlToData(int did, const YAML::Node& yaml, uint8_t* dataP
         {
             if (!valueNode.IsSequence()) continue;
 
-            size_t count = std::min(static_cast<size_t>(info.arraySize), valueNode.size());
+            size_t count = _MIN(static_cast<size_t>(info.arraySize), valueNode.size());
             for (size_t i = 0; i < count; ++i)
             {
                 std::string valStr = valueNode[i].as<std::string>();
@@ -2124,8 +2124,8 @@ void cISDataMappings::AppendMemoryUsage(std::vector<MemoryUsage>& usageVec, void
         if (!(newEnd < existing.ptr || newPtr8 > existingEnd))
         {
             // Expand existing range to include new range
-            uint8_t* newStart = std::min(existing.ptr, newPtr8);
-            uint8_t* mergedEnd = std::max(existingEnd, newEnd);
+            uint8_t* newStart = _MIN(existing.ptr, newPtr8);
+            uint8_t* mergedEnd = _MAX(existingEnd, newEnd);
 
             existing.ptr = newStart;
             existing.size = mergedEnd - newStart;
@@ -2139,8 +2139,8 @@ void cISDataMappings::AppendMemoryUsage(std::vector<MemoryUsage>& usageVec, void
                     if (!(existing.end() < other.ptr || existing.ptr > other.end()))
                     {
                         // Merge this block too
-                        uint8_t* mergedStart = std::min(existing.ptr, other.ptr);
-                        uint8_t* mergedEnd = std::max(existing.end(), other.end());
+                        uint8_t* mergedStart = _MIN(existing.ptr, other.ptr);
+                        uint8_t* mergedEnd = _MAX(existing.end(), other.end());
 
                         existing.ptr = mergedStart;
                         existing.size = mergedEnd - mergedStart;
@@ -2353,7 +2353,7 @@ bool cISDataMappings::StringToDidBuffer(int did, const std::string& fields, uint
             nullptr,
             dataPtr,
             info,
-            std::max(0, arrayIndex)
+            _MAX(0, arrayIndex)
         );
 
         success |= fieldSuccess;

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -84,10 +84,10 @@ static void PopulateMapDeviceInfo(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("reserved2", &dev_info_t::reserved2, DATA_TYPE_UINT8);
     mapper.AddMember("hardwareType", &dev_info_t::hardwareType, DATA_TYPE_UINT8,  "", "Hardware type: 1=uINS, 2=EVB, 3=IMX, 4=GPX", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("serialNumber", &dev_info_t::serialNumber, DATA_TYPE_UINT32, "", "Serial number", DATA_FLAGS_READ_ONLY);
-    mapper.AddArray("hardwareVer", &dev_info_t::hardwareVer, DATA_TYPE_UINT8, 4, "", "Hardware version", DATA_FLAGS_READ_ONLY);
-    mapper.AddArray("firmwareVer", &dev_info_t::firmwareVer, DATA_TYPE_UINT8, 4, "", "Firmware version", DATA_FLAGS_READ_ONLY);
+    mapper.AddArray("hardwareVer", &dev_info_t::hardwareVer, DATA_TYPE_UINT8, 4, {""}, {"Hardware version"}, DATA_FLAGS_READ_ONLY);
+    mapper.AddArray("firmwareVer", &dev_info_t::firmwareVer, DATA_TYPE_UINT8, 4, {""}, {"Firmware version"}, DATA_FLAGS_READ_ONLY);
     mapper.AddMember("buildNumber", &dev_info_t::buildNumber, DATA_TYPE_UINT32, "", "Build number (0xFFFFF000 = Host key, 0x00000FFF = Build #)", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddArray("protocolVer", &dev_info_t::protocolVer, DATA_TYPE_UINT8, 4, "", "Communications protocol version", DATA_FLAGS_READ_ONLY);
+    mapper.AddArray("protocolVer", &dev_info_t::protocolVer, DATA_TYPE_UINT8, 4, {""}, {"Communications protocol version"}, DATA_FLAGS_READ_ONLY);
     mapper.AddMember("repoRevision", &dev_info_t::repoRevision, DATA_TYPE_UINT32, "", "Repo revision", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember("manufacturer", &dev_info_t::manufacturer, DATA_TYPE_STRING, "", "manufacturer", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("buildType", &dev_info_t::buildType, DATA_TYPE_UINT8, "", "'a'(97)=ALPHA, 'b'(98)=BETA, 'c'(99)=CANDIDATE, 'r'(114)=PRODUCTION, 'd'(100)=develop, 's'(115)=snapshot, '^'(94)=dirty", DATA_FLAGS_READ_ONLY);
@@ -111,7 +111,7 @@ static void PopulateMapManufacturingInfo(data_set_t data_set[DID_COUNT], uint32_
     mapper.AddMember("key", &manufacturing_info_t::key, DATA_TYPE_UINT32, "", "key (times OTP area was set, 15 max)", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("platformType", &manufacturing_info_t::platformType, DATA_TYPE_INT32, "", "Platform type (carrier board)", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("reserved", &manufacturing_info_t::reserved, DATA_TYPE_INT32, "", "Reserved", DATA_FLAGS_READ_ONLY);
-    mapper.AddArray("uid", &manufacturing_info_t::uid, DATA_TYPE_UINT32, 4, "", "Unique microcontroller identifier", DATA_FLAGS_READ_ONLY);
+    mapper.AddArray("uid", &manufacturing_info_t::uid, DATA_TYPE_UINT32, 4, {""}, {"Unique microcontroller identifier"}, DATA_FLAGS_READ_ONLY);
 }
 
 static void PopulateMapBit(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -198,8 +198,8 @@ static void PopulateMapImu(data_set_t data_set[DID_COUNT], uint32_t did, string 
 {
     DataMapper<imu_t> mapper(data_set, did);
     mapper.AddMember("time", &imu_t::time, DATA_TYPE_F64, "s", "Time since boot up", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray2("pqr", offsetof(imu_t, I.pqr), DATA_TYPE_F32, 3, SYM_DEG_PER_S, "Angular rate.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
-    mapper.AddArray2("acc", offsetof(imu_t, I.acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Linear acceleration.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("pqr", offsetof(imu_t, I.pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Angular rate.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
+    mapper.AddArray2("acc", offsetof(imu_t, I.acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("status", &imu_t::status, DATA_TYPE_UINT32, "", s_imuStatusDescription, DATA_FLAGS_DISPLAY_HEX);
 }
 
@@ -208,12 +208,12 @@ static void PopulateMapImu3(data_set_t data_set[DID_COUNT], uint32_t did, string
     DataMapper<imu3_t> mapper(data_set, did);
     mapper.AddMember("time", &imu3_t::time, DATA_TYPE_F64, "s", "Time since boot up", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("status", &imu3_t::status, DATA_TYPE_UINT32, "", s_imuStatusDescription, DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddArray2("I0.pqr", offsetof(imu3_t, I[0].pqr), DATA_TYPE_F32, 3, SYM_DEG_PER_S, "IMU 1 angular rate.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
-    mapper.AddArray2("I0.acc", offsetof(imu3_t, I[0].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "IMU 1 linear acceleration.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray2("I1.pqr", offsetof(imu3_t, I[1].pqr), DATA_TYPE_F32, 3, SYM_DEG_PER_S, "IMU 2 angular rate.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
-    mapper.AddArray2("I1.acc", offsetof(imu3_t, I[1].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "IMU 2 linear acceleration.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray2("I2.pqr", offsetof(imu3_t, I[2].pqr), DATA_TYPE_F32, 3, SYM_DEG_PER_S, "IMU 3 angular rate.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
-    mapper.AddArray2("I2.acc", offsetof(imu3_t, I[2].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "IMU 3 linear acceleration.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("I0.pqr", offsetof(imu3_t, I[0].pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"IMU 1 angular rate.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
+    mapper.AddArray2("I0.acc", offsetof(imu3_t, I[0].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"IMU 1 linear acceleration.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("I1.pqr", offsetof(imu3_t, I[1].pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"IMU 2 angular rate.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
+    mapper.AddArray2("I1.acc", offsetof(imu3_t, I[1].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"IMU 2 linear acceleration.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("I2.pqr", offsetof(imu3_t, I[2].pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"IMU 3 angular rate.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
+    mapper.AddArray2("I2.acc", offsetof(imu3_t, I[2].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"IMU 3 linear acceleration.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
 }
 
 static void PopulateMapSysParams(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -240,9 +240,9 @@ static void PopulateMapSysSensors(data_set_t data_set[DID_COUNT], uint32_t did)
     DataMapper<sys_sensors_t> mapper(data_set, did);
     mapper.AddMember("time", &sys_sensors_t::time, DATA_TYPE_F64, "s", "Time since boot up", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("temp", &sys_sensors_t::temp, DATA_TYPE_F32, SYM_DEG_C, "System temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray("pqr", &sys_sensors_t::pqr, DATA_TYPE_F32, 3, SYM_DEG_PER_S, "Angular rate", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
-    mapper.AddArray("acc", &sys_sensors_t::acc, DATA_TYPE_F32, 3, SYM_M_PER_S, "Linear acceleration", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray("mag", &sys_sensors_t::mag, DATA_TYPE_F32, 3, "", "Magnetometer normalized gauss", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("pqr", &sys_sensors_t::pqr, DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Angular rate"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
+    mapper.AddArray("acc", &sys_sensors_t::acc, DATA_TYPE_F32, 3, {SYM_M_PER_S}, {"Linear acceleration"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("mag", &sys_sensors_t::mag, DATA_TYPE_F32, 3, {""}, {"Magnetometer normalized gauss"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("bar", &sys_sensors_t::bar, DATA_TYPE_F32, "kPa", "Barometric pressure", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3 );
     mapper.AddMember("barTemp", &sys_sensors_t::barTemp, DATA_TYPE_F32, "m", "Barometer MSL altitude", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2 );
     mapper.AddMember("mslBar", &sys_sensors_t::mslBar, DATA_TYPE_F32, "C", "Barometer temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
@@ -269,10 +269,10 @@ void PopulateMapIns1(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("timeOfWeek", &ins_1_t::timeOfWeek, DATA_TYPE_F64, "s", "Time of week since Sunday morning, GMT", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4 );
     mapper.AddMember("insStatus", &ins_1_t::insStatus, DATA_TYPE_UINT32,  "", s_insStatusDescription, DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_INS_STATUS);
     mapper.AddMember("hdwStatus", &ins_1_t::hdwStatus, DATA_TYPE_UINT32,  "", s_hdwStatusDescription, DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddVec3Rpy("theta", offsetof(ins_1_t, theta), DATA_TYPE_F32, SYM_DEG, "euler angle", flags | DATA_FLAGS_ANGLE, C_RAD2DEG); // ERROR_THRESH_ROLLPITCH);
+    mapper.AddVec3Rpy("theta", offsetof(ins_1_t,theta), DATA_TYPE_F32, SYM_DEG, "euler angle", flags | DATA_FLAGS_ANGLE, C_RAD2DEG); // ERROR_THRESH_ROLLPITCH);
     mapper.AddVec3Xyz("uvw", offsetof(ins_1_t,uvw), DATA_TYPE_F32, "m/s", "velocity in body frame", flags);
     str = " offset from reference LLA";
-    mapper.AddVec3("ned", offsetof(ins_1_t,ned), DATA_TYPE_F32, "m", "North"+str, "East"+str, "Down"+str, flags);
+    mapper.AddArray("ned", &ins_1_t::ned, DATA_TYPE_F32, 3, {"m"}, {"North"+str, "East"+str, "Down"+str}, flags);
     mapper.AddLlaDegM("lla", offsetof(ins_1_t, lla), "WGS84 coordinate", "ellipsoid altitude", DATA_FLAGS_READ_ONLY);
 }
 
@@ -285,7 +285,7 @@ static void PopulateMapIns2(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("insStatus", &ins_2_t::insStatus, DATA_TYPE_UINT32,  "", s_insStatusDescription, DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_INS_STATUS);
     mapper.AddMember("hdwStatus", &ins_2_t::hdwStatus, DATA_TYPE_UINT32,  "", s_hdwStatusDescription, DATA_FLAGS_DISPLAY_HEX);
     std::string str = " quaternion body rotation with respect to NED";
-    mapper.AddVec4("qn2b", offsetof(ins_2_t, qn2b), DATA_TYPE_F32, "", "W"+str, "X"+str, "Y"+str, "Z"+str, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("qn2b", &ins_2_t::qn2b, DATA_TYPE_F32, 4, {""}, {"W"+str, "X"+str, "Y"+str, "Z"+str}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddVec3Xyz("uvw", offsetof(ins_2_t, uvw), DATA_TYPE_F32, "m/s", "velocity in body frame", flags);
     mapper.AddLlaDegM("lla", offsetof(ins_2_t, lla), "WGS84 coordinate", "ellipsoid altitude", DATA_FLAGS_READ_ONLY);
 }
@@ -299,7 +299,7 @@ static void PopulateMapIns3(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("insStatus", &ins_3_t::insStatus, DATA_TYPE_UINT32,  "", s_insStatusDescription, DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_INS_STATUS);
     mapper.AddMember("hdwStatus", &ins_3_t::hdwStatus, DATA_TYPE_UINT32,  "", s_hdwStatusDescription, DATA_FLAGS_DISPLAY_HEX);
     std::string str = " quaternion body rotation with respect to NED";
-    mapper.AddVec4("qn2b", offsetof(ins_3_t, qn2b), DATA_TYPE_F32, "", "W"+str, "X"+str, "Y"+str, "Z"+str, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("qn2b", &ins_3_t::qn2b, DATA_TYPE_F32, 4, {""}, {"W"+str, "X"+str, "Y"+str, "Z"+str}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddVec3Xyz("uvw", offsetof(ins_3_t, uvw), DATA_TYPE_F32, "m/s", "velocity in body frame", flags);
     mapper.AddLlaDegM("lla", offsetof(ins_3_t, lla), "WGS84 coordinate", "ellipsoid altitude", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("msl", &ins_3_t::msl, DATA_TYPE_F32, "m", "Height above mean sea level (MSL)", flags);
@@ -314,7 +314,7 @@ static void PopulateMapIns4(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("insStatus", &ins_4_t::insStatus, DATA_TYPE_UINT32,  "", s_insStatusDescription, DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_INS_STATUS);
     mapper.AddMember("hdwStatus", &ins_4_t::hdwStatus, DATA_TYPE_UINT32,  "", s_hdwStatusDescription, DATA_FLAGS_DISPLAY_HEX);
     std::string str = " quaternion body rotation with respect to ECEF";
-    mapper.AddVec4("qe2b", offsetof(ins_4_t, qe2b), DATA_TYPE_F32, "", "W"+str, "X"+str, "Y"+str, "Z"+str, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("qe2b", &ins_4_t::qe2b, DATA_TYPE_F32, 4, {""}, {"W"+str, "X"+str, "Y"+str, "Z"+str}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddVec3Xyz("ve", offsetof(ins_4_t,ve), DATA_TYPE_F32, "m/s", "velocity in ECEF (earth-centered earth-fixed) frame", flags);
     mapper.AddVec3Xyz("ecef", offsetof(ins_4_t,ecef), DATA_TYPE_F64, "m", "position in ECEF (earth-centered earth-fixed) frame", flags);
 }
@@ -325,7 +325,7 @@ static void PopulateMapGpsPos(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("week", &gps_pos_t::week, DATA_TYPE_UINT32, "week", "Weeks since Jan 6, 1980", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("timeOfWeekMs", &gps_pos_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("status", &gps_pos_t::status, DATA_TYPE_UINT32, "", "GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_GPS_STATUS);
-    mapper.AddArray("ecef", &gps_pos_t::ecef, DATA_TYPE_F64, 3, "m", "Position in ECEF {x,y,z}", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("ecef", &gps_pos_t::ecef, DATA_TYPE_F64, 3, {"m"}, {"Position in ECEF {x,y,z}"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddLlaDegM("lla", offsetof(gps_pos_t, lla), "", "ellipsoid altitude", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("hMSL", &gps_pos_t::hMSL, DATA_TYPE_F32, "m", "Meters above sea level", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("hAcc", &gps_pos_t::hAcc, DATA_TYPE_F32, "m", "Position horizontal accuracy", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
@@ -343,7 +343,7 @@ static void PopulateMapGpsVel(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<gps_vel_t> mapper(data_set, did);
     mapper.AddMember("timeOfWeekMs", &gps_vel_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray("vel", &gps_vel_t::vel, DATA_TYPE_F32, 3, "m/s", "Velocity in ECEF {vx,vy,vz} or NED {vN, vE, 0} if status GPS_STATUS_FLAGS_GPS_NMEA_DATA = 0 or 1", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
+    mapper.AddArray("vel", &gps_vel_t::vel, DATA_TYPE_F32, 3, {"m/s"}, {"Velocity in ECEF {vx,vy,vz} or NED {vN, vE, 0} if status GPS_STATUS_FLAGS_GPS_NMEA_DATA = 0 or 1"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
     mapper.AddMember("sAcc", &gps_vel_t::sAcc, DATA_TYPE_F32, "m/s", "Speed accuracy", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
     mapper.AddMember("status", &gps_vel_t::status, DATA_TYPE_UINT32, "", "GPS status: NMEA input if status flag GPS_STATUS_FLAGS_GPS_NMEA_DATA", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
 }
@@ -387,7 +387,7 @@ static void PopulateMapGpsVersion(data_set_t data_set[DID_COUNT], uint32_t did)
     DataMapper<gps_version_t> mapper(data_set, did);
     mapper.AddMember("swVersion", &gps_version_t::swVersion, DATA_TYPE_STRING, "", "Software version");
     mapper.AddMember("hwVersion", &gps_version_t::hwVersion, DATA_TYPE_STRING, "", "Hardware version");
-    mapper.AddArray("extension", &gps_version_t::extension, DATA_TYPE_STRING, GPS_VER_NUM_EXTENSIONS, "", "Extension 30 bytes array description.");
+    mapper.AddArray("extension", &gps_version_t::extension, DATA_TYPE_STRING, GPS_VER_NUM_EXTENSIONS, {""}, {"Extension 30 bytes array description."});
 }
 
 static void PopulateMapGpsTimepulse(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -410,7 +410,7 @@ static void PopulateMapMagnetometer(data_set_t data_set[DID_COUNT], uint32_t did
 {
     DataMapper<magnetometer_t> mapper(data_set, did);
     mapper.AddMember("time", &magnetometer_t::time, DATA_TYPE_F64, "s", "Time since boot up", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray("mag", &magnetometer_t::mag, DATA_TYPE_F32, 3, "", "Normalized gauss", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("mag", &magnetometer_t::mag, DATA_TYPE_F32, 3, {SYM_M_PER_S}, {"Normalized gauss"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
 }
 
 static void PopulateMapBarometer(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -429,31 +429,31 @@ static void PopulateMapPimu(data_set_t data_set[DID_COUNT], uint32_t did, string
     mapper.AddMember("time", &pimu_t::time, DATA_TYPE_F64, "s", "Local time since startup.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("dt", &pimu_t::dt, DATA_TYPE_F32, "s", "Integration period.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("status", &pimu_t::status, DATA_TYPE_UINT32, "", s_imuStatusDescription, DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddArray("theta", &pimu_t::theta, DATA_TYPE_F32, 3, SYM_DEG, "IMU delta theta coning and sculling integrals in body/IMU frame.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
-    mapper.AddArray("vel", &pimu_t::vel, DATA_TYPE_F32, 3, "m/s", "IMU delta velocity coning and sculling integrals in body/IMU frame.  " + description, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_5);
+    mapper.AddArray("theta", &pimu_t::theta, DATA_TYPE_F32, 3, {SYM_DEG}, {"IMU delta theta coning and sculling integrals in body/IMU frame.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
+    mapper.AddArray("vel", &pimu_t::vel, DATA_TYPE_F32, 3, {"m/s"}, {"IMU delta velocity coning and sculling integrals in body/IMU frame.  " + description}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_5);
 }
 
 static void PopulateMapPimuMag(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<pimu_mag_t> mapper(data_set, did);
     mapper.AddMember2("imutime", offsetof(pimu_mag_t, pimu.time), DATA_TYPE_F64, "s", "Local time since startup.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray2("theta", offsetof(pimu_mag_t, pimu.theta), DATA_TYPE_F32, 3, SYM_DEG, "IMU delta theta coning and sculling integrals in body/IMU frame.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
-    mapper.AddArray2("vel", offsetof(pimu_mag_t, pimu.vel), DATA_TYPE_F32, 3, "m/s", "IMU delta velocity coning and sculling integrals in body/IMU frame.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_5);
+    mapper.AddArray2("theta", offsetof(pimu_mag_t, pimu.theta), DATA_TYPE_F32, 3, {SYM_DEG}, {"IMU delta theta coning and sculling integrals in body/IMU frame."}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
+    mapper.AddArray2("vel", offsetof(pimu_mag_t, pimu.vel), DATA_TYPE_F32, 3, {"m/s"}, {"IMU delta velocity coning and sculling integrals in body/IMU frame."}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_5);
     mapper.AddMember2("dt", offsetof(pimu_mag_t, pimu.dt), DATA_TYPE_F32, "s", "Integration period.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember2("imustatus", offsetof(pimu_mag_t, pimu.status), DATA_TYPE_UINT32, "", s_imuStatusDescription, DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember2("magtime", offsetof(pimu_mag_t, mag.time), DATA_TYPE_F64, "s", "Local time since startup.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray2("mag", offsetof(pimu_mag_t, mag.mag), DATA_TYPE_F32, 3, "", "Normalized gauss", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("mag", offsetof(pimu_mag_t, mag.mag), DATA_TYPE_F32, 3, {""}, {"Normalized gauss"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
 }
 
 static void PopulateMapImuMag(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<imu_mag_t> mapper(data_set, did);
     mapper.AddMember2("imutime", offsetof(imu_mag_t, imu.time), DATA_TYPE_F64, "s", "Time since boot up", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray2("pqr", offsetof(imu_mag_t, imu.I.pqr), DATA_TYPE_F32, 3, SYM_DEG_PER_S, "IMU Angular rate", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
-    mapper.AddArray2("acc", offsetof(imu_mag_t, imu.I.acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "IMU Linear acceleration", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("pqr", offsetof(imu_mag_t, imu.I.pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"IMU Angular rate"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
+    mapper.AddArray2("acc", offsetof(imu_mag_t, imu.I.acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"IMU Linear acceleration"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember2("imustatus", offsetof(imu_mag_t, imu.status), DATA_TYPE_UINT32, "", s_imuStatusDescription, DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember2("magtime", offsetof(imu_mag_t, mag.time), DATA_TYPE_F64, "s", "Local time since startup.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray2("mag", offsetof(imu_mag_t, mag.mag), DATA_TYPE_F32, 3, "", "Normalized gauss", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("mag", offsetof(imu_mag_t, mag.mag), DATA_TYPE_F32, 3, {""}, {"Normalized gauss"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
 }
 
 static void PopulateMapMagCal(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -473,19 +473,19 @@ static void PopulateMapInfieldCal(data_set_t data_set[DID_COUNT], uint32_t did)
 
     for (int i=0; i<NUM_IMU_DEVICES; i++)
     {
-        mapper.AddArray2("imu" + std::to_string(i) + ".pqr", i*sizeof(imus_t) + offsetof(infield_cal_t, imu[0].pqr), DATA_TYPE_F32, 3, SYM_DEG_PER_S, "Sampled angular rate.  IMU bias when state=INFIELD_CAL_STATE_SAVED_AND_FINISHED", DATA_FLAGS_FIXED_DECIMAL_3, C_RAD2DEG);
-        mapper.AddArray2("imu" + std::to_string(i) + ".acc", i*sizeof(imus_t) + offsetof(infield_cal_t, imu[0].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Sampled linear acceleration.  IMU bias when state=INFIELD_CAL_STATE_SAVED_AND_FINISHED", DATA_FLAGS_FIXED_DECIMAL_4);
+        mapper.AddArray2("imu" + std::to_string(i) + ".pqr", i*sizeof(imus_t) + offsetof(infield_cal_t, imu[0].pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Sampled angular rate.  IMU bias when state=INFIELD_CAL_STATE_SAVED_AND_FINISHED"}, DATA_FLAGS_FIXED_DECIMAL_3, C_RAD2DEG);
+        mapper.AddArray2("imu" + std::to_string(i) + ".acc", i*sizeof(imus_t) + offsetof(infield_cal_t, imu[0].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Sampled linear acceleration.  IMU bias when state=INFIELD_CAL_STATE_SAVED_AND_FINISHED"}, DATA_FLAGS_FIXED_DECIMAL_4);
     }
 
     for (int i=0; i<3; i++)
     {
-        mapper.AddArray2 ("calData" + std::to_string(i) + ".down.dev[0].acc", i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].down.dev[0].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Linear acceleration", DATA_FLAGS_FIXED_DECIMAL_4);
-        mapper.AddArray2 ("calData" + std::to_string(i) + ".down.dev[1].acc", i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].down.dev[1].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Linear acceleration", DATA_FLAGS_FIXED_DECIMAL_4);
-        mapper.AddArray2 ("calData" + std::to_string(i) + ".down.dev[2].acc", i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].down.dev[2].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Linear acceleration", DATA_FLAGS_FIXED_DECIMAL_4);
+        mapper.AddArray2("calData" + std::to_string(i) + ".down.dev[0].acc", i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].down.dev[0].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration"}, DATA_FLAGS_FIXED_DECIMAL_4);
+        mapper.AddArray2("calData" + std::to_string(i) + ".down.dev[1].acc", i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].down.dev[1].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration"}, DATA_FLAGS_FIXED_DECIMAL_4);
+        mapper.AddArray2("calData" + std::to_string(i) + ".down.dev[2].acc", i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].down.dev[2].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration"}, DATA_FLAGS_FIXED_DECIMAL_4);
         mapper.AddMember2("calData" + std::to_string(i) + ".down.yaw",        i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].down.yaw), DATA_TYPE_F32, SYM_DEG, "Yaw angle. >=999 means two samples have been averaged.", DATA_FLAGS_FIXED_DECIMAL_1, C_RAD2DEG);
-        mapper.AddArray2 ("calData" + std::to_string(i) + ".up.dev[0].acc",   i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].up.dev[0].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Linear acceleration", DATA_FLAGS_FIXED_DECIMAL_4);
-        mapper.AddArray2 ("calData" + std::to_string(i) + ".up.dev[1].acc",   i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].up.dev[1].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Linear acceleration", DATA_FLAGS_FIXED_DECIMAL_4);
-        mapper.AddArray2 ("calData" + std::to_string(i) + ".up.dev[2].acc",   i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].up.dev[2].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Linear acceleration", DATA_FLAGS_FIXED_DECIMAL_4);
+        mapper.AddArray2("calData" + std::to_string(i) + ".up.dev[0].acc",   i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].up.dev[0].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration"}, DATA_FLAGS_FIXED_DECIMAL_4);
+        mapper.AddArray2("calData" + std::to_string(i) + ".up.dev[1].acc",   i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].up.dev[1].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration"}, DATA_FLAGS_FIXED_DECIMAL_4);
+        mapper.AddArray2("calData" + std::to_string(i) + ".up.dev[2].acc",   i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].up.dev[2].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration"}, DATA_FLAGS_FIXED_DECIMAL_4);
         mapper.AddMember2("calData" + std::to_string(i) + ".up.yaw",          i*sizeof(infield_cal_vaxis_t) + offsetof(infield_cal_t, calData[0].up.yaw), DATA_TYPE_F32, SYM_DEG, "Yaw angle. >=999 means two samples have been averaged.", DATA_FLAGS_FIXED_DECIMAL_1, C_RAD2DEG);
     }
 }
@@ -510,10 +510,10 @@ static void PopulateMapGroundVehicle(data_set_t data_set[DID_COUNT], uint32_t di
     mapper.AddMember("status", &ground_vehicle_t::status, DATA_TYPE_UINT32, "", "", DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_READ_ONLY);
     mapper.AddMember("mode", &ground_vehicle_t::mode, DATA_TYPE_UINT32, "", "1=learning; Commands[2=start, 3=resume, 4=clear&start, 5=stop&save, 6=cancel]");
     mapper.AddMember2("wheelConfig.bits", offsetof(ground_vehicle_t, wheelConfig.bits), DATA_TYPE_UINT32, "", "", DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddArray2("wheelConfig.transform.e_b2w", offsetof(ground_vehicle_t, wheelConfig.transform.e_b2w), DATA_TYPE_F32, 3, "rad", "Euler angle rotation from imu (body) to wheel frame (center of non-steering axle)", DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray2("wheelConfig.transform.e_b2w_sigma", offsetof(ground_vehicle_t, wheelConfig.transform.e_b2w_sigma), DATA_TYPE_F32, 3, "rad", "Standard deviation of Euler angles describing rotation from imu (body) to wheel frame (center of non-steering axle)", DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray2("wheelConfig.transform.t_b2w", offsetof(ground_vehicle_t, wheelConfig.transform.t_b2w), DATA_TYPE_F32, 3, "m", "Translation from imu (body) to wheel frame origin (center of non-steering axle), expressed in imu (body) frame", DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray2("wheelConfig.transform.t_b2w_sigma", offsetof(ground_vehicle_t, wheelConfig.transform.t_b2w_sigma), DATA_TYPE_F32, 3, "m", "Standard deviation of translation from imu (body) to wheel frame origin (center of non-steering axle), expressed in imu (body) frame", DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("wheelConfig.transform.e_b2w", offsetof(ground_vehicle_t, wheelConfig.transform.e_b2w), DATA_TYPE_F32, 3, { "rad" }, { "Euler angle rotation from imu (body) to wheel frame (center of non-steering axle)" }, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("wheelConfig.transform.e_b2w_sigma", offsetof(ground_vehicle_t, wheelConfig.transform.e_b2w_sigma), DATA_TYPE_F32, 3, { "rad" }, { "Standard deviation of Euler angles describing rotation from imu (body) to wheel frame (center of non-steering axle)" }, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("wheelConfig.transform.t_b2w", offsetof(ground_vehicle_t, wheelConfig.transform.t_b2w), DATA_TYPE_F32, 3, { "m" }, { "Translation from imu (body) to wheel frame origin (center of non-steering axle), expressed in imu (body) frame" }, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("wheelConfig.transform.t_b2w_sigma", offsetof(ground_vehicle_t, wheelConfig.transform.t_b2w_sigma), DATA_TYPE_F32, 3, { "m" }, { "Standard deviation of translation from imu (body) to wheel frame origin (center of non-steering axle), expressed in imu (body) frame" }, DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember2("wheelConfig.track_width", offsetof(ground_vehicle_t, wheelConfig.track_width), DATA_TYPE_F32, "m", "Distance between left and right wheels");
     mapper.AddMember2("wheelConfig.radius", offsetof(ground_vehicle_t, wheelConfig.radius), DATA_TYPE_F32, "m", "Wheel radius");
 }
@@ -535,8 +535,8 @@ static void PopulateMapNvmFlashCfg(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("ser0BaudRate", &nvm_flash_cfg_t::ser0BaudRate, DATA_TYPE_UINT32, "bps", "Serial port 0 baud rate");
     mapper.AddMember("ser1BaudRate", &nvm_flash_cfg_t::ser1BaudRate, DATA_TYPE_UINT32, "bps", "Serial port 1 baud rate");
     mapper.AddMember("ser2BaudRate", &nvm_flash_cfg_t::ser2BaudRate, DATA_TYPE_UINT32, "bps", "Serial port 2 baud rate");
-    mapper.AddVec3Rpy("insRotation", offsetof(nvm_flash_cfg_t,insRotation), DATA_TYPE_F32, SYM_DEG, "rotation from INS Sensor Frame to Intermediate Output Frame.  Order applied: yaw, pitch, roll.", 0, C_RAD2DEG);
-    mapper.AddVec3Xyz("insOffset", offsetof(nvm_flash_cfg_t,insOffset), DATA_TYPE_F32, "m", "offset from Intermediate Output Frame to INS Output Frame.  INS rotation is applied before this.");
+    mapper.AddVec3Rpy("insRotation", offsetof(nvm_flash_cfg_t, insRotation), DATA_TYPE_F32, SYM_DEG, "rotation from INS Sensor Frame to Intermediate Output Frame.  Order applied: yaw, pitch, roll.", 0, C_RAD2DEG);
+    mapper.AddVec3Xyz("insOffset", offsetof(nvm_flash_cfg_t, insOffset), DATA_TYPE_F32, "m", "offset from Intermediate Output Frame to INS Output Frame.  INS rotation is applied before this.");
     mapper.AddVec3Xyz("gps1AntOffset", offsetof(nvm_flash_cfg_t,gps1AntOffset), DATA_TYPE_F32, "m", "offset from Sensor Frame origin to GPS1 antenna.");
     mapper.AddVec3Xyz("gps2AntOffset", offsetof(nvm_flash_cfg_t,gps2AntOffset), DATA_TYPE_F32, "m", "offset from Sensor Frame origin to GPS2 antenna.");
 
@@ -575,15 +575,14 @@ static void PopulateMapNvmFlashCfg(data_set_t data_set[DID_COUNT], uint32_t did)
 	mapper.AddMember("magInterferenceThreshold", &nvm_flash_cfg_t::magInterferenceThreshold, DATA_TYPE_F32, "", "Magnetometer interference sensitivity threshold. Typical range is 2-10 (3 default) and 1000 to disable mag interference detection.");
 	mapper.AddMember("magCalibrationQualityThreshold", &nvm_flash_cfg_t::magCalibrationQualityThreshold, DATA_TYPE_F32, "", "Magnetometer calibration quality sensitivity threshold. Typical range is 10-20 (10 default) and 1000 to disable mag calibration quality check, forcing it to be always good.");
     str = "rotation from INS Sensor Frame to Intermediate Output Frame.  Order applied: heading, pitch, roll.";
-    mapper.AddArray("zeroVelRotation", &nvm_flash_cfg_t::zeroVelRotation, DATA_TYPE_F32, 3, SYM_DEG, "Roll, pitch, yaw " + str, 0, C_RAD2DEG);
-    // Do not change `zeroVelOffset` registration from mapper.AddArray() to mapper.AddVec3Xyz() as it is used in a ci test.  
+    mapper.AddArray("zeroVelRotation", &nvm_flash_cfg_t::zeroVelRotation, DATA_TYPE_F32, 3, {SYM_DEG}, {"Roll, pitch, yaw " + str}, 0, C_RAD2DEG);
     str = "offset from Intermediate Output Frame to INS Output Frame.  INS rotation is applied before this.";
-    mapper.AddArray("zeroVelOffset", &nvm_flash_cfg_t::zeroVelOffset, DATA_TYPE_F32, 3, "m", "X,Y,Z " + str);
+    mapper.AddArray("zeroVelOffset", &nvm_flash_cfg_t::zeroVelOffset, DATA_TYPE_F32, 3, {"m"}, {"X,Y,Z " + str}, 0, C_RAD2DEG);
     mapper.AddMember2("wheelConfig.bits", offsetof(nvm_flash_cfg_t, wheelConfig.bits), DATA_TYPE_UINT32, "", "Wheel encoder config bits: 0x1 enable encoders, 0x2 kinematic constraints", DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddArray2("wheelConfig.transform.e_b2w", offsetof(nvm_flash_cfg_t, wheelConfig.transform.e_b2w), DATA_TYPE_F32, 3, "rad", "Euler angles describing the rotation from imu (body) to the wheel frame (center of the non-steering axle)", DATA_FLAGS_FIXED_DECIMAL_2);
-    mapper.AddArray2("wheelConfig.transform.e_b2w_sigma", offsetof(nvm_flash_cfg_t, wheelConfig.transform.e_b2w_sigma), DATA_TYPE_F32, 3, "m", "Standard deviation of Euler angles describing the rotation from imu (body) to the wheel frame (center of the non-steering axle)", DATA_FLAGS_FIXED_DECIMAL_2);
-    mapper.AddArray2("wheelConfig.transform.t_b2w", offsetof(nvm_flash_cfg_t, wheelConfig.transform.t_b2w), DATA_TYPE_F32, 3, "m", "Translation from the imu (body) to the wheel frame origin (center of the non-steering axle), expressed in the imu (body) frame", DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray2("wheelConfig.transform.t_b2w_sigma", offsetof(nvm_flash_cfg_t, wheelConfig.transform.t_b2w_sigma), DATA_TYPE_F32, 3, "rad", "Standard deviation of translation from the imu (body) to the wheel frame origin (center of the non-steering axle), expressed in the imu (body) frame", DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("wheelConfig.transform.e_b2w", offsetof(nvm_flash_cfg_t, wheelConfig.transform.e_b2w), DATA_TYPE_F32, 3, {"rad"}, {"Euler angles describing the rotation from imu (body) to the wheel frame (center of the non-steering axle)"}, DATA_FLAGS_FIXED_DECIMAL_2);
+    mapper.AddArray2("wheelConfig.transform.e_b2w_sigma", offsetof(nvm_flash_cfg_t, wheelConfig.transform.e_b2w_sigma), DATA_TYPE_F32, 3, {"rad"}, {"Standard deviation of Euler angles describing the rotation from imu (body) to the wheel frame (center of the non-steering axle)"}, DATA_FLAGS_FIXED_DECIMAL_2);
+    mapper.AddArray2("wheelConfig.transform.t_b2w", offsetof(nvm_flash_cfg_t, wheelConfig.transform.t_b2w), DATA_TYPE_F32, 3, {"m"}, {"Translation from the imu (body) to the wheel frame origin (center of the non-steering axle), expressed in the imu (body) frame"}, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray2("wheelConfig.transform.t_b2w_sigma", offsetof(nvm_flash_cfg_t, wheelConfig.transform.t_b2w_sigma), DATA_TYPE_F32, 3, {"rad"}, {"Standard deviation of translation from the imu (body) to the wheel frame origin (center of the non-steering axle), expressed in the imu (body) frame"}, DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember2("wheelConfig.track_width", offsetof(nvm_flash_cfg_t, wheelConfig.track_width), DATA_TYPE_F32, "m", "Distance between the left and right wheels");
     mapper.AddMember2("wheelConfig.radius", offsetof(nvm_flash_cfg_t, wheelConfig.radius), DATA_TYPE_F32, "m", "Wheel radius");
     mapper.AddMember("debug", &nvm_flash_cfg_t::debug, DATA_TYPE_UINT8);
@@ -629,10 +628,10 @@ static void PopulateMapGpxFlashCfg(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("ser1BaudRate", &gpx_flash_cfg_t::ser1BaudRate, DATA_TYPE_UINT32, "bps", "Serial port 1 baud rate");
     mapper.AddMember("ser2BaudRate", &gpx_flash_cfg_t::ser2BaudRate, DATA_TYPE_UINT32, "bps", "Serial port 2 baud rate");
     mapper.AddMember("startupGPSDtMs", &gpx_flash_cfg_t::startupGPSDtMs, DATA_TYPE_UINT32, "ms", "GPS measurement (system input data) update period in milliseconds set on startup. 200ms minimum (5Hz max).");
-    str = "offset from Sensor Frame origin to GPS1 antenna.";
-    mapper.AddArray("gps1AntOffset", &gpx_flash_cfg_t::gps1AntOffset, DATA_TYPE_F32, 3, "m", "X " + str);
-    str = "offset from Sensor Frame origin to GPS2 antenna.";
-    mapper.AddArray("gps2AntOffset", &gpx_flash_cfg_t::gps2AntOffset, DATA_TYPE_F32, 3, "m", "X " + str);
+    str = " offset from Sensor Frame origin to GPS1 antenna.";
+    mapper.AddArray("gps1AntOffset", &gpx_flash_cfg_t::gps1AntOffset, DATA_TYPE_F32, 3, {"m"}, {"X" + str, "Y" + str, "Z" + str});
+    str = " offset from Sensor Frame origin to GPS2 antenna.";
+    mapper.AddArray("gps2AntOffset", &gpx_flash_cfg_t::gps2AntOffset, DATA_TYPE_F32, 3, {"m"}, {"X" + str, "Y" + str, "Z" + str});
     mapper.AddMember("gnssSatSigConst", &gpx_flash_cfg_t::gnssSatSigConst, DATA_TYPE_UINT16, "", "GNSS constellations used. 0x0003=GPS, 0x000C=QZSS, 0x0030=Galileo, 0x00C0=Beidou, 0x0300=GLONASS, 0x1000=SBAS (see eGnssSatSigConst)", DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember("dynamicModel", &gpx_flash_cfg_t::dynamicModel, DATA_TYPE_UINT8, "", "0:port, 2:stationary, 3:walk, 4:ground vehicle, 5:sea, 6:air<1g, 7:air<2g, 8:air<4g, 9:wrist");
     mapper.AddMember("debug", &gpx_flash_cfg_t::debug, DATA_TYPE_UINT8, "", "Reserved", DATA_FLAGS_DISPLAY_HEX);
@@ -711,7 +710,7 @@ static void PopulateMapEvbStatus(data_set_t data_set[DID_COUNT], uint32_t did)
     DataMapper<evb_status_t> mapper(data_set, did);
     mapper.AddMember("week", &evb_status_t::week, DATA_TYPE_UINT32, "week", "Weeks since Jan 6, 1980", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("timeOfWeekMs", &evb_status_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY);
-    mapper.AddArray("firmwareVer", &evb_status_t::firmwareVer, DATA_TYPE_UINT8, 4, "", "Firmware version", DATA_FLAGS_READ_ONLY);
+    mapper.AddArray("firmwareVer", &evb_status_t::firmwareVer, DATA_TYPE_UINT8, 4, {""}, {"Firmware version"}, DATA_FLAGS_READ_ONLY);
     mapper.AddMember("evbStatus", &evb_status_t::evbStatus, DATA_TYPE_UINT32, "", "EVB status bits", DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember("loggerMode", &evb_status_t::loggerMode, DATA_TYPE_UINT32, "", std::to_string(EVB2_LOG_CMD_START) + "=start, " + std::to_string(EVB2_LOG_CMD_STOP) + "=stop");
     mapper.AddMember("loggerElapsedTimeMs", &evb_status_t::loggerElapsedTimeMs, DATA_TYPE_UINT32, "ms", "Elapsed time of the current data log.");
@@ -730,7 +729,7 @@ static void PopulateMapEvbFlashCfg(data_set_t data_set[DID_COUNT], uint32_t did)
         + to_string(EVB2_CB_PRESET_USB_HUB_RS422) + "=USB hub w/ RS422";
     mapper.AddMember("cbPreset", &evb_flash_cfg_t::cbPreset, DATA_TYPE_UINT8, "", str);
     mapper.AddArray("reserved1", &evb_flash_cfg_t::reserved1, DATA_TYPE_UINT8, 3);
-    mapper.AddArray("cbf", &evb_flash_cfg_t::cbf, DATA_TYPE_UINT32, EVB2_PORT_COUNT, "", "Communications bridge forwarding", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddArray("cbf", &evb_flash_cfg_t::cbf, DATA_TYPE_UINT32, EVB2_PORT_COUNT, {""}, {"Communications bridge forwarding"}, DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember("cbOptions", &evb_flash_cfg_t::cbOptions, DATA_TYPE_UINT32, "", "Communications bridge options (see eEvb2ComBridgeOptions)", DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember("uinsComPort", &evb_flash_cfg_t::uinsComPort, DATA_TYPE_UINT8, "", "EVB port for uINS communications and SD card logging. 0=uINS0 (default), 1=uINS1, SP330=5, 6=GPIO_H8 (use eEvb2CommPorts)");
     mapper.AddMember("uinsAuxPort", &evb_flash_cfg_t::uinsAuxPort, DATA_TYPE_UINT8, "", "EVB port for uINS aux com and RTK corrections. 0=uINS0, 1=uINS1 (default), 5=SP330, 6=GPIO_H8 (use eEvb2CommPorts)");
@@ -748,7 +747,7 @@ static void PopulateMapEvbFlashCfg(data_set_t data_set[DID_COUNT], uint32_t did)
 
     for (int i=0; i<NUM_WIFI_PRESETS; i++)
     {
-        mapper.AddArray2 ("server" + to_string(i) + ".ipAddr", i*sizeof(evb_server_t) + offsetof(evb_flash_cfg_t, server[0].ipAddr.u8), DATA_TYPE_UINT8, 4, "", "Server IP address");
+        mapper.AddArray2("server" + to_string(i) + ".ipAddr", i*sizeof(evb_server_t) + offsetof(evb_flash_cfg_t, server[0].ipAddr.u8), DATA_TYPE_UINT8, 4, {""}, {"Server IP address"});
         mapper.AddMember2("server" + to_string(i) + ".port",   i*sizeof(evb_server_t) + offsetof(evb_flash_cfg_t, server[0].port), DATA_TYPE_UINT32, "", "Sever port");
     }
 
@@ -772,8 +771,8 @@ static void PopulateMapDebugArray(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<debug_array_t> mapper(data_set, did);
     mapper.AddArray("i", &debug_array_t::i, DATA_TYPE_INT32, DEBUG_I_ARRAY_SIZE);
-    mapper.AddArray("f", &debug_array_t::f, DATA_TYPE_F32, DEBUG_F_ARRAY_SIZE, "", "", DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray("lf", &debug_array_t::lf, DATA_TYPE_F64, DEBUG_LF_ARRAY_SIZE, "", "", DATA_FLAGS_FIXED_DECIMAL_9);
+    mapper.AddArray("f", &debug_array_t::f, DATA_TYPE_F32, DEBUG_F_ARRAY_SIZE, {""}, {""}, DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("lf", &debug_array_t::lf, DATA_TYPE_F64, DEBUG_LF_ARRAY_SIZE, {""}, {""}, DATA_FLAGS_FIXED_DECIMAL_9);
 }
 
 static void PopulateMapDebugString(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -946,7 +945,7 @@ static void PopulateMapGpsRtkRel(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<gps_rtk_rel_t> mapper(data_set, did);
     mapper.AddMember("timeOfWeekMs", &gps_rtk_rel_t::timeOfWeekMs, DATA_TYPE_UINT32,  "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray("baseToRoverVector", &gps_rtk_rel_t::baseToRoverVector, DATA_TYPE_F32, 3, "m", "Vector from base to rover in ECEF.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
+    mapper.AddArray("baseToRoverVector", &gps_rtk_rel_t::baseToRoverVector, DATA_TYPE_F32, 3, {"m"}, {"Vector from base to rover in ECEF."}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
     mapper.AddMember("differentialAge", &gps_rtk_rel_t::differentialAge, DATA_TYPE_F32, "s", "Age of differential signal received.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("arRatio", &gps_rtk_rel_t::arRatio, DATA_TYPE_F32, "", "Ambiguity resolution ratio factor for validation.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_1);
     mapper.AddMember("baseToRoverDistance", &gps_rtk_rel_t::baseToRoverDistance, DATA_TYPE_F32, "", "baseToRoverDistance (m)", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
@@ -960,8 +959,8 @@ static void PopulateMapGpsRtkMisc(data_set_t data_set[DID_COUNT], uint32_t did)
     DataMapper<gps_rtk_misc_t> mapper(data_set, did);
     mapper.AddMember("timeOfWeekMs", &gps_rtk_misc_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("timeToFirstFixMs", &gps_rtk_misc_t::timeToFirstFixMs, DATA_TYPE_UINT32, "ms", "Time to first RTK fix", DATA_FLAGS_READ_ONLY);
-    mapper.AddArray("accuracyPos", &gps_rtk_misc_t::accuracyPos, DATA_TYPE_F32, 3, "m", "Accuracy in meters north, east, up (standard deviation)", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray("accuracyCov", &gps_rtk_misc_t::accuracyCov, DATA_TYPE_F32, 3, "m", "Absolute value of means square root of estimated covariance NE, EU, UN", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("accuracyPos", &gps_rtk_misc_t::accuracyPos, DATA_TYPE_F32, 3, {"m"}, {"Accuracy in meters north, east, up (standard deviation)"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("accuracyCov", &gps_rtk_misc_t::accuracyCov, DATA_TYPE_F32, 3, {"m"}, {"Absolute value of means square root of estimated covariance NE, EU, UN"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("arThreshold", &gps_rtk_misc_t::arThreshold, DATA_TYPE_F32, "", "Ambiguity resolution threshold for validation", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("gDop", &gps_rtk_misc_t::gDop, DATA_TYPE_F32, "m", "Geomatic dilution of precision", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddMember("hDop", &gps_rtk_misc_t::hDop, DATA_TYPE_F32, "m", "Horizontal dilution of precision", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
@@ -1146,18 +1145,18 @@ static void PopulateMapSensorsADC(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("time", &sys_sensors_adc_t::time, DATA_TYPE_F64, "s", "Time since boot up", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);    
     for (int i=0; i<NUM_IMU_DEVICES; i++)
     {
-        mapper.AddArray2("imu" + to_string(i) + ".pqr",   i*sizeof(sensors_imu_w_temp_t) + offsetof(sys_sensors_adc_t, imu[0].pqr), DATA_TYPE_F32, 3, "LSB", "", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
-        mapper.AddArray2("imu" + to_string(i) + ".acc",   i*sizeof(sensors_imu_w_temp_t) + offsetof(sys_sensors_adc_t, imu[0].acc), DATA_TYPE_F32, 3, "LSB", "", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
+        mapper.AddArray2("imu" + to_string(i) + ".pqr",   i*sizeof(sensors_imu_w_temp_t) + offsetof(sys_sensors_adc_t, imu[0].pqr), DATA_TYPE_F32, 3, {"LSB"}, {"Uncalibrated sensor output."}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
+        mapper.AddArray2("imu" + to_string(i) + ".acc",   i*sizeof(sensors_imu_w_temp_t) + offsetof(sys_sensors_adc_t, imu[0].acc), DATA_TYPE_F32, 3, {"LSB"}, {"Uncalibrated sensor output."}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
         mapper.AddMember2("imu" + to_string(i) + ".temp", i*sizeof(sensors_imu_w_temp_t) + offsetof(sys_sensors_adc_t, imu[0].temp), DATA_TYPE_F32, "LSB", "", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     }
     for (int i=0; i<NUM_MAG_DEVICES; i++)
     {
-        mapper.AddArray2("mag" + to_string(i) + ".mag", i*sizeof(sensors_mag_t) + offsetof(sys_sensors_adc_t, mag[0].mag), DATA_TYPE_F32, 3, "LSB", "", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
+        mapper.AddArray2("mag" + to_string(i) + ".mag", i*sizeof(sensors_mag_t) + offsetof(sys_sensors_adc_t, mag[0].mag), DATA_TYPE_F32, 3, {"LSB"}, {"Uncalibrated sensor output."}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
     }
     mapper.AddMember("bar", &sys_sensors_adc_t::bar, DATA_TYPE_F32, "kPa", "Barometric pressure", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("barTemp", &sys_sensors_adc_t::barTemp, DATA_TYPE_F32, SYM_DEG_C, "Barometer temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("humidity", &sys_sensors_adc_t::humidity, DATA_TYPE_F32, "%rH", "Relative humidity, 0%-100%", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray("ana", &sys_sensors_adc_t::ana, DATA_TYPE_F32, NUM_ANA_CHANNELS, "V", "ADC analog 0 input voltage", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("ana", &sys_sensors_adc_t::ana, DATA_TYPE_F32, NUM_ANA_CHANNELS, {"V"}, {"ADC analog 0 input voltage"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
 }
 
 static void PopulateMapSensorsWTemp(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -1168,13 +1167,13 @@ static void PopulateMapSensorsWTemp(data_set_t data_set[DID_COUNT], uint32_t did
     mapper.AddMember2("imu3.status", offsetof(sensors_w_temp_t, imu3.status), DATA_TYPE_UINT32, "", "Status", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
     for (int i=0; i<NUM_IMU_DEVICES; i++)
     {
-        mapper.AddArray2("imu" + to_string(i) + ".pqr", i*sizeof(imus_t) + offsetof(sensors_w_temp_t, imu3.I[0].pqr), DATA_TYPE_F32, 3, SYM_DEG_PER_S, "", flags, C_RAD2DEG);
-        mapper.AddArray2("imu" + to_string(i) + ".acc", i*sizeof(imus_t) + offsetof(sensors_w_temp_t, imu3.I[0].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "", flags);
+        mapper.AddArray2("imu" + to_string(i) + ".pqr", i*sizeof(imus_t) + offsetof(sensors_w_temp_t, imu3.I[0].pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Uncalibrated sensor output."}, flags, C_RAD2DEG);
+        mapper.AddArray2("imu" + to_string(i) + ".acc", i*sizeof(imus_t) + offsetof(sensors_w_temp_t, imu3.I[0].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Uncalibrated sensor output."}, flags);
     }
-    mapper.AddArray("temp", &sensors_w_temp_t::temp, DATA_TYPE_F32, 3, SYM_DEG_C, "Uncalibrated sensor output.", flags);
+    mapper.AddArray("temp", &sensors_w_temp_t::temp, DATA_TYPE_F32, 3, {SYM_DEG_C}, {"Uncalibrated sensor output."}, flags);
     for (int i=0; i<NUM_MAG_DEVICES; i++)
     {
-        mapper.AddArray2("mag" + to_string(i) + ".xyz", i*sizeof(mag_xyz_t) + offsetof(sensors_w_temp_t, mag[0].xyz), DATA_TYPE_F32, 3, "", "", flags);
+        mapper.AddArray2("mag" + to_string(i) + ".xyz", i*sizeof(mag_xyz_t) + offsetof(sensors_w_temp_t, mag[0].xyz), DATA_TYPE_F32, 3, {""}, {"Uncalibrated sensor output."}, flags);
     }
 }
 
@@ -1185,9 +1184,9 @@ static void PopulateMapSensors(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("time", &sensors_t::time, DATA_TYPE_F64, "s", "GPS time of week (since Sunday morning).");
     for (int i=0; i<NUM_IMU_DEVICES; i++)
     {
-        mapper.AddArray2("pqr" + to_string(i), i*sizeof(sensors_mpu_t) + offsetof(sensors_t, mpu[0].pqr), DATA_TYPE_F32, 3, SYM_DEG_PER_S, "Temperature compensation bias", flags);
-        mapper.AddArray2("acc" + to_string(i), i*sizeof(sensors_mpu_t) + offsetof(sensors_t, mpu[0].acc), DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Temperature compensation bias", flags);
-        mapper.AddArray2("mag" + to_string(i), i*sizeof(sensors_mpu_t) + offsetof(sensors_t, mpu[0].mag), DATA_TYPE_F32, 3, "", "Temperature compensation bias", flags);
+        mapper.AddArray2("pqr" + to_string(i), i*sizeof(sensors_mpu_t) + offsetof(sensors_t, mpu[0].pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Temperature compensation bias"}, flags);
+        mapper.AddArray2("acc" + to_string(i), i*sizeof(sensors_mpu_t) + offsetof(sensors_t, mpu[0].acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Temperature compensation bias"}, flags);
+        mapper.AddArray2("mag" + to_string(i), i*sizeof(sensors_mpu_t) + offsetof(sensors_t, mpu[0].mag), DATA_TYPE_F32, 3, {""}, {"Temperature compensation bias"}, flags);
     }
 }
 
@@ -1205,11 +1204,11 @@ static void PopulateMapInl2MagObsInfo(data_set_t data_set[DID_COUNT], uint32_t d
     mapper.AddMember("magInsHdgDelta", &inl2_mag_obs_info_t::magInsHdgDelta, DATA_TYPE_F32, "deg", "Difference between magHdg and insHdg", DATA_FLAGS_FIXED_DECIMAL_3 | DATA_FLAGS_ANGLE);
     mapper.AddMember("nis", &inl2_mag_obs_info_t::nis, DATA_TYPE_F32, "", "", DATA_FLAGS_FIXED_DECIMAL_5);
     mapper.AddMember("nis_threshold", &inl2_mag_obs_info_t::nis_threshold, DATA_TYPE_F32, "", "", DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray("Wcal", &inl2_mag_obs_info_t::Wcal, DATA_TYPE_F32, 9, "", "", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("Wcal", &inl2_mag_obs_info_t::Wcal, DATA_TYPE_F32, 9, {""}, {""}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("activeCalSet", &inl2_mag_obs_info_t::activeCalSet, DATA_TYPE_UINT32, "", "Active calibration set (0 or 1)");
     mapper.AddMember("magHdgOffset", &inl2_mag_obs_info_t::magHdgOffset, DATA_TYPE_F32, "deg", "Offset from mag heading to ins heading estimate", DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("Tcal", &inl2_mag_obs_info_t::Tcal, DATA_TYPE_F32, "", "Scaled computed variance of calibrated magnetometer samples. Above 5 is bad.", DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray("bias_cal", &inl2_mag_obs_info_t::bias_cal, DATA_TYPE_F32, 3, "", "", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_5);
+    mapper.AddArray("bias_cal", &inl2_mag_obs_info_t::bias_cal, DATA_TYPE_F32, 3, {""}, {""}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_5);
 }
 
 static void PopulateMapInl2States(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -1217,11 +1216,11 @@ static void PopulateMapInl2States(data_set_t data_set[DID_COUNT], uint32_t did)
     DataMapper<inl2_states_t> mapper(data_set, did);
     int flags = DATA_FLAGS_FIXED_DECIMAL_4;
     mapper.AddMember("timeOfWeek", &inl2_states_t::timeOfWeek, DATA_TYPE_F64, "s", "Time of week since Sunday morning, GMT", flags);
-    mapper.AddArray("qe2b", &inl2_states_t::qe2b, DATA_TYPE_F32, 4, "", "Quaternion rotation from ECEF to body frame", flags);
-    mapper.AddArray("ve", &inl2_states_t::ve, DATA_TYPE_F32, 3, "m/s", "Velocity in ECEF frame", flags);
-    mapper.AddArray("ecef", &inl2_states_t::ecef, DATA_TYPE_F64, 3, "m", "Position in ECEF frame", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray("biasPqr", &inl2_states_t::biasPqr, DATA_TYPE_F32, 3, SYM_DEG_PER_S, "Gyro bias", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3, C_RAD2DEG);
-    mapper.AddArray("biasAcc", &inl2_states_t::biasAcc, DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Accelerometer bias", flags);
+    mapper.AddArray("qe2b", &inl2_states_t::qe2b, DATA_TYPE_F32, 4, {""}, {"Quaternion rotation from ECEF to body frame"}, flags);
+    mapper.AddArray("ve", &inl2_states_t::ve, DATA_TYPE_F32, 3, {"m/s"}, {"Velocity in ECEF frame"}, flags);
+    mapper.AddArray("ecef", &inl2_states_t::ecef, DATA_TYPE_F64, 3, {"m"}, {"Position in ECEF frame"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("biasPqr", &inl2_states_t::biasPqr, DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Gyro bias"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3, C_RAD2DEG);
+    mapper.AddArray("biasAcc", &inl2_states_t::biasAcc, DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Accelerometer bias"}, flags);
     mapper.AddMember("biasBaro", &inl2_states_t::biasBaro, DATA_TYPE_F32, "m", "Barometer bias", flags);
     mapper.AddMember("magDec", &inl2_states_t::magDec, DATA_TYPE_F32, SYM_DEG, "Magnetic declination", flags, C_RAD2DEG);
     mapper.AddMember("magInc", &inl2_states_t::magInc, DATA_TYPE_F32, SYM_DEG, "Magnetic inclination", flags, C_RAD2DEG);
@@ -1232,11 +1231,11 @@ static void PopulateMapInl2NedSigma(data_set_t data_set[DID_COUNT], uint32_t did
     DataMapper<inl2_ned_sigma_t> mapper(data_set, did);
     int flags = DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_5;
     mapper.AddMember("timeOfWeekMs", &inl2_ned_sigma_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray("StdAttNed", &inl2_ned_sigma_t::StdAttNed, DATA_TYPE_F32, 3, SYM_DEG, "NED attitude error standard deviation", flags, C_RAD2DEG);
-    mapper.AddArray("StdVelNed", &inl2_ned_sigma_t::StdVelNed, DATA_TYPE_F32, 3, "m/s", "NED velocity error standard deviation", flags);
-    mapper.AddArray("StdPosNed", &inl2_ned_sigma_t::StdPosNed, DATA_TYPE_F32, 3, "m", "NED position error standard deviation", flags);
-    mapper.AddArray("StdAccBias", &inl2_ned_sigma_t::StdAccBias, DATA_TYPE_F32, 3, SYM_M_PER_S_2, "Acceleration bias error standard deviation", flags);
-    mapper.AddArray("StdGyrBias", &inl2_ned_sigma_t::StdGyrBias, DATA_TYPE_F32, 3, SYM_DEG, "Angular rate bias error standard deviation", flags, C_RAD2DEG);
+    mapper.AddArray("StdAttNed", &inl2_ned_sigma_t::StdAttNed, DATA_TYPE_F32, 3, {SYM_DEG}, {"NED attitude error standard deviation"}, flags, C_RAD2DEG);
+    mapper.AddArray("StdVelNed", &inl2_ned_sigma_t::StdVelNed, DATA_TYPE_F32, 3, {"m/s"}, {"NED velocity error standard deviation"}, flags);
+    mapper.AddArray("StdPosNed", &inl2_ned_sigma_t::StdPosNed, DATA_TYPE_F32, 3, {"m"}, {"NED position error standard deviation"}, flags);
+    mapper.AddArray("StdAccBias", &inl2_ned_sigma_t::StdAccBias, DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Acceleration bias error standard deviation"}, flags);
+    mapper.AddArray("StdGyrBias", &inl2_ned_sigma_t::StdGyrBias, DATA_TYPE_F32, 3, {SYM_DEG}, {"Angular rate bias error standard deviation"}, flags, C_RAD2DEG);
     mapper.AddMember("StdBarBias", &inl2_ned_sigma_t::StdBarBias, DATA_TYPE_F32, "m", "Barometric altitude bias error standard deviation", flags);
     mapper.AddMember("StdMagDeclination", &inl2_ned_sigma_t::StdMagDeclination, DATA_TYPE_F32, SYM_DEG, "Mag declination error standard deviation", flags, C_RAD2DEG);
 }
@@ -1249,8 +1248,8 @@ static void PopulateMapRosCovariancePoseTwist(data_set_t data_set[DID_COUNT], ui
     DataMapper<ros_covariance_pose_twist_t> mapper(data_set, did);
     int flags = DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_5;
     mapper.AddMember("timeOfWeek", &ros_covariance_pose_twist_t::timeOfWeek, DATA_TYPE_F64, "s", "Time of week since Sunday morning, GMT", flags);
-    mapper.AddArray("covPoseLD", &ros_covariance_pose_twist_t::covPoseLD, DATA_TYPE_F32, 21, COV_POSE_UNITS, "EKF attitude and position error covariance matrix lower diagonal in body (attitude) and ECEF (position) frames", flags);
-    mapper.AddArray("covTwistLD", &ros_covariance_pose_twist_t::covTwistLD, DATA_TYPE_F32, 21, COV_TWIST_UNITS, "EKF velocity and angular rate error covariance matrix lower diagonal in ECEF (velocity) and body (attitude) frames", flags);
+    mapper.AddArray("covPoseLD", &ros_covariance_pose_twist_t::covPoseLD, DATA_TYPE_F32, 21, {COV_POSE_UNITS}, {"EKF attitude and position error covariance matrix lower diagonal in body (attitude) and ECEF (position) frames"}, flags);
+    mapper.AddArray("covTwistLD", &ros_covariance_pose_twist_t::covTwistLD, DATA_TYPE_F32, 21, {COV_TWIST_UNITS}, {"EKF velocity and angular rate error covariance matrix lower diagonal in ECEF (velocity) and body (attitude) frames"}, flags);
 }
 
 #if PLATFORM_IS_EMBEDDED

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2024,6 +2024,7 @@ bool cISDataMappings::DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& ou
         if (info.arraySize > 0)
         {
             YAML::Node arr(YAML::NodeType::Sequence);
+            arr.SetStyle(YAML::EmitterStyle::Flow);     // Make array display on one line
             for (unsigned int i = 0; i < info.arraySize; ++i)
             {
                 if (DataToString(info, nullptr, dataPtr, stringBuffer, i))
@@ -2056,12 +2057,17 @@ bool cISDataMappings::DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& ou
 
 bool cISDataMappings::YamlToData(int did, const YAML::Node& yaml, uint8_t* dataPtr, std::vector<MemoryUsage>* usageVec)
 {
-    const std::string didName = cISDataMappings::DataName(did);
+    const std::string didName = std::string(cISDataMappings::DataName(did));
     const auto& dataSetMap = *NameToInfoMap(did);
     const YAML::Node& map = yaml[didName];
 
     if (!map || !map.IsMap()) {
         return false;
+    }
+
+    if (usageVec)
+    {
+        usageVec->clear();
     }
 
     for (const auto& kv : map)

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2161,6 +2161,18 @@ void cISDataMappings::AppendMemoryUsage(std::vector<MemoryUsage>& usageVec, void
     usageVec.push_back({ newPtr8, newSize });
 }
 
+void splitStringMulti(const std::string& input, const std::string& delimiters, std::vector<std::string>& output)
+{
+    size_t start = input.find_first_not_of(delimiters), end = 0;
+    while ((end = input.find_first_of(delimiters, start)) != std::string::npos)
+    {
+        output.push_back(input.substr(start, end - start));
+        start = input.find_first_not_of(delimiters, end);
+    }
+    if (start != std::string::npos)
+        output.push_back(input.substr(start));
+}
+
 bool cISDataMappings::DidBufferToString(int did, const uint8_t* dataPtr, string &output, std::string fields)
 {
     std::ostringstream oss, ossHdr;
@@ -2174,7 +2186,7 @@ bool cISDataMappings::DidBufferToString(int did, const uint8_t* dataPtr, string 
     if (!showAll)
     {
         std::vector<std::string> splitFields;
-        splitString(fields, ',', splitFields);
+        splitStringMulti(fields, "\n,|", splitFields);
 
         for (std::string f : splitFields)
         {
@@ -2285,7 +2297,7 @@ bool cISDataMappings::StringToDidBuffer(int did, const std::string& fields, uint
 
     bool success = false;
     std::vector<std::string> keyValues;
-    splitString(fields, '\n', keyValues);
+    splitStringMulti(fields, "\n,|", keyValues);
 
     for (const std::string& keyValue : keyValues)
     {

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1987,7 +1987,7 @@ bool cISDataMappings::VariableToString(eDataType dataType, eDataFlags dataFlags,
 }
 
 
-string cISDataMappings::DidToString(int did, uint8_t* dataPtr, std::string fields)
+bool cISDataMappings::DidToString(int did, const uint8_t* dataPtr, string &output, std::string fields)
 {
     std::ostringstream oss, ossHdr;
     const map_name_to_info_t& dataSetMap = *NameToInfoMap(did);
@@ -2094,10 +2094,11 @@ string cISDataMappings::DidToString(int did, uint8_t* dataPtr, std::string field
     if (!oss.str().empty())
     {
         ossHdr << DataName(did) << " (" << did << ")" << std::endl;
-        return ossHdr.str() + oss.str();
+        output = ossHdr.str() + oss.str();
+        return true;
     }
 
-    return "";
+    return false;
 }
 
 

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -20,6 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <sstream>
 
 #include "ISDataMappings.h"
 #include "DataJSON.h"

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1987,7 +1987,7 @@ bool cISDataMappings::VariableToString(eDataType dataType, eDataFlags dataFlags,
 }
 
 
-bool cISDataMappings::DidToString(int did, const uint8_t* dataPtr, string &output, std::string fields)
+bool cISDataMappings::DidBufferToString(int did, const uint8_t* dataPtr, string &output, std::string fields)
 {
     std::ostringstream oss, ossHdr;
     const map_name_to_info_t& dataSetMap = *NameToInfoMap(did);
@@ -2102,7 +2102,7 @@ bool cISDataMappings::DidToString(int did, const uint8_t* dataPtr, string &outpu
 }
 
 
-bool cISDataMappings::StringToDid(int did, const std::string& fields, uint8_t* dataPtr)
+bool cISDataMappings::StringToDidBuffer(int did, const std::string& fields, uint8_t* dataPtr)
 {
     const map_name_to_info_t& dataSetMap = *NameToInfoMap(did);
     if (!dataPtr || dataSetMap.empty())

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1556,7 +1556,7 @@ const char* cISDataMappings::DataName(uint32_t did)
 
 uint32_t cISDataMappings::Did(string s)
 {
-    // Try to use DID number
+    // Try to use DID numbers
     uint32_t did = strtol(s.c_str(), NULL, 10);
 
     if (did <= DID_NULL || did >= DID_COUNT)

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vector>
 #include <map>
 #include <inttypes.h>
+#include <yaml-cpp/yaml.h>
 #include "com_manager.h"
 
 #include <type_traits>
@@ -606,6 +607,12 @@ public:
 	 * @return true if successful, false if error
 	 */
 	static bool DidBufferToString(int did, const uint8_t* dataPtr, std::string &output, std::string fields="");
+
+	// static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node &output, const YAML::Node fields = YAML::Node());
+	static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& output);
+	static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& output, const YAML::Node& filter);
+
+	static bool YamlToData(int did, const YAML::Node& yaml, uint8_t* dataPtr);
 
 	/**
 	* Convert a string representation to a did data set buffer

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -492,11 +492,19 @@ public:
 	static const char* DataName(uint32_t did);
 
 	/**
-	* Get a data set id from name
-	* @param did the data id to get a data set name from
-	* @return data set name or NULL if not found
+	* Get a data set id from a numeric or alphabetic string (i.e. "DID_INS_1" or "4")
+	* @param string the string to convert to a data id
+	* @return data set ID or NULL if not found
 	*/
-	static uint32_t Did(std::string name);
+	static uint32_t Did(std::string string);
+
+	/**
+	 * @brief Convert a name to a data set id
+	 * 
+	 * @param name the name to convert
+	* @return data set ID or NULL if not found
+	 */
+	static uint32_t NameToDid(std::string name);
 
 	/**
 	* Get the size of a given data id
@@ -594,6 +602,18 @@ public:
 	* @return true if success, false if error
 	*/
 	static bool VariableToString(eDataType dataType, eDataFlags dataFlags, const uint8_t* dataBuffer, uint32_t dataSize, data_mapping_string_t stringBuffer, double conversion = 1.0, bool json = false);
+
+	/**
+	 * @brief Convert a data set to a string representation
+	 * @param did the data ID
+	 * @param dataPtr pointer to the data buffer
+	 * @param fieldName optional field name print only one field
+	 * @return std::string the string representation of the data set
+	 */
+	static std::string DidToString(int did, uint8_t* dataPtr, std::string fields);
+	static bool StringToDid(int did, const std::string& fields, uint8_t* dataPtr);
+
+	static int ExtractArrayIndex(const std::string &str);
 
 	/**
 	* Get a timestamp from data if available

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -598,15 +598,24 @@ public:
 
 	/**
 	 * @brief Convert a data set to a string representation
+	 * 
 	 * @param did the data ID
 	 * @param dataPtr pointer to the data buffer
-	 * @param fieldName optional field name print only one field
-	 * @return std::string the string representation of the data set
+	 * @param output the string representation of the data set
+	 * @param fields optional fields to include in the output
+	 * @return true if successful, false if error
 	 */
-	static std::string DidToString(int did, uint8_t* dataPtr, std::string fields);
-	static bool StringToDid(int did, const std::string& fields, uint8_t* dataPtr);
+	static bool DidToString(int did, const uint8_t* dataPtr, std::string &output, std::string fields);
 
-	static int ExtractArrayIndex(std::string &str);
+	/**
+	* Convert a data set to a string representation
+	* @param did the data ID
+	* @param dataPtr pointer to the data buffer
+	* @param output the string representation of the data set
+	* @param fields optional fields to include in the output
+	* @return true if successful, false if error
+	*/
+	static bool StringToDid(int did, const std::string& fields, uint8_t* dataPtr);
 
 	/**
 	* Get a timestamp from data if available
@@ -635,6 +644,8 @@ public:
 	static const uint8_t* FieldData(const data_info_t& info, uint32_t arrayIndex, const p_data_hdr_t* hdr, const uint8_t* buf);
 
 protected:
+	static int ExtractArrayIndex(std::string &str);
+
 	static const char* const m_dataIdNames[];
 
 	data_set_t m_data_set[DID_COUNT];

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -606,7 +606,7 @@ public:
 	static std::string DidToString(int did, uint8_t* dataPtr, std::string fields);
 	static bool StringToDid(int did, const std::string& fields, uint8_t* dataPtr);
 
-	static int ExtractArrayIndex(const std::string &str);
+	static int ExtractArrayIndex(std::string &str);
 
 	/**
 	* Get a timestamp from data if available

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -478,6 +478,14 @@ public:
 
 	virtual ~cISDataMappings() {}
 
+	struct MemoryUsage
+	{
+		uint8_t* ptr;
+		size_t size;
+
+		uint8_t* end() const { return ptr + size; }
+	};
+
 	/**
 	* Get a data set name from an id
 	* @param did the data id to get a data set name from
@@ -612,7 +620,7 @@ public:
 	static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& output);
 	static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& output, const YAML::Node& filter);
 
-	static bool YamlToData(int did, const YAML::Node& yaml, uint8_t* dataPtr);
+	static bool YamlToData(int did, const YAML::Node& yaml, uint8_t* dataPtr, std::vector<MemoryUsage>* usageVec = nullptr);
 
 	/**
 	* Convert a string representation to a did data set buffer
@@ -649,7 +657,10 @@ public:
 	*/
 	static const uint8_t* FieldData(const data_info_t& info, uint32_t arrayIndex, const p_data_hdr_t* hdr, const uint8_t* buf);
 
+	static void AppendMemoryUsage(std::vector<MemoryUsage>& usageVec, void* newPtr, size_t newSize);
+
 protected:
+
 	static int ExtractArrayIndex(std::string &str);
 
 	static const char* const m_dataIdNames[];

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -597,25 +597,24 @@ public:
 	static bool VariableToString(eDataType dataType, eDataFlags dataFlags, const uint8_t* dataBuffer, uint32_t dataSize, data_mapping_string_t stringBuffer, double conversion = 1.0, bool json = false);
 
 	/**
-	 * @brief Convert a data set to a string representation
-	 * 
+	 * @brief Convert a did data set buffer to a string representation
+	 *
 	 * @param did the data ID
-	 * @param dataPtr pointer to the data buffer
+	 * @param dataPtr pointer to the did buffer
 	 * @param output the string representation of the data set
 	 * @param fields optional fields to include in the output
 	 * @return true if successful, false if error
 	 */
-	static bool DidToString(int did, const uint8_t* dataPtr, std::string &output, std::string fields);
+	static bool DidBufferToString(int did, const uint8_t* dataPtr, std::string &output, std::string fields="");
 
 	/**
-	* Convert a data set to a string representation
+	* Convert a string representation to a did data set buffer
 	* @param did the data ID
-	* @param dataPtr pointer to the data buffer
-	* @param output the string representation of the data set
 	* @param fields optional fields to include in the output
+	* @param dataPtr pointer to the did buffer
 	* @return true if successful, false if error
 	*/
-	static bool StringToDid(int did, const std::string& fields, uint8_t* dataPtr);
+	static bool StringToDidBuffer(int did, const std::string& fields, uint8_t* dataPtr);
 
 	/**
 	* Get a timestamp from data if available

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -605,6 +605,25 @@ public:
 	*/
 	static bool VariableToString(eDataType dataType, eDataFlags dataFlags, const uint8_t* dataBuffer, uint32_t dataSize, data_mapping_string_t stringBuffer, double conversion = 1.0, bool json = false);
 
+	/*** Convert a did data set buffer to a YAML node
+	* @param did the data ID
+	* @param dataPtr pointer to the did buffer
+	* @param output the YAML node representation of the data set
+	* @param filter optional filter to apply to the output
+	* @return true if successful, false if error
+	*/
+	static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& output);
+	static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& output, const YAML::Node& filter);
+
+	/*** Convert a YAML node to a did data set buffer
+	* @param did the data ID
+	* @param yaml the YAML node to convert
+	* @param dataPtr pointer to the did buffer
+	* @param usageVec optional vector to hold memory usage information
+	* @return true if successful, false if error
+	*/
+	static bool YamlToData(int did, const YAML::Node& yaml, uint8_t* dataPtr, std::vector<MemoryUsage>* usageVec = nullptr);
+
 	/**
 	 * @brief Convert a did data set buffer to a string representation
 	 *
@@ -615,12 +634,6 @@ public:
 	 * @return true if successful, false if error
 	 */
 	static bool DidBufferToString(int did, const uint8_t* dataPtr, std::string &output, std::string fields="");
-
-	// static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node &output, const YAML::Node fields = YAML::Node());
-	static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& output);
-	static bool DataToYaml(int did, const uint8_t* dataPtr, YAML::Node& output, const YAML::Node& filter);
-
-	static bool YamlToData(int did, const YAML::Node& yaml, uint8_t* dataPtr, std::vector<MemoryUsage>* usageVec = nullptr);
 
 	/**
 	* Convert a string representation to a did data set buffer

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -236,10 +236,13 @@ string cInertialSenseDisplay::Hello()
 
 string cInertialSenseDisplay::Connected()
 {
-	if (!m_outputOnceDid.empty())
-	{	// Don't print connected message if outputOnceDid is set
-		return "";
-	}
+	// Apply this breaking change in Develop and document in change_log.md
+	// Uncomment this to prevent printing "Connected" message when outputOnceDid is set.  
+	// You also need to remove " << endl" from all instances of "cout << Connected() << endl;"
+	// if (!m_outputOnceDid.empty())
+	// {	// Don't print connected message if outputOnceDid is set
+	// 	return "";
+	// }
 
 	if (m_startMs==0)
 	{	// Initialize start time
@@ -275,7 +278,7 @@ string cInertialSenseDisplay::Connected()
 		}
 		stream << " (" << bytesPerS << " bytes/s)";
 	}
-	stream << "     " << endl << endl;
+	stream << "     " << endl;
 
 	return stream.str();
 }
@@ -571,7 +574,7 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 		if (m_enableReplay)
 			cout << Replay(m_replaySpeedX) << endl;
 		else
-			cout << Connected();
+			cout << Connected() << endl;
 
 		cout << VectorToString();
 		return true;
@@ -581,7 +584,7 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 		if (m_enableReplay)
 			cout << Replay(m_replaySpeedX) << endl;
 		else
-			cout << Connected();
+			cout << Connected() << endl;
 
 		// Generic column format
 		cout << DatasetToString(&m_editData.pData);
@@ -589,7 +592,7 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 
 	case DMODE_STATS:
 		Home();
-		cout << Connected();
+		cout << Connected() << endl;
 		PrintStats();
 		return true;
 

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -559,7 +559,8 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 	switch (m_displayMode)
 	{
 	default:	// Do not display
-		// fall through
+		break;
+
 	case DMODE_PRETTY:
 		Home();
 		if (m_enableReplay)

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -535,10 +535,10 @@ void cInertialSenseDisplay::ProcessData(p_data_t* data, bool enableReplay, doubl
 	}
 
     // if we are doing a onceDid for any other display type, and we got it, shutdown normally, ASAP, but not immediately...
-    if (m_outputOnceDid == data->hdr.id)
-    {
-        SetExitProgram();
-    }
+	if (std::find(m_outputOnceDid.begin(), m_outputOnceDid.end(), data->hdr.id) != m_outputOnceDid.end())
+	{
+		SetExitProgram();
+	}
 }
 
 // Print data to standard out at the following refresh rate.  Return true to refresh display.

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -236,6 +236,11 @@ string cInertialSenseDisplay::Hello()
 
 string cInertialSenseDisplay::Connected()
 {
+	if (!m_outputOnceDid.empty())
+	{	// Don't print connected message if outputOnceDid is set
+		return "";
+	}
+
 	if (m_startMs==0)
 	{	// Initialize start time
 		m_startMs = current_timeMs();
@@ -270,7 +275,7 @@ string cInertialSenseDisplay::Connected()
 		}
 		stream << " (" << bytesPerS << " bytes/s)";
 	}
-	stream << "     " << endl;
+	stream << "     " << endl << endl;
 
 	return stream.str();
 }
@@ -566,7 +571,7 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 		if (m_enableReplay)
 			cout << Replay(m_replaySpeedX) << endl;
 		else
-			cout << Connected() << endl;
+			cout << Connected();
 
 		cout << VectorToString();
 		return true;
@@ -576,7 +581,7 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 		if (m_enableReplay)
 			cout << Replay(m_replaySpeedX) << endl;
 		else
-			cout << Connected() << endl;
+			cout << Connected();
 
 		// Generic column format
 		cout << DatasetToString(&m_editData.pData);
@@ -584,7 +589,7 @@ bool cInertialSenseDisplay::PrintData(unsigned int refreshPeriodMs)
 
 	case DMODE_STATS:
 		Home();
-		cout << Connected() << endl;
+		cout << Connected();
 		PrintStats();
 		return true;
 

--- a/src/ISDisplay.h
+++ b/src/ISDisplay.h
@@ -144,7 +144,10 @@ public:
 	void StopEditing();
 	bool UploadNeeded() { bool uploadNeeded = m_editData.uploadNeeded; m_editData.uploadNeeded = false; return uploadNeeded; };
 	edit_data_t *EditData() { return &m_editData; }
-	void setOutputOnceDid(int did) { m_outputOnceDid = did; m_interactiveMode = m_outputOnceDid == 0; }
+	void setOutputOnceDid(std::vector<uint32_t> did) 
+	{ 
+		m_outputOnceDid = did; m_interactiveMode = did.empty(); 
+	}
 	void SetSerialPort(serial_port_t* port) { m_port = port; }
 	void SetCommInstance(is_comm_instance_t* comm) { m_comm = comm; }
 
@@ -163,7 +166,7 @@ private:
 	double m_replaySpeedX = 1.0;
 
 	edit_data_t m_editData = {};
-	uint32_t m_outputOnceDid = 0;			// Set to DID to display then exit cltool.  0 = disabled
+	std::vector<uint32_t> m_outputOnceDid = {};			// Set to DID to display then exit cltool.  0 = disabled
 	bool m_interactiveMode = true;
     bool m_showRawHex = false;
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1056,7 +1056,7 @@ bool InertialSense::SetGpxFlashConfig(gpx_flash_cfg_t &flashCfg, int pHandle)
         return 0;
     }
     ISDevice& device = m_comManagerState.devices[pHandle];
-
+    
     // Iterate over and upload flash config in 4 byte segments.  Upload only contiguous segments of mismatched data starting at `key` (i = 2).  Don't upload size or checksum.
     static_assert(sizeof(gpx_flash_cfg_t) % 4 == 0, "Size of gpx_flash_cfg_t must be a 4 bytes in size!!!");
     uint32_t *newCfg = (uint32_t*)&flashCfg;
@@ -1092,14 +1092,13 @@ bool InertialSense::SetGpxFlashConfig(gpx_flash_cfg_t &flashCfg, int pHandle)
     if (device.gpxFlashCfgUploadTimeMs)
     {
         device.gpxFlashCfgUploadChecksum = flashCfg.checksum;
-
-        // Update local copy of flash config
-        device.gpxFlashCfg = flashCfg;
-
-        return true;
     }
 
-    return false;
+    // Update local copy of flash config
+    device.gpxFlashCfg = flashCfg;
+
+    // Success
+    return !failure;
 }
 
 bool InertialSense::WaitForImxFlashCfgSynced(int pHandle)

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -367,15 +367,6 @@ public:
     bool SetImxFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle = 0);
     bool SetGpxFlashConfig(gpx_flash_cfg_t &flashCfg, int pHandle = 0);
 
-    // Send only the modified portion of the data set.  Iterate over and upload flash config in 4 byte segments.  Upload only contiguous segments of mismatched data starting at `key` (i = 2).  Don't upload size or checksum.
-    static bool SendDataSetChange(void *newData, void *curData, void *newData2, void *curData2, int did, int size, int pHandle = 0);
-    template <typename T>
-    static bool SendDataSetChangeTemplate(T* newData, T* curData, T* newData2, T* curData2, int did, int pHandle = 0)
-    {
-        static_assert(sizeof(T) % 4 == 0, "Struct must be a multiple of 4 bytes.");
-        return SendDataSetChange(newData, curData, newData2, curData2, did, sizeof(T), pHandle);
-    }
-
     /**
      * @brief Blocking wait calling Update() and SLEEP(10ms) until the flash config has been synchronized. 
      * 

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -364,6 +364,7 @@ public:
     * @param pHandle the pHandle to set flash config for
     * @return true if success
     */
+    bool UploadFlashConfigDiff(int pHandle, uint8_t* newData, uint8_t* curData, size_t sizeBytes, uint32_t did, uint32_t& uploadTimeMsOut, uint32_t& checksumOut);
     bool SetImxFlashConfig(nvm_flash_cfg_t &flashCfg, int pHandle = 0);
     bool SetGpxFlashConfig(gpx_flash_cfg_t &flashCfg, int pHandle = 0);
 

--- a/src/com_manager.c
+++ b/src/com_manager.c
@@ -920,19 +920,21 @@ int sendDataPacket(com_manager_t* cm, int port, packet_t* pkt)
 
 void sendAck(com_manager_t* cmInstance, int pHandle, packet_t *pkt, uint8_t pTypeFlags)
 {
-    int ackSize;
-
     // Create and Send request packet
     p_ack_t ack = { 0 };
-    ack.hdr.pktInfo = pkt->hdr.flags;
-    ackSize = sizeof(p_ack_hdr_t);
+    ack.hdr.pktInfo.flags = pkt->hdr.flags;
+    ack.hdr.pktInfo.id = pkt->hdr.id;
 
     // Set ack body
     switch (pkt->hdr.flags & PKT_TYPE_MASK)
     {
     case PKT_TYPE_SET_DATA:
-        ack.body.dataHdr = *((p_data_hdr_t*)(pkt->data.ptr));
-        ackSize += sizeof(p_data_hdr_t);
+        ack.body.dataHdr.id = pkt->hdr.id;
+        ack.body.dataHdr.size = pkt->hdr.payloadSize;
+        if (pkt->hdr.flags & ISB_FLAGS_PAYLOAD_W_OFFSET)
+        {
+            ack.body.dataHdr.offset += pkt->offset; // add offset to size
+        }
         break;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 # Define the executable
 add_executable(${PROJECT_NAME} 
-    ${TESTS_SOURCES}
+    # ${TESTS_SOURCES}
     runtime/device_runtime_tests.cpp
 
     # test_ISLogger.cpp
@@ -42,7 +42,7 @@ add_executable(${PROJECT_NAME}
     # test_time_conversion.cpp    
     # test_runtime_tests.cpp
     # test_data_utils.cpp
-    # test_ISDataMappings.cpp
+    test_ISDataMappings.cpp
 )
 
 if(WIN32)   # Windows

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 # Define the executable
 add_executable(${PROJECT_NAME} 
-    # ${TESTS_SOURCES}
+    ${TESTS_SOURCES}
     runtime/device_runtime_tests.cpp
 
     # test_ISLogger.cpp
@@ -42,7 +42,7 @@ add_executable(${PROJECT_NAME}
     # test_time_conversion.cpp    
     # test_runtime_tests.cpp
     # test_data_utils.cpp
-    test_ISDataMappings.cpp
+    # test_ISDataMappings.cpp
 )
 
 if(WIN32)   # Windows

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,8 @@ file(GLOB TESTS_SOURCES "${CMAKE_CURRENT_LIST_DIR}/test_*.cpp")
 list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_com_manager_2.cpp")
 if(WIN32)   # These do not run in Windows
     list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_time_conversion.cpp")
+    # yamlcpp needs to know it's a static lib
+    add_definitions(-DYAML_CPP_STATIC_DEFINE)
 endif()
 
 # Define the executable

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 # Define the executable
 add_executable(${PROJECT_NAME} 
-    ${TESTS_SOURCES}
+    # ${TESTS_SOURCES}
     runtime/device_runtime_tests.cpp
 
     # test_ISLogger.cpp
@@ -42,6 +42,7 @@ add_executable(${PROJECT_NAME}
     # test_time_conversion.cpp    
     # test_runtime_tests.cpp
     # test_data_utils.cpp
+    test_ISDataMappings.cpp
 )
 
 if(WIN32)   # Windows

--- a/tests/test_ISDataMappings.cpp
+++ b/tests/test_ISDataMappings.cpp
@@ -64,3 +64,83 @@ TEST(ISDataMappings, StringToDataToString)
 	}
 }
 
+void testDataToYamlToData(const uDatasets& d1, uint32_t did, size_t size)
+{
+	// Run the conversion from data to YAML and back to data twice to ensure small rounding does not affect the result.
+	YAML::Node yaml1 = YAML::Node();
+	EXPECT_TRUE(cISDataMappings::DataToYaml(did, (uint8_t*)&d1, yaml1));
+	uDatasets d2 = {};
+	EXPECT_TRUE(cISDataMappings::YamlToData(did, yaml1, (uint8_t*)&d2));
+	YAML::Node yaml2 = YAML::Node();
+	EXPECT_TRUE(cISDataMappings::DataToYaml(did, (uint8_t*)&d2, yaml2));
+	uDatasets result = {};
+	EXPECT_TRUE(cISDataMappings::YamlToData(did, yaml2, (uint8_t*)&result));
+
+	EXPECT_EQ(0, memcmp(&d2, &result, size));
+}
+
+TEST(ISDataMappings, DataToYamlToData)
+{
+	uDatasets d = {};
+
+	d.ins1.timeOfWeek = 123456.789;
+	d.ins1.lla[0] = 37.7749; // Latitude
+	d.ins1.lla[1] = -122.4194; // Longitude
+	d.ins1.lla[2] = 30.0; // Height above ellipsoid
+	d.ins1.uvw[0] = 1.0; // U velocity
+	d.ins1.uvw[1] = 2.0; // V velocity
+	d.ins1.uvw[2] = 3.0; // W velocity
+	d.ins1.theta[0] = 0.1; // Roll
+	d.ins1.theta[1] = 0.2; // Pitch
+	d.ins1.theta[2] = 0.3; // Yaw
+	d.ins1.week = 1234; // GPS week
+	d.ins1.insStatus = 0x01020304; // INS status flags
+	d.ins1.hdwStatus = 0x05060708; // Hardware status flags
+	testDataToYamlToData(d, DID_INS_1, sizeof(ins_1_t));
+
+	d.sysParams.navOutputPeriodMs = 100; // Navigation output period in milliseconds
+	d.sysParams.insStatus = 0x01020304; // INS status flags
+	d.sysParams.hdwStatus = 0x05060708; // Hardware status flags
+	d.sysParams.imuTemp = 25.0f; // IMU temperature in degrees
+	d.sysParams.baroTemp = 20.0f; // Barometer temperature in degrees
+	d.sysParams.mcuTemp = 30.0f; // MCU temperature in degrees
+	d.sysParams.sysStatus = 0x090A0B0C; // System status
+	d.sysParams.imuSamplePeriodMs = 50; // IMU sample period in milliseconds
+	d.sysParams.navOutputPeriodMs = 100; // Navigation output period in milliseconds
+	d.sysParams.sensorTruePeriod = 0.001; // Sensor true period in seconds
+	d.sysParams.flashCfgChecksum = 0x12345678; // Flash config checksum
+	d.sysParams.navUpdatePeriodMs = 200; // Navigation update period in milliseconds
+	d.sysParams.genFaultCode = 0x0F0E0D0C; // General fault code
+	d.sysParams.upTime = 3600.0; // System up time in seconds
+	testDataToYamlToData(d, DID_SYS_PARAMS, sizeof(sys_params_t));
+
+	d.flashCfg.startupImuDtMs = 100;
+	d.flashCfg.startupNavDtMs = 200;
+	d.flashCfg.ser0BaudRate = 115200;
+	d.flashCfg.ser1BaudRate = 230400;
+	d.flashCfg.insRotation[0] = 0.01f; // Rotation about X
+	d.flashCfg.insRotation[1] = 0.02f; // Rotation about Y
+	d.flashCfg.insRotation[2] = 0.03f; // Rotation about Z
+	d.flashCfg.insOffset[0] = 0.1f; // X offset
+	d.flashCfg.insOffset[1] = 0.2f; // Y offset
+	d.flashCfg.insOffset[2] = 0.3f; // Z offset
+	d.flashCfg.gps1AntOffset[0] = 0.01f; // X antenna offset
+	d.flashCfg.gps1AntOffset[1] = 0.02f; // Y antenna offset
+	d.flashCfg.gps1AntOffset[2] = 0.03f; // Z antenna offset
+	d.flashCfg.dynamicModel = 4; // Ground vehicle
+	d.flashCfg.debug = 1; // Debug enabled
+	d.flashCfg.gnssSatSigConst = 0x0003; // GPS constellation
+	d.flashCfg.sysCfgBits = 0x00000001; // System configuration bits
+	d.flashCfg.refLla[0] = 37.7749; // Reference latitude
+	d.flashCfg.refLla[1] = -122.4194; // Reference longitude
+	d.flashCfg.refLla[2] = 30.0; // Reference height above ellipsoid
+	d.flashCfg.lastLla[0] = 37.7749; // Last latitude
+	d.flashCfg.lastLla[1] = -122.4194; // Last longitude
+	d.flashCfg.lastLla[2] = 30.0; // Last height above ellipsoid
+	d.flashCfg.lastLlaTimeOfWeekMs = 123456; // Last LLA time of week in milliseconds
+	d.flashCfg.lastLlaWeek = 123; // Last LLA GPS week
+	d.flashCfg.lastLlaUpdateDistance = 100.0f; // Last LLA update distance
+	d.flashCfg.ioConfig = 0x00000001; // IO configuration bits
+	d.flashCfg.platformConfig = 0x00000002; // Platform configuration bits
+	testDataToYamlToData(d, DID_FLASH_CONFIG, sizeof(nvm_flash_cfg_t));
+}

--- a/tests/test_ISDataMappings.cpp
+++ b/tests/test_ISDataMappings.cpp
@@ -71,7 +71,7 @@ void PrintYamlNode(const YAML::Node& node)
 }
 
 
-void testDataToYamlToData(const uDatasets& d1, uint32_t did, size_t size)
+void testDataToYamlToData(const uDatasets& d1, uint32_t did)
 {
 	// Run the conversion from data to YAML and back to data twice to ensure small rounding does not affect the result.
 	YAML::Node yaml1 = YAML::Node();
@@ -85,13 +85,11 @@ void testDataToYamlToData(const uDatasets& d1, uint32_t did, size_t size)
 
 	// PrintYamlNode(yaml1);
 
-	EXPECT_EQ(0, memcmp(&d2, &result, size));
+	EXPECT_EQ(0, memcmp(&d2, &result, cISDataMappings::DataSize(did)));
 }
 
 TEST(ISDataMappings, DataToYamlToData)
 {
-	return;
-
 	uDatasets d = {};
 
 	d.ins1.timeOfWeek = 123456.789;
@@ -107,7 +105,7 @@ TEST(ISDataMappings, DataToYamlToData)
 	d.ins1.week = 1234; // GPS week
 	d.ins1.insStatus = 0x01020304; // INS status flags
 	d.ins1.hdwStatus = 0x05060708; // Hardware status flags
-	testDataToYamlToData(d, DID_INS_1, sizeof(ins_1_t));
+	testDataToYamlToData(d, DID_INS_1);
 
 	d.sysParams.navOutputPeriodMs = 100; // Navigation output period in milliseconds
 	d.sysParams.insStatus = 0x01020304; // INS status flags
@@ -123,7 +121,7 @@ TEST(ISDataMappings, DataToYamlToData)
 	d.sysParams.navUpdatePeriodMs = 200; // Navigation update period in milliseconds
 	d.sysParams.genFaultCode = 0x0F0E0D0C; // General fault code
 	d.sysParams.upTime = 3600.0; // System up time in seconds
-	testDataToYamlToData(d, DID_SYS_PARAMS, sizeof(sys_params_t));
+	testDataToYamlToData(d, DID_SYS_PARAMS);
 
 	d.flashCfg.startupImuDtMs = 100;
 	d.flashCfg.startupNavDtMs = 200;
@@ -153,7 +151,7 @@ TEST(ISDataMappings, DataToYamlToData)
 	d.flashCfg.lastLlaUpdateDistance = 100.0f; // Last LLA update distance
 	d.flashCfg.ioConfig = 0x00000001; // IO configuration bits
 	d.flashCfg.platformConfig = 0x00000002; // Platform configuration bits
-	testDataToYamlToData(d, DID_FLASH_CONFIG, sizeof(nvm_flash_cfg_t));
+	testDataToYamlToData(d, DID_FLASH_CONFIG);
 }
 
 
@@ -255,4 +253,84 @@ TEST(ISDataMappings, YamlToDataMemoryUsage)
 	// Group 3:
 	EXPECT_EQ(usageVec[2].ptr, reinterpret_cast<uint8_t*>(&d.sysParams.navUpdatePeriodMs));
 	EXPECT_EQ(usageVec[2].size, sizeof(d.sysParams.navUpdatePeriodMs) + sizeof(d.sysParams.genFaultCode));
+}
+
+void testDidBufToStringToDidBuf(const uDatasets& d1, uint32_t did)
+{
+	std::string str1;
+	EXPECT_TRUE(cISDataMappings::DidBufferToString(did, (uint8_t*)&d1, str1));
+	uDatasets d2 = {};
+	EXPECT_TRUE(cISDataMappings::StringToDidBuffer(did, str1, (uint8_t*)&d2));
+	std::string str2;
+	EXPECT_TRUE(cISDataMappings::DidBufferToString(did, (uint8_t*)&d2, str2));
+	uDatasets result = {};
+	EXPECT_TRUE(cISDataMappings::StringToDidBuffer(did, str2, (uint8_t*)&result));
+
+	EXPECT_EQ(0, memcmp(&d2, &result, cISDataMappings::DataSize(did)));
+}
+
+TEST(ISDataMappings, DidBufferToStringToDidBuffer)
+{
+	uDatasets d = {};
+
+	d.ins1.timeOfWeek = 123456.789;
+	d.ins1.lla[0] = 37.7749; // Latitude
+	d.ins1.lla[1] = -122.4194; // Longitude
+	d.ins1.lla[2] = 30.0; // Height above ellipsoid
+	d.ins1.uvw[0] = 1.0; // U velocity
+	d.ins1.uvw[1] = 2.0; // V velocity
+	d.ins1.uvw[2] = 3.0; // W velocity
+	d.ins1.theta[0] = 0.1; // Roll
+	d.ins1.theta[1] = 0.2; // Pitch
+	d.ins1.theta[2] = 0.3; // Yaw
+	d.ins1.week = 1234; // GPS week
+	d.ins1.insStatus = 0x01020304; // INS status flags
+	d.ins1.hdwStatus = 0x05060708; // Hardware status flags
+	testDidBufToStringToDidBuf(d, DID_INS_1);
+
+	d.sysParams.navOutputPeriodMs = 100; // Navigation output period in milliseconds
+	d.sysParams.insStatus = 0x01020304; // INS status flags
+	d.sysParams.hdwStatus = 0x05060708; // Hardware status flags
+	d.sysParams.imuTemp = 25.0f; // IMU temperature in degrees
+	d.sysParams.baroTemp = 20.0f; // Barometer temperature in degrees
+	d.sysParams.mcuTemp = 30.0f; // MCU temperature in degrees
+	d.sysParams.sysStatus = 0x090A0B0C; // System status
+	d.sysParams.imuSamplePeriodMs = 50; // IMU sample period in milliseconds
+	d.sysParams.navOutputPeriodMs = 100; // Navigation output period in milliseconds
+	d.sysParams.sensorTruePeriod = 0.001; // Sensor true period in seconds
+	d.sysParams.flashCfgChecksum = 0x12345678; // Flash config checksum
+	d.sysParams.navUpdatePeriodMs = 200; // Navigation update period in milliseconds
+	d.sysParams.genFaultCode = 0x0F0E0D0C; // General fault code
+	d.sysParams.upTime = 3600.0; // System up time in seconds
+	testDidBufToStringToDidBuf(d, DID_SYS_PARAMS);
+
+	d.flashCfg.startupImuDtMs = 100;
+	d.flashCfg.startupNavDtMs = 200;
+	d.flashCfg.ser0BaudRate = 115200;
+	d.flashCfg.ser1BaudRate = 230400;
+	d.flashCfg.insRotation[0] = 0.01f; // Rotation about X
+	d.flashCfg.insRotation[1] = 0.02f; // Rotation about Y
+	d.flashCfg.insRotation[2] = 0.03f; // Rotation about Z
+	d.flashCfg.insOffset[0] = 0.1f; // X offset
+	d.flashCfg.insOffset[1] = 0.2f; // Y offset
+	d.flashCfg.insOffset[2] = 0.3f; // Z offset
+	d.flashCfg.gps1AntOffset[0] = 0.01f; // X antenna offset
+	d.flashCfg.gps1AntOffset[1] = 0.02f; // Y antenna offset
+	d.flashCfg.gps1AntOffset[2] = 0.03f; // Z antenna offset
+	d.flashCfg.dynamicModel = 4; // Ground vehicle
+	d.flashCfg.debug = 1; // Debug enabled
+	d.flashCfg.gnssSatSigConst = 0x0003; // GPS constellation
+	d.flashCfg.sysCfgBits = 0x00000001; // System configuration bits
+	d.flashCfg.refLla[0] = 37.7749; // Reference latitude
+	d.flashCfg.refLla[1] = -122.4194; // Reference longitude
+	d.flashCfg.refLla[2] = 30.0; // Reference height above ellipsoid
+	d.flashCfg.lastLla[0] = 37.7749; // Last latitude
+	d.flashCfg.lastLla[1] = -122.4194; // Last longitude
+	d.flashCfg.lastLla[2] = 30.0; // Last height above ellipsoid
+	d.flashCfg.lastLlaTimeOfWeekMs = 123456; // Last LLA time of week in milliseconds
+	d.flashCfg.lastLlaWeek = 123; // Last LLA GPS week
+	d.flashCfg.lastLlaUpdateDistance = 100.0f; // Last LLA update distance
+	d.flashCfg.ioConfig = 0x00000001; // IO configuration bits
+	d.flashCfg.platformConfig = 0x00000002; // Platform configuration bits
+	testDidBufToStringToDidBuf(d, DID_FLASH_CONFIG);
 }


### PR DESCRIPTION
- Created cltool options -get and -set which can read or write to any DID using single line yaml format.
- Fixed ISDataMapping representation of arrays within data sets.

This PR is for the revised version of the cltool -get and -set options to read/write to any DID.  This took way longer than it should have.  It uses single line YAML input which is clean enough.  Unfortunately it does require quotes for the entire section, but this is necessary to prevent parsing errors on some platforms.  [@Kyle Mallory](https://inertialsensegroup.slack.com/team/U03DDVBFKT5) I didn't implement automatic format detection for lack of time (we can consider that later).  The out YAML is compact enough (and I've run out of time) that I don't care to implement a feature for selecting different output formats.


$ ./cltool -c /dev/ttyACM2 -get "{DID_INS_1, DID_FLASH_CONFIG}"

```
DID_FLASH_CONFIG:
  checksum: 2039277512
  debug: 51
  dynamicModel: 0
  gnssCn0DynMinOffset: 20
  gnssCn0Minimum: 30
  gnssSatSigConst: 0x13FF
  gps1AntOffset: [0.1, 0.2, 0.30000001]
  gps2AntOffset: [0, 0, 0]
  gpsMinimumElevation: 10.0
  gpsTimeSyncPeriodMs: 1000
  gpsTimeUserDelay: 0.000
  imuRejectThreshGyroHigh: 3
  imuRejectThreshGyroLow: 2
  imuShockDeltaAccHighThreshold: 20
  imuShockDeltaAccLowThreshold: 3
  imuShockDeltaGyroHighThreshold: 120
  imuShockDeltaGyroLowThreshold: 12
  imuShockDetectLatencyMs: 10
  imuShockOptions: 0x02
  imuShockRejectLatchMs: 5
  insOffset: [1.2, 1.3, 1.4]
  insRotation: [0, 0, 0]
  ioConfig: 0x06DB2046
  ioConfig2: 0x00
  key: 36
  lastLla: [0.000000000, 0.000000000, 0.000000000]
  lastLlaTimeOfWeekMs: 0
  lastLlaUpdateDistance: 1000
  lastLlaWeek: 0
  magCalibrationQualityThreshold: 10
  magDeclination: 0.00
  magInterferenceThreshold: 3
  platformConfig: 0x00000090
  refLla: [0.000000000, 0.000000000, 0.000000000]
  RTKCfgBits: 0x00000000
  sensorConfig: 0x00000033
  ser0BaudRate: 921600
  ser1BaudRate: 921600
  ser2BaudRate: 921600
  size: 288
  startupGPSDtMs: 200
  startupImuDtMs: 1
  startupNavDtMs: 7
  sysCfgBits: 0x00000000
  wheelConfig.bits: 0x00000000
  wheelConfig.radius: 0
  wheelConfig.track_width: 0
  wheelConfig.transform.e_b2w: [0.00, 0.00, 0.00]
  wheelConfig.transform.e_b2w_sigma: [0.02, 0.02, 0.02]
  wheelConfig.transform.t_b2w: [0.000, 0.000, 0.000]
  wheelConfig.transform.t_b2w_sigma: [0.300, 0.300, 0.300]
  zeroVelOffset: [0, 0, 0]
  zeroVelRotation: [0, 0, 0]
DID_INS_1:
  hdwStatus: 0x03080050
  insStatus: 0x01445126
  lla: [40.055770162, -111.658582869, 1405.619554877]
  ned: [0.551, 1.142, -2.290]
  theta: [4.003, 3.589, 62.617]
  timeOfWeek: 300442.62504
  uvw: [0.067, -0.030, -0.161]
  week: 2375
```

```
$ ./cltool -c /dev/ttyACM2 -get "{4: {timeOfWeek,theta}, DID_FLASH_CONFIG: {ser1BaudRate,insOffset}}"

DID_FLASH_CONFIG:
  insOffset: [1.2, 1.3, 1.4]
  ser1BaudRate: 921600
DID_INS_1:
  theta: [2.893, 6.049, 56.327]
  timeOfWeek: 6145.77035
```

This example is cool because it shows how the SDK was smart about consolidating upload of only the parameters that were changed.

```
$ ./cltool -c /dev/ttyACM2 -set "{DID_FLASH_CONFIG: {sysCfgBits: 0x00000000, insOffset: [1.2, 1.3, 1.4], gps1AntOffset: [0.1, 0.2, 0.3], gnssSatSigConst: 0, debug: 23}, DID_SYS_PARAMS: {sysStatus: 0x00000004}}"

Uploading DID_FLASH_CONFIG, size: 7, offset: 65
Uploading DID_FLASH_CONFIG, size: 24, offset: 40
Uploading DID_SYS_PARAMS, size: 4, offset: 24
```