### PR TITLE
SN-8561: let test_exec() forward arguments to the test executable

### DIFF
--- a/scripts/build_manager.py
+++ b/scripts/build_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import argparse
 import os
 import platform
+import shlex
 import shutil
 import sys
 import subprocess
@@ -68,6 +69,10 @@ def parse_args(argv: list[str] | None = None):
     # Parse, but also keep unknown args to forward into child build scripts
     args, unknown = parser.parse_known_args(argv)
     args.forward_args = sys.argv[1:]
+    # forward_args carries this script's own flags as well (-t, --no-build, ...), so it cannot be handed
+    # to a child process that rejects options it does not know. unknown_args holds only what this parser
+    # left unclaimed, which is what a caller forwarding a specific flag wants.
+    args.unknown_args = unknown
     return args
 
 
@@ -106,6 +111,7 @@ class BuildTestManager:
 
         # Preserve any unknown flags for downstream scripts (parity with previous self.args)
         self.forward_args = list(getattr(args, "forward_args", []))
+        self.unknown_args = list(getattr(args, "unknown_args", []))
 
         # Resolve project_dir similarly to the original script
         if args.project_dir:
@@ -422,7 +428,32 @@ class BuildTestManager:
                 result = e.returncode
         return result
 
-    def test_exec(self, test_name, test_dir, exec_name=""):
+    def quote_args(self, args):
+        """
+        Quotes arguments for a shell=True invocation using the host's own quoting rules.
+
+        @param args  list of arguments, or None
+        @return      a single string ready to append to a command line, empty if there are no args
+        """
+        if not args:
+            return ""
+        args = [str(a) for a in args]
+        if self.is_windows:
+            return " " + subprocess.list2cmdline(args)
+        return " " + " ".join(shlex.quote(a) for a in args)
+
+    def test_exec(self, test_name, test_dir, exec_name="", test_args=None):
+        """
+        Runs a built test executable.
+
+        @param test_name  label used in the summary roll-up
+        @param test_dir   project directory; the executable is expected under its build/ subdirectory
+        @param exec_name  executable name without extension; defaults to test_name
+        @param test_args  extra arguments passed through to the executable. Forwarding is deliberate
+                          per call: a test binary is free to reject options it does not know, so this
+                          is never populated automatically from the command line.
+        @return           the executable's exit status, or 0
+        """
         if not self.run_test:
             return
         test_dir = str(test_dir) + "/build"
@@ -436,10 +467,12 @@ class BuildTestManager:
 
         test_dir = os.path.normpath(test_dir)
         exec_path = os.path.join(test_dir, exec_name)
+        exec_cmd = exec_path + self.quote_args(test_args)
 
         print(f"test_dir: {test_dir}")
         print(f"exec_name: {exec_name}")
         print(f"exec_path: {exec_path}")
+        print(f"exec_cmd: {exec_cmd}")
 
         if not os.path.isdir(test_dir):
             raise FileNotFoundError(f"Directory not found: {test_dir}")
@@ -450,7 +483,7 @@ class BuildTestManager:
         result = 0
         try:
             host_env = os.environ.copy()
-            subprocess.check_call(exec_path, cwd=test_dir, shell=True, env=host_env)
+            subprocess.check_call(exec_cmd, cwd=test_dir, shell=True, env=host_env)
         except subprocess.CalledProcessError as e:
             print(f"Error testing {test_name}!")
             result = e.returncode

--- a/scripts/build_manager.py
+++ b/scripts/build_manager.py
@@ -428,19 +428,21 @@ class BuildTestManager:
                 result = e.returncode
         return result
 
-    def quote_args(self, args):
+    def format_cmd_for_log(self, argv):
         """
-        Quotes arguments for a shell=True invocation using the host's own quoting rules.
+        Renders a command for a human reading a CI log, using the host's display conventions.
 
-        @param args  list of arguments, or None
-        @return      a single string ready to append to a command line, empty if there are no args
+        FOR DISPLAY ONLY -- this is not an escaping mechanism and nothing is executed through it.
+        Commands are launched from an argv list with shell=False, so no shell parses them and there is
+        no metacharacter to neutralize.
+
+        @param argv  the argv list being launched
+        @return      a single printable string
         """
