### PR TITLE
Change RUG-G0 to RUG-n-G0

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3202,7 +3202,7 @@ enum ePlatformConfig
     PLATFORM_CFG_TYPE_RUG4_X20                                                      = (int)5,   //!< PCB RUG-4-X20:       PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_RUG4_SG5                                                      = (int)6,   //!< PCB RUG-4-SG5:       PPS1 on G15 (pin 20), PPS2 on G11 (pin 16)
     PLATFORM_CFG_TYPE_RUG4_GPX                                                      = (int)7,   //!< PCB RUG-4-GPX:       PPS1 on G15 (pin 20), PPS2 on G11 (pin 16)
-    PLATFORM_CFG_TYPE_RUGX_G0                                                        = (int)8,   //!< PCB RUG-3.x.         PPS disabled
+    PLATFORM_CFG_TYPE_RUGX_G0                                                       = (int)8,   //!< PCB RUG-x.x.         PPS disabled
     PLATFORM_CFG_TYPE_RUG3_G1                                                       = (int)9,   //!< PCB RUG-3.x.         PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_RUG3_G2                                                       = (int)10,  //!< PCB RUG-3.x.         PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_EVB2_G2                                                       = (int)11,  //!< EVB-2 carrier board

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3202,7 +3202,7 @@ enum ePlatformConfig
     PLATFORM_CFG_TYPE_RUG4_X20                                                      = (int)5,   //!< PCB RUG-4-X20:       PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_RUG4_SG5                                                      = (int)6,   //!< PCB RUG-4-SG5:       PPS1 on G15 (pin 20), PPS2 on G11 (pin 16)
     PLATFORM_CFG_TYPE_RUG4_GPX                                                      = (int)7,   //!< PCB RUG-4-GPX:       PPS1 on G15 (pin 20), PPS2 on G11 (pin 16)
-    PLATFORM_CFG_TYPE_RUGX_G0                                                       = (int)8,   //!< PCB RUG-x.x.         PPS disabled
+    PLATFORM_CFG_TYPE_RUGn_G0                                                       = (int)8,   //!< PCB RUG-x.x. (i.e. RUG-3, RUG-4) PPS disabled
     PLATFORM_CFG_TYPE_RUG3_G1                                                       = (int)9,   //!< PCB RUG-3.x.         PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_RUG3_G2                                                       = (int)10,  //!< PCB RUG-3.x.         PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_EVB2_G2                                                       = (int)11,  //!< EVB-2 carrier board

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3202,7 +3202,7 @@ enum ePlatformConfig
     PLATFORM_CFG_TYPE_RUG4_X20                                                      = (int)5,   //!< PCB RUG-4-X20:       PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_RUG4_SG5                                                      = (int)6,   //!< PCB RUG-4-SG5:       PPS1 on G15 (pin 20), PPS2 on G11 (pin 16)
     PLATFORM_CFG_TYPE_RUG4_GPX                                                      = (int)7,   //!< PCB RUG-4-GPX:       PPS1 on G15 (pin 20), PPS2 on G11 (pin 16)
-    PLATFORM_CFG_TYPE_RUG_G0                                                        = (int)8,   //!< PCB RUG-3.x.         PPS disabled
+    PLATFORM_CFG_TYPE_RUGX_G0                                                        = (int)8,   //!< PCB RUG-3.x.         PPS disabled
     PLATFORM_CFG_TYPE_RUG3_G1                                                       = (int)9,   //!< PCB RUG-3.x.         PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_RUG3_G2                                                       = (int)10,  //!< PCB RUG-3.x.         PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_EVB2_G2                                                       = (int)11,  //!< EVB-2 carrier board

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -200,7 +200,7 @@ void imxPlatformConfigToRug4FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             break;
-        default:    // RUG_G0, RUG3_G1, RUG3_G2, RUG4_X20: onboard u-blox receiver (ZED-F9P / X20)
+        default:    // RUGX_G0, RUG3_G1, RUG3_G2, RUG4_X20: onboard u-blox receiver (ZED-F9P / X20)
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_UBLOX);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_UBLOX);
             break;

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -17,7 +17,7 @@ void imxPlatformConfigErrorCheck(uint32_t *platformConfig)
     {
         type = PLATFORM_CFG_TYPE_NONE;
     }
-    else if (type == PLATFORM_CFG_TYPE_RUGX_G0 && preset > PLATFORM_CFG_RUG3_PRESET__COUNT)
+    else if (type == PLATFORM_CFG_TYPE_RUGn_G0 && preset > PLATFORM_CFG_RUG3_PRESET__COUNT)
     {
         preset = PLATFORM_CFG_RUG3_PRESET__G0_DEFAULT;
     }
@@ -46,7 +46,7 @@ void imxPlatformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
     uint32_t preset = (platformConfig&PLATFORM_CFG_PRESET_MASK)>>PLATFORM_CFG_PRESET_OFFSET;
 
     // is platform R3?
