### PR TITLE
Flash cfg sync cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,11 +66,6 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 11)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-set_source_files_properties(
-    src/libusb/libusb/core.c
-    PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable"
-)
-
 # Other settings
 if (WIN32)
     # yamlcpp needs to know it's a static lib.
@@ -87,6 +82,11 @@ else ()
     # Linux specific include dir
     target_include_directories(${PROJECT_NAME} PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/src/libusb/linux
+    )
+
+    set_source_files_properties(
+        src/libusb/libusb/core.c
+        PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable"
     )
 
     # Linux compiler flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,11 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 11)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+set_source_files_properties(
+    src/libusb/libusb/core.c
+    PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable"
+)
+
 # Other settings
 if (WIN32)
     # yamlcpp needs to know it's a static lib.

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -828,6 +828,7 @@ void InertialSense::DeviceSyncFlashCfg(int devIndex, unsigned int timeMs, uint16
         if (timeMs - uploadTimeMs < SYNC_FLASH_CFG_CHECK_PERIOD_MS)
         {	// Wait for upload to process.  Pause sync.
             syncChecksum = 0xFFFFFFFF;      // invalidate checksum
+            return;
         }
     }
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1079,15 +1079,24 @@ bool InertialSense::SetGpxFlashConfig(gpx_flash_cfg_t &flashCfg, int pHandle)
     return success;
 }
 
