### PR TITLE
Rename IMX-5.0 to IMX-6

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1111,7 +1111,7 @@ static int inertialSenseMain()
     // if app firmware was specified on the command line, do that now and return
     else if ((g_commandLineOptions.updateFirmwareTarget == fwUpdate::TARGET_HOST) && (g_commandLineOptions.updateAppFirmwareFilename.length() != 0))
     {
-        // FIXME: {{ DEPRECATED }} -- This is the legacy update method (still required by the uINS3 and IMX-5, but will go away with the IMX-5.1)
+        // FIXME: {{ DEPRECATED }} -- This is the legacy update method (still required by the uINS3 and IMX-5, but will go away with the IMX-6)
         signal(SIGINT, sigint_cb);
         return cltool_updateFirmware();
     }

--- a/src/ISBootloaderBase.h
+++ b/src/ISBootloaderBase.h
@@ -51,7 +51,7 @@ typedef enum {
     IS_PROCESSOR_UNKNOWN = -1,
     IS_PROCESSOR_SAMx70 = 0,        // uINS-3/4, EVB-2
     IS_PROCESSOR_STM32L4,           // IMX-5
-    IS_PROCESSOR_STM32U5,           // GPX-1, IMX-5.1
+    IS_PROCESSOR_STM32U5,           // GPX-1, IMX-6
 
     IS_PROCESSOR_NUM,               // Must be last
 } eProcessorType;

