### PR TITLE
SN-7024 bootloader debug

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1095,7 +1095,7 @@ static int inertialSenseMain()
 {
     g_inertialSenseDisplay.SetDisplayMode((cInertialSenseDisplay::eDisplayMode)g_commandLineOptions.displayMode);
     g_inertialSenseDisplay.SetKeyboardNonBlocking();
-    g_inertialSenseDisplay.Clear();     // clear display
+    // g_inertialSenseDisplay.Clear();     // clear display
 
     // if replay data log specified on command line, do that now and return
     if (g_commandLineOptions.replayDataLog)

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -1529,8 +1529,6 @@ is_operation_result InertialSense::BootloadFile(
         return IS_OP_ERROR;
     }
 
-    printf("\n\r");
-
     ISBootloader::firmwares_t files;
     files.fw_uINS_3.path = fileName;
     files.bl_uINS_3.path = blFileName;

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -195,6 +195,7 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
     case PLATFORM_CFG_TYPE_NONE:
         break;
         // G8
+    case PLATFORM_CFG_TYPE_EVB2_G2:
     case PLATFORM_CFG_TYPE_IG1_0_G2:
         *ioConfig |= IO_CFG_GNSS1_PPS_SOURCE_G8<<IO_CFG_GNSS1_PPS_SOURCE_OFFSET;
         break;


### PR DESCRIPTION
- Remove clear screen command from cltool startup to allow viewing of command history.
- Restore PLATFORM_CFG_TYPE_EVB2_G2 GNSS PPS pin configuration use for internal testing.