-bool InertialSense::WaitForImxFlashCfgSynced(int pHandle)
+bool InertialSense::WaitForImxFlashCfgSynced(bool forceSync, uint32_t timeout, int pHandle)
 {
+    if (m_comManagerState.devices.size() == 0)
+    {   // No devices
+        return false;
+    }
+    ISDevice& device = m_comManagerState.devices[pHandle];
+
+    if (forceSync)
+        device.sysParams.flashCfgChecksum = 0xFFFFFFFF;    // Invalidate to force re-sync
+
     unsigned int startMs = current_timeMs();
     while(!ImxFlashConfigSynced(pHandle))
     {   // Request and wait for IMX flash config
         Update();
         SLEEP_MS(100);
 
-        if (current_timeMs() - startMs > 3000)
+        if (current_timeMs() - startMs > timeout)
         {   // Timeout waiting for IMX flash config
             printf("Timeout waiting for DID_FLASH_CONFIG failure!\n");
 
@@ -1110,15 +1119,24 @@ bool InertialSense::WaitForImxFlashCfgSynced(int pHandle)
     return ImxFlashConfigSynced(pHandle);
 }
 
-bool InertialSense::WaitForGpxFlashCfgSynced(int pHandle)
+bool InertialSense::WaitForGpxFlashCfgSynced(bool forceSync, uint32_t timeout, int pHandle)
 {
+    if (m_comManagerState.devices.size() == 0)
+    {   // No devices
+        return false;
+    }
+    ISDevice& device = m_comManagerState.devices[pHandle];
+
+    if (forceSync)
+        device.gpxStatus.flashCfgChecksum = 0xFFFFFFFF;    // Invalidate to force re-sync
+
     unsigned int startMs = current_timeMs();
     while(!GpxFlashConfigSynced(pHandle))
     {   // Request and wait for GPX flash config
         Update();
         SLEEP_MS(100);
 
-        if (current_timeMs() - startMs > 3000)
+        if (current_timeMs() - startMs > timeout)
         {   // Timeout waiting for GPX flash config
             printf("Timeout waiting for DID_GPX_FLASH_CONFIG failure!\n");
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -821,7 +821,7 @@ void InertialSense::CheckRequestFlashConfig(unsigned int timeMs, unsigned int &u
 }
 
 // Check if flash config is synchronized and if not request it from the device.
-void InertialSense::DeviceSyncFlashCfg(int devIndex, unsigned int timeMs, uint16_t flashCfgDid, unsigned int &uploadTimeMs, uint32_t &flashCfgChecksum, uint32_t &syncChecksum, uint32_t &uploadChecksum)
+void InertialSense::DeviceSyncFlashCfg(int devIndex, unsigned int timeMs, uint16_t flashCfgDid, uint16_t syncDid, unsigned int &uploadTimeMs, uint32_t &flashCfgChecksum, uint32_t &syncChecksum, uint32_t &uploadChecksum)
 {
     if (uploadTimeMs)
     {	// Upload in progress
@@ -856,6 +856,11 @@ void InertialSense::DeviceSyncFlashCfg(int devIndex, unsigned int timeMs, uint16
             comManagerGetData(devIndex, flashCfgDid, 0, 0, 0);
         }
     } 
+    else
+    {	// Out of sync.  Request sysParams or gpxStatus.
+        DEBUG_PRINT("Out of sync.  Requesting %s...\n", cISDataMappings::DataName(syncDid));
+        comManagerGetData(devIndex, syncDid, 0, 0, 0);
+    }
 }
 
 // This method uses DID_SYS_PARAMS.flashCfgChecksum to determine if the local flash config is synchronized.
@@ -871,19 +876,15 @@ void InertialSense::SyncFlashConfig(unsigned int timeMs)
     {
         ISDevice& device = m_comManagerState.devices[i];
 
-        if (device.devInfo.hardwareType == IS_HARDWARE_TYPE_IMX ||
-            device.sysParams.timeOfWeekMs || 
-            device.imxFlashCfg.checksum)
+        if (device.devInfo.hardwareType == IS_HARDWARE_TYPE_IMX)
         {   // Sync IMX flash config if a IMX present
-            DeviceSyncFlashCfg(i, timeMs, DID_FLASH_CONFIG,  device.imxFlashCfgUploadTimeMs, device.imxFlashCfg.checksum, device.sysParams.flashCfgChecksum, device.imxFlashCfgUploadChecksum);
+            DeviceSyncFlashCfg(i, timeMs, DID_FLASH_CONFIG,  DID_SYS_PARAMS, device.imxFlashCfgUploadTimeMs, device.imxFlashCfg.checksum, device.sysParams.flashCfgChecksum, device.imxFlashCfgUploadChecksum);
         }
 
         if (device.devInfo.hardwareType == IS_HARDWARE_TYPE_GPX ||
-            device.gpxDevInfo.hardwareType == IS_HARDWARE_TYPE_GPX ||
-            device.gpxStatus.timeOfWeekMs || 
-            device.gpxFlashCfg.checksum)
+            device.gpxDevInfo.hardwareType == IS_HARDWARE_TYPE_GPX)
         {   // Sync GPX flash config if a GPX present
-            DeviceSyncFlashCfg(i, timeMs, DID_GPX_FLASH_CFG, device.gpxFlashCfgUploadTimeMs, device.gpxFlashCfg.checksum, device.gpxStatus.flashCfgChecksum, device.gpxFlashCfgUploadChecksum);
+            DeviceSyncFlashCfg(i, timeMs, DID_GPX_FLASH_CFG, DID_GPX_STATUS, device.gpxFlashCfgUploadTimeMs, device.gpxFlashCfg.checksum, device.gpxStatus.flashCfgChecksum, device.gpxFlashCfgUploadChecksum);
         }
     }
 }

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -688,7 +688,7 @@ private:
 
     void CheckRequestFlashConfig(unsigned int timeMs, unsigned int &uploadTimeMs, bool synced, int port, uint16_t did);
     void SyncFlashConfig(unsigned int timeMs);
-    void DeviceSyncFlashCfg(int devIndex, unsigned int timeMs, uint16_t flashCfgDid, unsigned int &uploadTimeMs, uint32_t &flashCfgChecksum, uint32_t &syncChecksum, uint32_t &uploadChecksum);
+    void DeviceSyncFlashCfg(int devIndex, unsigned int timeMs, uint16_t flashCfgDid, uint16_t syncDid, unsigned int &uploadTimeMs, uint32_t &flashCfgChecksum, uint32_t &syncChecksum, uint32_t &uploadChecksum);
     bool UploadFlashConfigDiff(int pHandle, uint8_t* newData, uint8_t* curData, size_t sizeBytes, uint32_t did, uint32_t& uploadTimeMsOut, uint32_t& checksumOut);
     void UpdateFlashConfigChecksum(nvm_flash_cfg_t &flashCfg);
     bool ValidFlashCfgCksum(uint32_t checksum) { return (checksum != 0xFFFFFFFF); }

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -48,8 +48,6 @@ extern "C"
 #include "serialPortPlatform.h"
 }
 
-#define SYNC_FLASH_CFG_CHECK_PERIOD_MS      200
-
 class InertialSense;
 
 typedef std::function<void(InertialSense* i, p_data_t* data, int pHandle)> pfnHandleBinaryData;
@@ -407,8 +405,8 @@ public:
      * @param pHandle the port pHandle
      * @return false When failed to synchronize
      */
-    bool WaitForImxFlashCfgSynced(int pHandle = 0);
-    bool WaitForGpxFlashCfgSynced(int pHandle = 0);
+    bool WaitForImxFlashCfgSynced(bool forceSync = false, uint32_t timeout = SYNC_FLASH_CFG_TIMEOUT_MS, int pHandle = 0);
+    bool WaitForGpxFlashCfgSynced(bool forceSync = false, uint32_t timeout = SYNC_FLASH_CFG_TIMEOUT_MS, int pHandle = 0);
 
     void ProcessRxData(int pHandle, p_data_t* data);
     void ProcessRxNmea(int pHandle, const uint8_t* msg, int msgSize);
@@ -625,6 +623,9 @@ public:
     // Used for testing
     InertialSense::com_manager_cpp_state_t* ComManagerState() { return &m_comManagerState; }
     ISDevice* ComManagerDevice(int pHandle=0) { if (pHandle >= (int)m_comManagerState.devices.size()) return NULLPTR; return &(m_comManagerState.devices[pHandle]); }
+
+    static const int SYNC_FLASH_CFG_CHECK_PERIOD_MS =    200;
+    static const int SYNC_FLASH_CFG_TIMEOUT_MS =        3000;
 
 protected:
     bool OnClientPacketReceived(const uint8_t* data, uint32_t dataLength);


### PR DESCRIPTION
- Fix NPP build in Windows due to statically linked yaml-cpp.
- Pull forward IMX/GPX flash sync improvements from develop.