### PR TITLE
SN-6893 - Fixes/improves the completion message when a firmware update finishes, but has errors.

### DIFF
--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -627,7 +627,7 @@ void ISFirmwareUpdater::runCommand(std::string cmd) {
             commands.clear();
             bool reportErrors = (args.size() == 1 && args[0] == "true");
             if (reportErrors && (pfnInfoProgress_cb != nullptr))
-                pfnInfoProgress_cb(this, ISBootloader::IS_LOG_LEVEL_INFO, "Firmware updated completed %s", reportErrors ? "with errors. Please review update log for specifics." : "successfully.");
+                pfnInfoProgress_cb(this, ISBootloader::IS_LOG_LEVEL_INFO, "Firmware Update completed %s", reportErrors ? "with errors. Please review update log for specifics." : "successfully.");
         } else {
             // unknown command - ignore it
             if (pfnInfoProgress_cb != nullptr)

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -627,7 +627,7 @@ void ISFirmwareUpdater::runCommand(std::string cmd) {
             commands.clear();
             bool reportErrors = (args.size() == 1 && args[0] == "true");
             if (reportErrors && (pfnInfoProgress_cb != nullptr))
-                pfnInfoProgress_cb(this, ISBootloader::IS_LOG_LEVEL_INFO, "TODO: Give some kind of finish report (errors: %s)", reportErrors ? "true" : "false");
+                pfnInfoProgress_cb(this, ISBootloader::IS_LOG_LEVEL_INFO, "Firmware updated completed %s", reportErrors ? "with errors. Please review update log for specifics." : "successfully.");
         } else {
             // unknown command - ignore it
             if (pfnInfoProgress_cb != nullptr)


### PR DESCRIPTION
Specifically, the message clearly indicated success or failure, and directs the user to inspect the logs for specific error messages.

Note that Firmware Updates are complex mechanisms, particularly with packages, and that some upgrades may fail while others succeed.  It is important not to blindly communicate that the process was a pass or fail outcome, and instead direct the user to investigate the outcomes of each individual step.