--- a/src/ISBootloaderISB.cpp
+++ b/src/ISBootloaderISB.cpp
@@ -602,7 +602,7 @@ is_operation_result cISBootloaderISB::fill_current_page(int* currentPage, int* c
         while (*currentOffset < FLASH_PAGE_SIZE)
         {
             if (*currentPage == 7 && *currentOffset >= 36480)
-            {   // The last (7th) page of flash memory on the IMX-5.0 (STM32L4) is restricted to 36480 bytes.  We should fill beyond this point on the 7th page.
+            {   // The last (7th) page of flash memory on the IMX-5 (STM32L4) is restricted to 36480 bytes.  We should fill beyond this point on the 7th page.
                 break;
             }
 

--- a/src/ISBootloaderSTM32.cpp
+++ b/src/ISBootloaderSTM32.cpp
@@ -80,10 +80,10 @@ uint8_t cISBootloaderSTM32::check_is_compatible(uint32_t imgSign)
     {
     case 0x62: 
         m_info_callback(this, "Detected STM32L4 device", IS_LOG_LEVEL_DEBUG);
-        return IS_IMAGE_SIGN_STM_L4;   // STM32L452 (IMX-5.0)
+        return IS_IMAGE_SIGN_STM_L4;   // STM32L452 (IMX-5)
     case 0x82: 
         m_info_callback(this, "Detected STM32U5 device", IS_LOG_LEVEL_DEBUG);
-        return IS_IMAGE_SIGN_STM_U5;   // STM32U575/STM32U585 (GPX-1/IMX-5.1)
+        return IS_IMAGE_SIGN_STM_U5;   // STM32U575/STM32U585 (GPX-1/IMX-6)
     default: 
         m_info_callback(this, "No STM32 device detected", IS_LOG_LEVEL_DEBUG);
         return IS_IMAGE_SIGN_NONE;
@@ -154,7 +154,7 @@ is_operation_result cISBootloaderSTM32::download_image(void)
         // Check the address range
         switch(m_pid)
         {
-        case 0x62:      // STM32L452 (IMX-5.0)
+        case 0x62:      // STM32L452 (IMX-5)
             // TODO: Add support for other areas.
             if(image[i].address < 0x08000000 || (image[i].address + image[i].len) > 0x0807FFFF)
             {
@@ -162,7 +162,7 @@ is_operation_result cISBootloaderSTM32::download_image(void)
                 continue;
             }
             break;
-        case 0x82:      // STM32U575/STM32U585 (GPX-1/IMX-5.1)
+        case 0x82:      // STM32U575/STM32U585 (GPX-1/IMX-6)
             // TODO: Add support for other areas.
             if(image[i].address < 0x08000000 || (image[i].address + image[i].len) > 0x08200000)
             {

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -151,7 +151,7 @@ typedef enum
     IS_BAUDRATE_19200           = 19200,
     IS_BAUDRATE_38400           = 38400,
     IS_BAUDRATE_57600           = 57600,
-    IS_BAUDRATE_115200          = 115200,       //  IMX-5.0,  uINS-3,  Actual baudrates                                             
+    IS_BAUDRATE_115200          = 115200,       //  IMX-5,  uINS-3,  Actual baudrates                                             
     IS_BAUDRATE_230400          = 230400,       //   230547,  232700, 
     IS_BAUDRATE_460800          = 460800,       //   462428,  468600, 
     IS_BAUDRATE_921600          = 921600,       //   930233,  937734,

--- a/src/ISDFUFirmwareUpdater.cpp
+++ b/src/ISDFUFirmwareUpdater.cpp
@@ -159,7 +159,7 @@ namespace dfu {
 
         SLEEP_MS(100);
         // TODO make this IMX/GPX aware (OTP location maybe processor and/or product/device dependent)
-        // Its important to note that if this is a BRAND NEW, NEVER BEEN PROGRAMMED STM32, it will have no OTP data. Even if we know the MCU type, we still don't know the application its in (ie, IMX-5.1 vs GPX-1).
+        // Its important to note that if this is a BRAND NEW, NEVER BEEN PROGRAMMED STM32, it will have no OTP data. Even if we know the MCU type, we still don't know the application its in (ie, IMX-6 vs GPX-1).
 
         libusb_device *usb_device = libusb_get_device(usbHandle);
         if (libusb_get_device_descriptor(usb_device, &desc) != LIBUSB_SUCCESS) {
@@ -255,7 +255,7 @@ namespace dfu {
             md5_update(fingerprint, (uint8_t *) dfuDesc.c_str(), dfuDesc.size());
         }
 
-        // TODO: make this work for both GPX-1 and IMX-5.1
+        // TODO: make this work for both GPX-1 and IMX-6
         uint16_t hardwareType = 0;
         processorType = IS_PROCESSOR_UNKNOWN;
 
@@ -285,7 +285,7 @@ namespace dfu {
 
         if ((hardwareId == 0xFFFF) && (processorType != IS_PROCESSOR_UNKNOWN)) {
             if (processorType == IS_PROCESSOR_STM32L4) hardwareType = IS_HARDWARE_TYPE_IMX; // only the IMX-5 uses the STM32L4
-            else if (processorType == IS_PROCESSOR_STM32U5) hardwareType = IS_HARDWARE_TYPE_GPX; // TODO: Both the GPX-1 and IMX-5.1 will use the STM32U5 (at the moment)
+            else if (processorType == IS_PROCESSOR_STM32U5) hardwareType = IS_HARDWARE_TYPE_GPX; // TODO: Both the GPX-1 and IMX-6 will use the STM32U5 (at the moment)
         }
 
         // based on what we know so far, let's try and figure out a hardware type

--- a/src/ISDFUFirmwareUpdater.h
+++ b/src/ISDFUFirmwareUpdater.h
@@ -169,7 +169,7 @@ typedef enum {
     IS_PROCESSOR_UNKNOWN = -1,
     IS_PROCESSOR_SAMx70 = 0,        // uINS-3/4, EVB-2
     IS_PROCESSOR_STM32L4,           // IMX-5
-    IS_PROCESSOR_STM32U5,           // GPX-1, IMX-5.1
+    IS_PROCESSOR_STM32U5,           // GPX-1, IMX-6
 
     IS_PROCESSOR_NUM,               // Must be last
 } eProcessorType;

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -538,7 +538,7 @@ typedef struct PACKED
  *
  *  Upper 6 bits are the hardware type (IMX, GPX, uINS, etc; 64 possible values)
  *  Middle 4 bits are the major hardware version (GPX-1, uINS-3, IMX-5, etc; 16 possible values)
- *  Lower 6 bits are the minor hardware version (IMX-5.1, uINS-3.2, GPX-1.0; 64 possible values)
+ *  Lower 6 bits are the minor hardware version (IMX-6, uINS-3.2, GPX-1.0; 64 possible values)
  *
  *  If the TYPE and MAJOR are 0, then fall back to eIsHardwareType to determine the type from the legacy map:
  *      0 = Unknown


### PR DESCRIPTION
- Changed references from IMX-5.1 to IMX-6.0 (or IMX-6).
- Where appropriate, renamed IMX-5.0 to IMX-5.