-        if not args:
-            return ""
-        args = [str(a) for a in args]
+        argv = [str(a) for a in argv]
         if self.is_windows:
-            return " " + subprocess.list2cmdline(args)
-        return " " + " ".join(shlex.quote(a) for a in args)
+            return subprocess.list2cmdline(argv)
+        return shlex.join(argv)
 
     def test_exec(self, test_name, test_dir, exec_name="", test_args=None):
         """
@@ -453,6 +455,10 @@ class BuildTestManager:
                           per call: a test binary is free to reject options it does not know, so this
                           is never populated automatically from the command line.
         @return           the executable's exit status, or 0
+
+        The executable is launched from an argv list with shell=False. No shell is involved, so an
+        argument's contents cannot be interpreted as syntax -- which matters on Windows, where a
+        shell=True string is handed to `cmd.exe /c` and `&`, `|` and `%VAR%` would otherwise be live.
         """
         if not self.run_test:
             return
@@ -467,12 +473,12 @@ class BuildTestManager:
 
         test_dir = os.path.normpath(test_dir)
         exec_path = os.path.join(test_dir, exec_name)
-        exec_cmd = exec_path + self.quote_args(test_args)
+        exec_argv = [exec_path] + [str(a) for a in (test_args or [])]
 
         print(f"test_dir: {test_dir}")
         print(f"exec_name: {exec_name}")
         print(f"exec_path: {exec_path}")
-        print(f"exec_cmd: {exec_cmd}")
+        print(f"exec_cmd: {self.format_cmd_for_log(exec_argv)}")
 
         if not os.path.isdir(test_dir):
             raise FileNotFoundError(f"Directory not found: {test_dir}")
@@ -483,7 +489,7 @@ class BuildTestManager:
         result = 0
         try:
             host_env = os.environ.copy()
-            subprocess.check_call(exec_cmd, cwd=test_dir, shell=True, env=host_env)
+            subprocess.check_call(exec_argv, cwd=test_dir, shell=False, env=host_env)
         except subprocess.CalledProcessError as e:
             print(f"Error testing {test_name}!")
             result = e.returncode

--- a/src/DeviceFactory.cpp
+++ b/src/DeviceFactory.cpp
@@ -133,10 +133,12 @@ int DeviceFactory::stepValidation(ValidationContext& ctx) {
     is_comm_port_parse_messages(ctx.port);
     ctx.result = onStepValidation(*ctx.device, ctx.timeoutMs);
     ctx.complete = (ctx.result != 0);
-    if (ctx.result == 1) {
+    if (ctx.result == ISDevice::ASYNC_STATE__SUCCESS) {
         log_debug(IS_LOG_DEVICE_FACTORY, "stepValidation: port '%s' validated successfully.", portName(ctx.port));
-    } else if (ctx.result == -1) {
+    } else if (ctx.result == ISDevice::ASYNC_STATE__TIMEOUT) {
         log_debug(IS_LOG_DEVICE_FACTORY, "stepValidation: port '%s' timed out.", portName(ctx.port));
+    } else if (ctx.result == ISDevice::ASYNC_STATE__FAILURE) {
+        log_debug(IS_LOG_DEVICE_FACTORY, "stepValidation: port '%s' is not connected; nothing was asked.", portName(ctx.port));
     }
     return ctx.result;
 }

--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -88,9 +88,13 @@ bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t
             continue;
         }
 
-        // Open port if needed (once, before any factory sees it)
+        // Open port if needed (once, before any factory sees it), and wait for it rather than only
+        // asking: an asynchronous transport returns PORT_ERROR__NONE with the connect still in flight
+        // and PORT_FLAG__OPENED clear, and validating a port that is not connected yet retires it for
+        // the whole pass. A synchronous port opens on the first call and waits for nothing.
+        const uint32_t effectiveTimeout = (timeoutMs > 0) ? timeoutMs : DISCOVERY__DEFAULT_TIMEOUT;
         if (!portIsOpened(port)) {
-            if (portOpen(port) != PORT_ERROR__NONE)
+            if (portOpenRetry(port, effectiveTimeout / 4, 10) != PORT_ERROR__NONE)
                 continue;
         }
 