-    if (type != PLATFORM_CFG_TYPE_RUGX_G0 &&
+    if (type != PLATFORM_CFG_TYPE_RUGn_G0 &&
         type != PLATFORM_CFG_TYPE_RUG3_G1 &&
         type != PLATFORM_CFG_TYPE_RUG3_G2)  { return; }
 
@@ -107,7 +107,7 @@ void imxPlatformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
 
     switch (type)
     {
-        case PLATFORM_CFG_TYPE_RUGX_G0:
+        case PLATFORM_CFG_TYPE_RUGn_G0:
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             break;
@@ -128,7 +128,7 @@ void imxPlatformConfigToRug4FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
     uint32_t preset = (platformConfig&PLATFORM_CFG_PRESET_MASK)>>PLATFORM_CFG_PRESET_OFFSET;
 
     // is platform R4?
-    if (type != PLATFORM_CFG_TYPE_RUGX_G0 &&
+    if (type != PLATFORM_CFG_TYPE_RUGn_G0 &&
         type != PLATFORM_CFG_TYPE_RUG4_X20 &&
         type != PLATFORM_CFG_TYPE_RUG4_SG5 &&
         type != PLATFORM_CFG_TYPE_RUG4_GPX)  { return; }
@@ -196,11 +196,11 @@ void imxPlatformConfigToRug4FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_GPX);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_GPX);
             break;
-        case PLATFORM_CFG_TYPE_RUGX_G0:
+        case PLATFORM_CFG_TYPE_RUGn_G0:
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             break;
-        default:    // RUGX_G0, RUG3_G1, RUG3_G2, RUG4_X20: onboard u-blox receiver (ZED-F9P / X20)
+        default:    // RUGn_G0 (RUG3_G0, RUG4_G0), RUG3_G1, RUG3_G2, RUG4_X20: onboard u-blox receiver (ZED-F9P / X20)
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_UBLOX);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_UBLOX);
             break;
@@ -226,7 +226,7 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
         SET_IO_CFG_GNSS1_TYPE(  *ioConfig, IO_CONFIG_GNSS_TYPE_UBLOX);
         SET_IO_CFG_GNSS2_TYPE(  *ioConfig, IO_CONFIG_GNSS_TYPE_UBLOX);
         break;
-    case PLATFORM_CFG_TYPE_RUGX_G0:
+    case PLATFORM_CFG_TYPE_RUGn_G0:
         // Shared value between RUG-3 (IMX-5) and RUG-4 (IMX-6) "no GPS" variants; dispatch based on which platform this firmware is built for
 #if defined(IMX_5)
         imxPlatformConfigToRug3FlashCfgIoConfig(ioConfig, platformConfig);
