### PR TITLE
SN-7018 bootloader v6g fail w two imxs

### DIFF
--- a/src/ISBootloaderThread.cpp
+++ b/src/ISBootloaderThread.cpp
@@ -850,6 +850,7 @@ is_operation_result cISBootloaderThread::update(
         return IS_OP_CANCELLED; 
     }
     m_infoProgress(NULL, IS_LOG_LEVEL_INFO, "Updating...");
+    SLEEP_MS(2500);
 
     ////////////////////////////////////////////////////////////////////////////
     // Run `mgmt_thread_libusb` to update DFU devices


### PR DESCRIPTION
Fixes an issue where IMX bootloader updates fail when starting with bootloader v6g and updating multiple devices. The fix adds a delay in the SDK firmware updater to ensure devices enter ROM bootloader mode before the update proceeds.