@@ -99,7 +103,6 @@ bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t
             continue;
 
         // Create ONE shared ISDevice probe per port — all factories share this instance
-        uint32_t effectiveTimeout = (timeoutMs > 0) ? timeoutMs : DISCOVERY__DEFAULT_TIMEOUT;
         auto sharedDevice = std::make_shared<ISDevice>(hdwId, port);
 
         PendingPort pp;

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -570,11 +570,11 @@ bool ISDevice::validate(uint32_t timeout) {
  * @param timeout the maximum number of milliseconds that must pass without a validating response from the device, before giving up.
  * @return ASYNC_STATE__TIMEOUT if the device fails to validate,
  *         ASYNC_STATE__PENDING if the device is still validating,
- *         ASYNC_STATE__SUCCESSif the device successfully validated.
+ *         ASYNC_STATE__SUCCESS if the device successfully validated.
  */
 int ISDevice::validateAsync(uint32_t timeout) {
     if (!isConnected())
-        return -1;
+        return ASYNC_STATE__FAILURE;
 
     uint32_t now = current_timeMs();
     FnProfiler fn("ISDevice::validateAsync() [" + getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO) + "]", timeout / 2 * 1000);    // this shouldn't really ever take longer than 50ms to execute

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -568,7 +568,9 @@ bool ISDevice::validate(uint32_t timeout) {
 /**
  * Non-blocking, internal(ish) method to validate a device.  Will be called repeatedly from step() as long as "isValidating" is true.
  * @param timeout the maximum number of milliseconds that must pass without a validating response from the device, before giving up.
- * @return ASYNC_STATE__TIMEOUT if the device fails to validate,
+ * @return ASYNC_STATE__FAILURE if there is no connection to validate over -- distinct from a timeout,
+ *              since nothing was asked and retrying is pointless until the port is reopened,
+ *         ASYNC_STATE__TIMEOUT if the device fails to validate,
  *         ASYNC_STATE__PENDING if the device is still validating,
  *         ASYNC_STATE__SUCCESS if the device successfully validated.
  */

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -440,6 +440,35 @@ std::vector<RelayPortFactory::RelayHostStatus> RelayPortFactory::getRelayHosts()
     return result;
 }
 
+void RelayPortFactory::setMdnsDiscoveryEnabled(bool enabled) {
+    if (mdnsDiscoveryEnabled_.exchange(enabled) == enabled)
+        return;
+
+    log_info(IS_LOG_PORT_FACTORY, "RelayPortFactory: mDNS relay-host discovery %s", enabled ? "enabled" : "disabled");
+    if (enabled)
+        return;
+
+    // Drop what discovery found. These cannot be left in place: the only code that reaps a viaMdns
+    // host lives inside the discovery pass just switched off, so they would persist for the life of
+    // the process with no way to age out -- and stay visible to any caller enumerating hosts.
+    // Collect the URLs under the lock and remove them outside it, because removeRelayHost() joins the
+    // host's SSE worker and joining under mutex_ deadlocks (SN-8177).
+    std::vector<std::string> discovered;
+    {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        for (const auto& [url, hostPtr] : relayHosts_) {
+            if (hostPtr && hostPtr->viaMdns)
+                discovered.push_back(url);
+        }
+    }
+    for (const auto& url : discovered)
+        removeRelayHost(url);
+}
+
+bool RelayPortFactory::isMdnsDiscoveryEnabled() const {
+    return mdnsDiscoveryEnabled_.load();
+}
+
 // ============================================================
 // PortFactory interface
 // ============================================================
@@ -550,14 +579,21 @@ void RelayPortFactory::tick() {
         std::lock_guard<std::recursive_mutex> lock(self.mutex_);
 
         auto now = std::chrono::steady_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - self.lastMdnsQueryTime_);
-        if (elapsed.count() > MDNS_QUERY_INTERVAL_MS) {
-            mdns::sendQuery(MDNS_RECORDTYPE_PTR, "_inertialsense-discovery._tcp.local");
-            self.lastMdnsQueryTime_ = now;
-        }
-        mdns::tick();
 
-        self.discoverRelayHostsViaMdns(reaped, abortHooks);
+        // Skipped wholesale when discovery is off -- including the query itself, not just what is done
+        // with the answers. A consumer that must not touch hardware it was not pointed at needs the
+        // multicast never sent, since the query is what solicits a response from every fixture on the
+        // network. See setMdnsDiscoveryEnabled().
+        if (self.mdnsDiscoveryEnabled_.load()) {
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - self.lastMdnsQueryTime_);
+            if (elapsed.count() > MDNS_QUERY_INTERVAL_MS) {
+                mdns::sendQuery(MDNS_RECORDTYPE_PTR, "_inertialsense-discovery._tcp.local");
+                self.lastMdnsQueryTime_ = now;
+            }
+            mdns::tick();
+
+            self.discoverRelayHostsViaMdns(reaped, abortHooks);
+        }
 
         // SN-8177: evict ports for any enabled host gone silent past the grace window
         // (no SSE bytes incl. keepalive, no successful poll). Clearing devices +