@@ -317,7 +317,7 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
     switch (type)
     {
         // Disabled
-    case PLATFORM_CFG_TYPE_RUGX_G0:               
+    case PLATFORM_CFG_TYPE_RUGn_G0:               
     case PLATFORM_CFG_TYPE_NONE:
         break;
         // G5
@@ -371,7 +371,7 @@ uint32_t imxPlatformConfigTypeToDefaultPlatformConfig(uint32_t platformType)
 // Return default platform preset based on platformType
 uint32_t imxPlatformConfigTypeToDefaultPlatformPreset(uint32_t platformType)
 {
-    if (platformType == PLATFORM_CFG_TYPE_RUGX_G0)
+    if (platformType == PLATFORM_CFG_TYPE_RUGn_G0)
         return PLATFORM_CFG_RUG3_PRESET__G0_DEFAULT;
     else if (platformType == PLATFORM_CFG_TYPE_RUG3_G1 ||
              platformType == PLATFORM_CFG_TYPE_RUG3_G2)

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -17,7 +17,7 @@ void imxPlatformConfigErrorCheck(uint32_t *platformConfig)
     {
         type = PLATFORM_CFG_TYPE_NONE;
     }
-    else if (type == PLATFORM_CFG_TYPE_RUG_G0 && preset > PLATFORM_CFG_RUG3_PRESET__COUNT)
+    else if (type == PLATFORM_CFG_TYPE_RUGX_G0 && preset > PLATFORM_CFG_RUG3_PRESET__COUNT)
     {
         preset = PLATFORM_CFG_RUG3_PRESET__G0_DEFAULT;
     }
@@ -46,7 +46,7 @@ void imxPlatformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
     uint32_t preset = (platformConfig&PLATFORM_CFG_PRESET_MASK)>>PLATFORM_CFG_PRESET_OFFSET;
 
     // is platform R3?
-    if (type != PLATFORM_CFG_TYPE_RUG_G0 &&
+    if (type != PLATFORM_CFG_TYPE_RUGX_G0 &&
         type != PLATFORM_CFG_TYPE_RUG3_G1 &&
         type != PLATFORM_CFG_TYPE_RUG3_G2)  { return; }
 
@@ -107,7 +107,7 @@ void imxPlatformConfigToRug3FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
 
     switch (type)
     {
-        case PLATFORM_CFG_TYPE_RUG_G0:
+        case PLATFORM_CFG_TYPE_RUGX_G0:
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             break;
@@ -128,7 +128,7 @@ void imxPlatformConfigToRug4FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
     uint32_t preset = (platformConfig&PLATFORM_CFG_PRESET_MASK)>>PLATFORM_CFG_PRESET_OFFSET;
 
     // is platform R4?
-    if (type != PLATFORM_CFG_TYPE_RUG_G0 &&
+    if (type != PLATFORM_CFG_TYPE_RUGX_G0 &&
         type != PLATFORM_CFG_TYPE_RUG4_X20 &&
         type != PLATFORM_CFG_TYPE_RUG4_SG5 &&
         type != PLATFORM_CFG_TYPE_RUG4_GPX)  { return; }
@@ -196,7 +196,7 @@ void imxPlatformConfigToRug4FlashCfgIoConfig(uint32_t *ioConfig, uint32_t platfo
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_GPX);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_GPX);
             break;
-        case PLATFORM_CFG_TYPE_RUG_G0:
+        case PLATFORM_CFG_TYPE_RUGX_G0:
             SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             SET_IO_CFG_GNSS2_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_NONE);
             break;
@@ -226,7 +226,7 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
         SET_IO_CFG_GNSS1_TYPE(  *ioConfig, IO_CONFIG_GNSS_TYPE_UBLOX);
         SET_IO_CFG_GNSS2_TYPE(  *ioConfig, IO_CONFIG_GNSS_TYPE_UBLOX);
         break;
-    case PLATFORM_CFG_TYPE_RUG_G0:
+    case PLATFORM_CFG_TYPE_RUGX_G0:
         // Shared value between RUG-3 (IMX-5) and RUG-4 (IMX-6) "no GPS" variants; dispatch based on which platform this firmware is built for
 #if defined(IMX_5)
         imxPlatformConfigToRug3FlashCfgIoConfig(ioConfig, platformConfig);
@@ -317,7 +317,7 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
     switch (type)
     {
         // Disabled
-    case PLATFORM_CFG_TYPE_RUG_G0:               
+    case PLATFORM_CFG_TYPE_RUGX_G0:               
     case PLATFORM_CFG_TYPE_NONE:
         break;
         // G5
@@ -371,7 +371,7 @@ uint32_t imxPlatformConfigTypeToDefaultPlatformConfig(uint32_t platformType)
 // Return default platform preset based on platformType
 uint32_t imxPlatformConfigTypeToDefaultPlatformPreset(uint32_t platformType)
 {
-    if (platformType == PLATFORM_CFG_TYPE_RUG_G0)
+    if (platformType == PLATFORM_CFG_TYPE_RUGX_G0)
         return PLATFORM_CFG_RUG3_PRESET__G0_DEFAULT;
     else if (platformType == PLATFORM_CFG_TYPE_RUG3_G1 ||
              platformType == PLATFORM_CFG_TYPE_RUG3_G2)


### PR DESCRIPTION
This pull request updates the naming of a platform configuration constant throughout the codebase to improve clarity and consistency. The constant `PLATFORM_CFG_TYPE_RUG_G0` has been renamed to `PLATFORM_CFG_TYPE_RUGX_G0` in both the enum definition and all relevant logic, ensuring uniform usage and reducing the risk of confusion.

**Platform configuration constant renaming:**

* Renamed `PLATFORM_CFG_TYPE_RUG_G0` to `PLATFORM_CFG_TYPE_RUGX_G0` in the `ePlatformConfig` enum in `src/data_sets.h`.
* Updated all usages of the old constant name to the new one in the following functions in `src/imx_defaults.c`:
  - `imxPlatformConfigErrorCheck`
  - `imxPlatformConfigToRug3FlashCfgIoConfig` [[1]](diffhunk://#diff-bd039bc263d7e25c27fdaa3fc61b8cd215777fa6eb314b7a4e3aa50d0adc7776L49-R49) [[2]](diffhunk://#diff-bd039bc263d7e25c27fdaa3fc61b8cd215777fa6eb314b7a4e3aa50d0adc7776L110-R110)
  - `imxPlatformConfigToRug4FlashCfgIoConfig` [[1]](diffhunk://#diff-bd039bc263d7e25c27fdaa3fc61b8cd215777fa6eb314b7a4e3aa50d0adc7776L131-R131) [[2]](diffhunk://#diff-bd039bc263d7e25c27fdaa3fc61b8cd215777fa6eb314b7a4e3aa50d0adc7776L199-R199)
  - `imxPlatformConfigToFlashCfgIoConfig` [[1]](diffhunk://#diff-bd039bc263d7e25c27fdaa3fc61b8cd215777fa6eb314b7a4e3aa50d0adc7776L229-R229) [[2]](diffhunk://#diff-bd039bc263d7e25c27fdaa3fc61b8cd215777fa6eb314b7a4e3aa50d0adc7776L320-R320)
  - `imxPlatformConfigTypeToDefaultPlatformConfig` and `imxPlatformConfigTypeToDefaultPlatformPreset`

This change is purely a renaming for clarity—no logic or behavior is altered.