### PR TITLE
faster ecef-to-ned computation

### DIFF
--- a/src/ISEarth.c
+++ b/src/ISEarth.c
@@ -686,12 +686,25 @@ float gravity_igf80(float lat_rad, float alt)
 /* Attitude quaternion for NED frame in ECEF */
 void quat_ecef2ned(float lat, float lon, float *qe2n)
 {
-    float eul[3];
+    //eul[0] = 0.0f;
+    //eul[1] = -lat - 0.5f * C_PI_F;
+    //eul[2] = lon;
+    //euler2quat(eul, qe2n);
 
-    eul[0] = 0.0f;
-    eul[1] = -lat - 0.5f * C_PI_F;
-    eul[2] = lon;
-    euler2quat(eul, qe2n);
+    // Faster:
+    f_t the = -(lat + 0.5f * C_PI_F) * 0.5f;
+    f_t psi = lon * 0.5f;
+
+    f_t sthe = _SIN(the);
+    f_t cthe = _COS(the);
+
+    f_t spsi = _SIN(psi);
+    f_t cpsi = _COS(psi);
+
+    qe2n[0] =  cthe * cpsi;
+    qe2n[1] = -sthe * spsi;
+    qe2n[2] =  sthe * cpsi;
+    qe2n[3] =  cthe * spsi;
 }
 
 

--- a/src/ISEarth.c
+++ b/src/ISEarth.c
@@ -692,19 +692,19 @@ void quat_ecef2ned(float lat, float lon, float *qe2n)
     //euler2quat(eul, qe2n);
 
     // Faster:
-    f_t the = -(lat + 0.5f * C_PI_F) * 0.5f;
-    f_t psi = lon * 0.5f;
+    f_t hthe = -(lat + 0.5f * C_PI_F) * 0.5f;
+    f_t hpsi = lon * 0.5f;
 
-    f_t sthe = _SIN(the);
-    f_t cthe = _COS(the);
+    f_t shthe = _SIN(hthe);
+    f_t chthe = _COS(hthe);
 
-    f_t spsi = _SIN(psi);
-    f_t cpsi = _COS(psi);
+    f_t shpsi = _SIN(hpsi);
+    f_t chpsi = _COS(hpsi);
 
-    qe2n[0] =  cthe * cpsi;
-    qe2n[1] = -sthe * spsi;
-    qe2n[2] =  sthe * cpsi;
-    qe2n[3] =  cthe * spsi;
+    qe2n[0] =  chthe * chpsi;
+    qe2n[1] = -shthe * shpsi;
+    qe2n[2] =  shthe * chpsi;
+    qe2n[3] =  chthe * shpsi;
 }
 
 

--- a/src/ISPose.c
+++ b/src/ISPose.c
@@ -242,14 +242,28 @@ void euler2quat(const ixEuler euler, ixQuat q)
 */
 void qe2b2EulerNedLLA(ixVector3 eul, const ixVector4 qe2b, const ixVector3d lla)
 {
-    ixVector3 eulned;
     ixVector4 qe2n;
     ixVector4 qn2b;
 
-    eulned[0] = 0.0f;
-    eulned[1] = ((float)-lla[0]) - 0.5f * C_PI_F;
-    eulned[2] = (float)lla[1];
-    euler2quat(eulned, qe2n);
+    //eulned[0] = 0.0f;
+    //eulned[1] = ((float)-lla[0]) - 0.5f * C_PI_F;
+    //eulned[2] = (float)lla[1];
+    //euler2quat(eulned, qe2n);
+
+    // Faster:
+    f_t the = -((float)lla[0] + 0.5f * C_PI_F) * 0.5f;
+    f_t psi = (float)lla[1] * 0.5f;
+
+    f_t sthe = _SIN(the);
+    f_t cthe = _COS(the);
+    f_t spsi = _SIN(psi);
+    f_t cpsi = _COS(psi);
+
+    qe2n[0] = cthe * cpsi;
+    qe2n[1] = -sthe * spsi;
+    qe2n[2] = sthe * cpsi;
+    qe2n[3] = cthe * spsi;
+
     mul_Quat_ConjQuat(qn2b, qe2b, qe2n);
     quat2euler(qn2b, eul);
 }

--- a/src/ISPose.c
+++ b/src/ISPose.c
@@ -251,18 +251,18 @@ void qe2b2EulerNedLLA(ixVector3 eul, const ixVector4 qe2b, const ixVector3d lla)
     //euler2quat(eulned, qe2n);
 
     // Faster:
-    f_t the = -((float)lla[0] + 0.5f * C_PI_F) * 0.5f;
-    f_t psi = (float)lla[1] * 0.5f;
+    f_t hthe = -((float)lla[0] + 0.5f * C_PI_F) * 0.5f;
+    f_t hpsi = (float)lla[1] * 0.5f;
 
-    f_t sthe = _SIN(the);
-    f_t cthe = _COS(the);
-    f_t spsi = _SIN(psi);
-    f_t cpsi = _COS(psi);
+    f_t shthe = _SIN(hthe);
+    f_t chthe = _COS(hthe);
+    f_t shpsi = _SIN(hpsi);
+    f_t chpsi = _COS(hpsi);
 
-    qe2n[0] = cthe * cpsi;
-    qe2n[1] = -sthe * spsi;
-    qe2n[2] = sthe * cpsi;
-    qe2n[3] = cthe * spsi;
+    qe2n[0] =  chthe * chpsi;
+    qe2n[1] = -shthe * shpsi;
+    qe2n[2] =  shthe * chpsi;
+    qe2n[3] =  chthe * shpsi;
 
     mul_Quat_ConjQuat(qn2b, qe2b, qe2n);
     quat2euler(qn2b, eul);


### PR DESCRIPTION
Faster euler-to-quaternion for ECEF-to-NED by skipping sin, cos and multiplications for zero