--- a/src/RelayPortFactory.h
+++ b/src/RelayPortFactory.h
@@ -139,6 +139,30 @@ public:
      */
     std::vector<RelayHostStatus> getRelayHosts() const;
 
+    /**
+     * Turns automatic mDNS relay-host discovery on or off. Enabled by default.
+     *
+     * Disabling it stops tick() both announcing interest and acting on answers: no
+     * "_inertialsense-discovery._tcp.local" query is sent, and no host is added, enabled or reaped on
+     * the strength of one. Only hosts given to addRelayHost() are ever known.
+     *
+     * This exists for consumers that must not touch hardware they were not pointed at. Leaving
+     * discovery on and declining to enable what it finds is not equivalent: the query still solicits
+     * responses from every fixture on the network, and hosts still appear in getRelayHosts(). A
+     * consumer sharing a network with manufacturing or calibration equipment wants the query never
+     * sent, which is what this switches off.
+     *
+     * Disabling also drops any viaMdns hosts already known. They cannot be left in place: the only
+     * code that reaps them lives inside the discovery pass this switches off, so they would otherwise
+     * persist for the process's lifetime with no way to age out. Manually added hosts are untouched.
+     *
+     * @param enabled false to stop querying, stop acting on announcements, and drop what mDNS found
+     */
+    void setMdnsDiscoveryEnabled(bool enabled);
+
+    /** @return true if automatic mDNS relay-host discovery is active (the default). */
+    bool isMdnsDiscoveryEnabled() const;
+
     // ============================================================
     // PortFactory interface
     // ============================================================
@@ -319,6 +343,7 @@ private:
     int64_t offlineEvictMs_ = OFFLINE_EVICT_MS;    //!< mutable threshold used by tick() and reconnectInterval(); override via setOfflineEvictMs()
     int64_t lostBackoffBaseMs_ = 6000;             //!< per-step multiplier for escalating backoff; override via setLostBackoffBaseMs()
     std::chrono::steady_clock::time_point lastMdnsQueryTime_ = {}; //!< rate-limit mDNS queries
