### PR TITLE
SN-6866 cltool syscmd error

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -524,7 +524,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
         // Write key (uint32_t) and platformType (int32_t), 8 bytes
         inertialSenseInterface.SendRawData(DID_MANUFACTURING_INFO, (uint8_t*)&manfInfo.key, sizeof(uint32_t)*2, offsetof(manufacturing_info_t, key));
         SLEEP_MS(XMIT_CLOSE_DELAY_MS);      // Delay to allow transmit time before port closes
-        return false;
+        exitApp = true;
     }
     if (g_commandLineOptions.roverConnection.length() != 0)
     {

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -578,7 +578,7 @@ static void PopulateMapNvmFlashCfg(data_set_t data_set[DID_COUNT], uint32_t did)
     str = "rotation from INS Sensor Frame to Intermediate Output Frame.  Order applied: heading, pitch, roll.";
     mapper.AddArray("zeroVelRotation", &nvm_flash_cfg_t::zeroVelRotation, DATA_TYPE_F32, 3, {SYM_DEG}, {"Roll, pitch, yaw " + str}, 0, C_RAD2DEG);
     str = "offset from Intermediate Output Frame to INS Output Frame.  INS rotation is applied before this.";
-    mapper.AddArray("zeroVelOffset", &nvm_flash_cfg_t::zeroVelOffset, DATA_TYPE_F32, 3, {"m"}, {"X,Y,Z " + str}, 0, C_RAD2DEG);
+    mapper.AddArray("zeroVelOffset", &nvm_flash_cfg_t::zeroVelOffset, DATA_TYPE_F32, 3, {"m"}, {"X,Y,Z " + str}, 0);
     mapper.AddMember2("wheelConfig.bits", offsetof(nvm_flash_cfg_t, wheelConfig.bits), DATA_TYPE_UINT32, "", "Wheel encoder config bits: 0x1 enable encoders, 0x2 kinematic constraints", DATA_FLAGS_DISPLAY_HEX);
     mapper.AddArray2("wheelConfig.transform.e_b2w", offsetof(nvm_flash_cfg_t, wheelConfig.transform.e_b2w), DATA_TYPE_F32, 3, {"rad"}, {"Euler angles describing the rotation from imu (body) to the wheel frame (center of the non-steering axle)"}, DATA_FLAGS_FIXED_DECIMAL_2);
     mapper.AddArray2("wheelConfig.transform.e_b2w_sigma", offsetof(nvm_flash_cfg_t, wheelConfig.transform.e_b2w_sigma), DATA_TYPE_F32, 3, {"rad"}, {"Standard deviation of Euler angles describing the rotation from imu (body) to the wheel frame (center of the non-steering axle)"}, DATA_FLAGS_FIXED_DECIMAL_2);

--- a/tests/test_ISDataMappings.cpp
+++ b/tests/test_ISDataMappings.cpp
@@ -107,7 +107,6 @@ TEST(ISDataMappings, DataToYamlToData)
 	d.ins1.hdwStatus = 0x05060708; // Hardware status flags
 	testDataToYamlToData(d, DID_INS_1);
 
-	d.sysParams.navOutputPeriodMs = 100; // Navigation output period in milliseconds
 	d.sysParams.insStatus = 0x01020304; // INS status flags
 	d.sysParams.hdwStatus = 0x05060708; // Hardware status flags
 	d.sysParams.imuTemp = 25.0f; // IMU temperature in degrees
@@ -118,7 +117,7 @@ TEST(ISDataMappings, DataToYamlToData)
 	d.sysParams.navOutputPeriodMs = 100; // Navigation output period in milliseconds
 	d.sysParams.sensorTruePeriod = 0.001; // Sensor true period in seconds
 	d.sysParams.flashCfgChecksum = 0x12345678; // Flash config checksum
-	d.sysParams.navUpdatePeriodMs = 200; // Navigation update period in milliseconds
+	d.sysParams.navUpdatePeriodMs = 100; // Navigation update period in milliseconds
 	d.sysParams.genFaultCode = 0x0F0E0D0C; // General fault code
 	d.sysParams.upTime = 3600.0; // System up time in seconds
 	testDataToYamlToData(d, DID_SYS_PARAMS);


### PR DESCRIPTION
Fixed invalid message "Failed to setup communications!" in cltool when using -sysCmd.  Recent refactor to return error to the command line broke this.  The sysCmd as well setting the platformType would send correctly but cause this error to be reported. 