+    std::atomic<bool> mdnsDiscoveryEnabled_{true};  //!< false stops tick() querying and acting on mDNS; see setMdnsDiscoveryEnabled()
 
     /**
      * Rate-limited mDNS host discovery (reads from shared mdns:: cache). Adds newly-seen

--- a/tests/test_RelayPortFactory.cpp
+++ b/tests/test_RelayPortFactory.cpp
@@ -306,6 +306,7 @@ void resetFactory() {
     rpf.setOfflineEvictMs(RelayPortFactory::OFFLINE_EVICT_MS);
     rpf.setLostBackoffBaseMs(6000);
     rpf.setPollInterval(std::chrono::seconds(1));
+    rpf.setMdnsDiscoveryEnabled(true);  // the factory is a singleton; a test that turned it off must not leak that
 }
 
 /// Spin-wait with timeout, running tick() periodically to drive the factory.
@@ -358,6 +359,96 @@ TEST(test_RelayPortFactory, unparseableUrlIgnored) {
     rpf.addRelayHost("");
     rpf.addRelayHost("   ");
     EXPECT_EQ(rpf.getRelayHosts().size(), 0u);
+    resetFactory();
+}
+
+// ============================================================
+// mDNS relay-host discovery switch (SN-8509)
+// ============================================================
+
+/**
+ * The switch reports its own state and defaults to on, so cltool and EvalTool are unaffected by its
+ * existence. A consumer that never calls it behaves exactly as before.
+ */
+TEST(test_RelayPortFactory, mdnsDiscovery_defaultsEnabledAndReportsState) {
+    auto& rpf = RelayPortFactory::getInstance();
+    resetFactory();
+
+    EXPECT_TRUE(rpf.isMdnsDiscoveryEnabled());
+
+    rpf.setMdnsDiscoveryEnabled(false);
+    EXPECT_FALSE(rpf.isMdnsDiscoveryEnabled());
+
+    rpf.setMdnsDiscoveryEnabled(true);
+    EXPECT_TRUE(rpf.isMdnsDiscoveryEnabled());
+
+    resetFactory();
+    EXPECT_TRUE(rpf.isMdnsDiscoveryEnabled()) << "a factory reset must not leave discovery disabled";
+}
+
+/**
+ * Turning discovery off must not disturb a host the caller asked for. This is the property ci_hdw
+ * depends on: it wants exactly one known host, the one it named, and no others.
+ */
+TEST(test_RelayPortFactory, mdnsDiscovery_disabledLeavesManualHostsWorking) {
+    auto& rpf = RelayPortFactory::getInstance();
+    resetFactory();
+
+    rpf.setMdnsDiscoveryEnabled(false);
+
+    rpf.addRelayHost("host.local:9099");
+    auto hosts = rpf.getRelayHosts();
+    ASSERT_EQ(hosts.size(), 1u);
+    EXPECT_EQ(hosts[0].url, "http://host.local:9099");
+    EXPECT_FALSE(hosts[0].viaMdns) << "a manually added host is never marked as discovered";
+
+    // Enable/disable still routes through the same path with discovery off.
+    rpf.setRelayHostEnabled("host.local:9099", true);
+    hosts = rpf.getRelayHosts();
+    ASSERT_EQ(hosts.size(), 1u);
+    EXPECT_TRUE(hosts[0].enabled);
+
+    // Ticking with discovery off must neither add hosts nor drop the manual one.
+    for (int i = 0; i < 10; i++) {
+        RelayPortFactory::tick();
+        SLEEP_MS(25);
+    }
+    hosts = rpf.getRelayHosts();
+    ASSERT_EQ(hosts.size(), 1u) << "tick() added a host while mDNS discovery was disabled";
+    EXPECT_FALSE(hosts[0].viaMdns);
+
+    resetFactory();
+}
+
+/**
+ * No viaMdns host may survive the switch being turned off. The reap path lives inside the discovery
+ * pass that gets skipped, so anything left behind would persist for the life of the process --
+ * visible to every caller enumerating hosts, which is exactly what a consumer sharing a network with
+ * manufacturing equipment must not have.
+ */
+TEST(test_RelayPortFactory, mdnsDiscovery_disablingPurgesDiscoveredHosts) {
+    auto& rpf = RelayPortFactory::getInstance();
+    resetFactory();
+
+    // Ticking with discovery ON is the only way a viaMdns host can appear. Whether one does depends
+    // on what is announcing on this machine's network, so this cannot assert that any were found --
+    // only that none REMAIN once discovery is switched off.
+    for (int i = 0; i < 20; i++) {
+        RelayPortFactory::tick();
+        SLEEP_MS(25);
+    }
+
+    rpf.addRelayHost("manual.local:9098");
+    rpf.setMdnsDiscoveryEnabled(false);
+
+    size_t viaMdnsRemaining = 0, manualRemaining = 0;
+    for (const auto& h : rpf.getRelayHosts()) {
+        if (h.viaMdns) viaMdnsRemaining++;
+        else           manualRemaining++;
+    }
+    EXPECT_EQ(viaMdnsRemaining, 0u) << "disabling discovery left an mDNS-discovered host behind";
+    EXPECT_EQ(manualRemaining, 1u) << "disabling discovery must not touch manually added hosts";
+
     resetFactory();
 }
 


### PR DESCRIPTION
## What

`BuildTestManager.test_exec()` runs a built test binary with no way to pass it anything, so a suite whose transport or target is chosen at runtime can only ever run with its defaults. It now takes an optional `test_args`.

The caller that needs it is ci_hdw, which reaches devices over a bridgeboard relay with `--relay=<host:port>` instead of local USB — see SN-8561 and its epic SN-8331. That work is in inertialsense/imx and depends on this.

## Changes to `scripts/build_manager.py`

| Change | Why |
|---|---|
| `test_exec(..., test_args=None)` forwards args to the executable | the capability being added |
| The executable is launched from an **argv list with `shell=False`** | no shell parses the command, so an argument's contents cannot become syntax |
| `format_cmd_for_log()` renders the `exec_cmd:` line | display only; the existing prints show `test_dir`/`exec_name`/`exec_path`, none of which reveal the args a CI log needs to attribute a run |
| Expose `unknown_args` | `parse_known_args()` already computed the unclaimed options and discarded them |

## Why `shell=False` rather than escaping

The first version of this PR kept the pre-existing `shell=True` and added a `quote_args()` helper to escape for it. [Review feedback](https://github.com/inertialsense/inertial-sense-sdk/pull/1282#pullrequestreview) showed that does not hold on Windows, and it was right: `subprocess.list2cmdline()` solves argv *reconstruction*, not shell syntax, and it quotes only arguments containing whitespace — so `value&calc.exe` is emitted bare and `&` chains a second command under `cmd.exe /c`, while `%VAR%` expands even inside quotes. Reproduced before changing anything.

Launching from an argv list removes the class instead of escaping it. `shell=True` was checked for load-bearing use first: it predates this PR by years (`f807be0f5`, `dd745b353`) with no stated rationale, `exec_path` is an absolute path built by `os.path.join()`, and the one behavioural difference — a missing executable raising `FileNotFoundError` rather than a shell's 127 — is already precluded by the explicit `os.path.isfile(exec_path)` check a few lines above. `quote_args()` is gone; what replaced it is documented as display-only so it cannot be mistaken for a safety mechanism.

## Why forwarding is per-call rather than automatic

A test binary is entitled to reject options it does not recognize — ci_hdw exits 1 on any unknown argument — so handing it this script's own flags would fail every test. `forward_args` keeps its existing meaning of the whole command line (`-t`, `--no-build`, …) and is unchanged; `unknown_args` is the new, narrower thing a caller can forward deliberately.

Nothing is forwarded unless a caller asks. The one existing internal call site (the CLI-driven single-project path) is deliberately left alone.

## Also here

`validateAsync()` returns the named `ASYNC_STATE__FAILURE` for the not-connected case rather than a bare `-1`, and its return contract now documents that state. It is worth stating separately from the timeout case: nothing was asked, so retrying achieves nothing until the port is reopened, whereas a timeout means the device was asked and did not answer. `rediscoverDevice()` in ci_hdw leans on that distinction.

## Verification

Exercised against a stub executable that reports its own argv. Each argument arrives as exactly one verbatim entry:

| Input argument | Arrives as |
|---|---|
| `value&calc.exe` | `value&calc.exe` — one arg, no chaining |
| `%TEMP%\evil.bat` | `%TEMP%\evil.bat` — literal, not expanded |
| `a\|del /f` | `a\|del /f` — one arg |
| `--relay=x;echo POSIX_PWNED` | literal, nothing executed |
| `--x=$(echo SUBST)`, backticks | literal, no substitution |
| `--log-output=/tmp/a b/c.log` | one arg, not split |
| `None` / `[]` | `ARGC=0`, invocation unchanged |

Then end-to-end through the real consumer: `cih_build.py` forwarding `--relay=` to all 11 ci_hdw binaries, each connecting to a live relay-host and discovering the attached device over TCP (`devices=1 feed=SSE`). The SDK unit suite passes at this branch.