### PR TITLE
SN-8553: host-side support for updating a GNSS receiver behind a module

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1385,7 +1385,7 @@ static inline void parse_messages(is_comm_instance_t* comm, port_handle_t port)
     protocol_type_t ptype;
 
 #if DEBUG_PARSE_MSG
-    static const char* ptype_names[_PTYPE_SIZE] = { "NONE", "ERROR", "ISB_ACK", "ISB_CMD", "ISB_DATA", "NMEA", "UBLOX", "RTCM3", "SPARTN", "SONY" };
+    static const char* ptype_names[_PTYPE_SIZE] = { "NONE", "ERROR", "ISB_ACK", "ISB_CMD", "ISB_DATA", "NMEA", "UBLOX", "RTCM3", "SPARTN", "SONY", "SEPT_SBF", "SEPT_REPLY" };
     static char log_msg[512];
     int log_msg_pos = sprintf(log_msg, "parse_messages() parsed:");
 #endif

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -458,6 +458,12 @@ bool ISDevice::queryDeviceInfoISbl(uint32_t timeout) {
 
 
 bool ISDevice::validate(uint32_t timeout) {
+    // validate() is its own blocking implementation rather than a wrapper around validateAsync(), so
+    // it needs the guard too -- see disableValidation(). Silent, because a caller that disabled
+    // validation asked for exactly this and does not need telling each time.
+    if (doNotValidate)
+        return false;
+
     if (!isConnected()) {
         // INFO, not debug: validating a closed port is a caller mistake in the same class as querying
         // one, and not a hard failure -- but the caller should hear about it. This return also precedes
@@ -575,6 +581,13 @@ bool ISDevice::validate(uint32_t timeout) {
  *         ASYNC_STATE__SUCCESS if the device successfully validated.
  */
 int ISDevice::validateAsync(uint32_t timeout) {
+    // Guarded here rather than at each caller: step(), DeviceFactory::stepValidation() and the
+    // bootloader updaters all reach validation through this one function, and a device told never to
+    // validate must mean it for all of them. FAILURE rather than TIMEOUT for the same reason a closed
+    // port returns it -- nothing was asked, and retrying will not change that.
+    if (doNotValidate)
+        return ASYNC_STATE__FAILURE;
+
     if (!isConnected())
         return ASYNC_STATE__FAILURE;
 

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -898,6 +898,27 @@ public:
     /** @brief Non-blocking counterpart to validate(): advances one step of the query cycle per call. @return an AsyncState value indicating progress/result. */
     int validateAsync(uint32_t timeout = 1000);
 
+    /**
+     * Stops this device ever attempting to validate.
+     *
+     * For a device that is known not to speak ISB at all -- a port bound without validation, or one
+     * carrying a directly attached third-party receiver -- validation cannot succeed, and every
+     * attempt writes probe traffic to the link and consumes what comes back. On a port whose data
+     * belongs to something else, that is not merely wasted effort: it takes the bytes that other
+     * reader was waiting for.
+     *
+     * Distinct from COMM_PORT_FLAG__EXPLICIT_READ, which says another reader owns the port rather
+     * than that this device should give up on identifying itself. The flag happens to suppress the
+     * validation attempt in step(), but says nothing to validate()/validateAsync() called from
+     * anywhere else, and conflating the two leaves the intent unrecorded.
+     *
+     * @param disable true to never validate; false to restore the default behaviour.
+     */
+    void disableValidation(bool disable = true) { doNotValidate = disable; }
+
+    /** @return true if validation has been disabled for this device; see disableValidation(). */
+    bool validationDisabled() const { return doNotValidate; }
+
     /** @brief ISComm packet-received callback; currently only forwards _PTYPE_INERTIAL_SENSE_ACK packets to onIsbAckHandler(). @return 1 to allow other registered handlers to continue processing this message. */
     virtual int onPacketHandler(protocol_type_t ptype, packet_t *pkt, port_handle_t port);
     /** @brief ISComm ISB "Data" message callback; updates devInfo/sysParams/etc from the parsed DID payload. @return 1 to allow other registered handlers to continue processing this message. */
@@ -925,6 +946,7 @@ private:
     uint32_t                    validationStartMs = 0;               //!< If non-zero, the time in Epoch Ms at which validation was started; if zero, validation has finished (use hasDeviceInfo() to determine device status)
     uint32_t                    nextValidationMs = 0;                //!< if current_timeMs() > than this time, we'll perform the next validation query, otherwise we wait to see if the previous responds.
     queryType                   nextValidationType = QUERYTYPE_NMEA; //!< we cycle through different types of device queries looking for the first response (0 = NMEA, 1 = ISbinary, 2 = ISbootloader, 3 = MCUboot/SMP)
+    bool                        doNotValidate = false;               //!< never attempt validation on this device; see disableValidation()
     unsigned int                syncCheckTimeMs = 0;
 
     std::array<std::chrono::high_resolution_clock::time_point, _PTYPE_SIZE> lastRxTs; //!< An array of timestamps of when last data was received of a particular protocol type (ISB, NMEA, RTCM3, etc)

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -396,7 +396,14 @@ bool ISFirmwareUpdater::fwUpdate_handleResendChunk(const fwUpdate::payload_t &ms
         LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_DEBUG, "Remote asked to slow down after %u chunks; chunk delay now %ums",
                             (unsigned)sustained, chunkDelay);
 
-        return fwUpdate_sendNextChunk();
+        // Honour the pace that was just derived, rather than sending immediately. Sending here
+        // bypasses the nextChunkSend gate that fwUpdate_step() consults -- and it is the ONLY reader
+        // of that gate -- so a target that refuses again is answered one round trip later, at which
+        // point the delay is raised again and sent through immediately again. Measured: at a 503ms
+        // derived delay the requests arrived 88ms apart, the delay climbing 1ms each time and
+        // throttling nothing. Scheduling instead makes the derived rate the rate.
+        nextChunkSend = current_ms + chunkDelay;
+        return true;
     }
 
     // Any other resend means this target could not take the data at the rate it was offered, but
@@ -738,6 +745,14 @@ bool ISFirmwareUpdater::fwUpdate_step(fwUpdate::msg_types_e msg_type, bool proce
 bool ISFirmwareUpdater::fwUpdate_writeToWire(fwUpdate::target_t target, uint8_t *buffer, int buff_len) {
     // std::lock_guard<std::recursive_mutex> lock(mutex);
 
+    // Arm the pace BEFORE the local-device branch below returns. A device updater living in this
+    // process is still being sent to, and it is the one that most needs pacing: it accepts a message
+    // the instant it is handed one, so nothing else throttles the stream. Left after that early
+    // return, chunkDelay was computed, logged and never applied for ISB, DFU or any other in-process
+    // updater -- fwUpdate_step()'s gate stayed permanently open and chunks went out as fast as it was
+    // called. Measured before this: 7 chunks in 71ms against a 226ms derived delay.
+    nextChunkSend = current_timeMs() + chunkDelay; // give *at_least* enough time for the send buffer to actually transmit before we send the next message
+
     if (deviceUpdater != nullptr) {
         bool result = deviceUpdater->fwUpdate_processMessage(buffer, buff_len);
         if (!toHost.empty()) // check for any responses
@@ -753,8 +768,6 @@ bool ISFirmwareUpdater::fwUpdate_writeToWire(fwUpdate::target_t target, uint8_t 
         }
     }
     // TODO: end
-
-    nextChunkSend = current_timeMs() + chunkDelay; // give *at_least* enough time for the send buffer to actually transmit before we send the next message
 
     port_handle_t preferredPort = portIsOpened(device->port) ? device->port : (portIsOpened(port) ? port : nullptr);
     int result = comManagerSendData(preferredPort, buffer, DID_FIRMWARE_UPDATE, buff_len, 0);
@@ -1313,11 +1326,22 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                 pingTimeoutExpires = 0;
             }
 
-            // Set useAlternateMD5 for legacy firmware compatibility (only needed for GPX 2.0.0)
-            if (target_devInfo && remoteDevInfo.firmwareVer[0] == 2 && remoteDevInfo.firmwareVer[1] == 0 && remoteDevInfo.firmwareVer[2] == 0)
+            // The deprecated alternate MD5 is for legacy GPX-1.0 firmware and nothing else.
+            //
+            // It must be opted into on POSITIVE evidence, never by default: the device side has no
+            // alternate path at all -- fwUpdate_handleChunk() always accumulates with the standard
+            // md5_update() -- so declaring an alternate hash guarantees ERR_CHECKSUM_MISMATCH for
+            // every target that does not implement it. Defaulting to it for an unreadable version was
+            // therefore not "safe"; it turned a failed version probe into a failed update, which is
+            // how a directly-attached Septentrio failed after transferring all 2.95 MB correctly
+            // (SN-8553).
+            const bool isGpx10 = target_devInfo &&
+                                 (remoteDevInfo.hardwareType == IS_HARDWARE_TYPE_GPX) &&
+                                 (remoteDevInfo.hardwareVer[0] == 1) && (remoteDevInfo.hardwareVer[1] == 0);
+            const bool fwAtMost20 = (remoteDevInfo.firmwareVer[0] < 2) ||
+                                    ((remoteDevInfo.firmwareVer[0] == 2) && (remoteDevInfo.firmwareVer[1] == 0));
+            if (isGpx10 && fwAtMost20)
                 flags |= fwUpdate::IMG_FLAG_useAlternateMD5;
-            else if (!target_devInfo)
-                flags |= fwUpdate::IMG_FLAG_useAlternateMD5;  // unknown version, use alternate MD5 for safety
         }
 
         // If the target is a MAIN MCU in bootloader mode, the app firmware version is

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -640,7 +640,15 @@ private:
     static const uint16_t CHUNK_DELAY_BASE_MS  = 5;          //!< default starting delay and decay floor; see startingChunkDelay()
     static const uint32_t CXD_FRAME_BYTES      = 4086;       //!< a Sony CXD5610 firmware frame; see startingChunkDelay()
     static const uint32_t CXD_FRAME_MS         = 50;         //!< and what one costs it: ~44ms on the 921600-baud update link, plus the acknowledgement
-    static const uint16_t CHUNK_DELAY_MAX_MS   = 50;         //!< ceiling for the backoff
+    /**
+     * Ceiling for the backoff.
+     *
+     * Generous on purpose: this mechanism exists for the target that needs an unusual pace, and a
+     * ceiling set near the common case silently becomes the pace. At 50 ms a 512-byte chunk over a
+     * 115200 link -- which needs 44.4 ms -- reached the cap almost immediately and had nowhere left to
+     * go, so a device still asking to slow down could not be accommodated.
+     */
+    static const uint16_t CHUNK_DELAY_MAX_MS   = 1000;
     static const uint16_t CHUNK_RAISE_PERCENT  = 10;         //!< margin above the measured rate, on REASON_TOO_FAST
     static const uint16_t CHUNK_DECAY_PERCENT  = 5;          //!< taken off the delay at each decay step
     static const uint16_t CHUNK_DECAY_CHUNKS   = 100;        //!< chunks sent without a resend before the delay decays

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -995,8 +995,18 @@ bool InertialSense::OpenPorts(const char* portPattern, int baudRate, uint16_t fi
         // taking the two in that order here and the opposite order elsewhere is how a deadlock starts.
         for (auto port : ports)
         {
-            if (deviceManager.getDevice(port) == nullptr)
-                deviceManager.registerNewDevice(port);
+            if (deviceManager.getDevice(port) != nullptr)
+                continue;
+
+            device_handle_t device = deviceManager.registerNewDevice(port);
+            if (device)
+            {
+                // A caller that disabled validation is saying the far end may not speak ISB at all, so
+                // the device must not keep trying to identify itself: each attempt writes probe traffic
+                // to the link and consumes what comes back, which on a port whose data belongs to
+                // something else takes the bytes that reader was waiting for.
+                device->disableValidation();
+            }
         }
 
         log_info(IS_LOG_FACILITY_NONE, "Device validation disabled; bound %lu unvalidated device(s) to %lu port(s).",

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -971,6 +971,37 @@ bool InertialSense::OpenPorts(const char* portPattern, int baudRate, uint16_t fi
             log_error(IS_LOG_FACILITY_NONE, "Timeout waiting to validate %lu ports: %s.", portsToValidate.size(), names.c_str());
         }
     }
+    else
+    {
+        // Validation disabled: bind a device to each port without probing it.
+        //
+        // An ISDevice wraps a port for ISB comms; it does not require the far end to speak ISB, and a
+        // caller that asked not to validate still needs devices to address -- DeviceCount() is what
+        // most consumers gate on, and this function already reports success on ports alone when
+        // validation is off. Without this, Open() succeeds while every device-based consumer sees
+        // nothing, which is indistinguishable from a dead link.
+        //
+        // registerNewDevice() allocates through the registered factories and binds the device to the
+        // port with an unknown hardware id, which is all an unprobed port can honestly claim. It also
+        // registers directly rather than through registerDevice(), whose de-duplication keys on
+        // hardware id and serial number -- both of which are unset here, so every port after the
+        // first would otherwise be discarded as a duplicate.
+        std::vector<port_handle_t> ports;
+        for (auto port : portManager.locked_range())
+            ports.push_back(port);
+
+        // The ports are collected before registering rather than registered inside the iteration: the
+        // range holds the PortManager mutex and registerNewDevice() takes the DeviceManager's, and
+        // taking the two in that order here and the opposite order elsewhere is how a deadlock starts.
+        for (auto port : ports)
+        {
+            if (deviceManager.getDevice(port) == nullptr)
+                deviceManager.registerNewDevice(port);
+        }
+
+        log_info(IS_LOG_FACILITY_NONE, "Device validation disabled; bound %lu unvalidated device(s) to %lu port(s).",
+                 deviceManager.size(), portManager.size());
+    }
 
     // request extended device info for remaining connected devices...
     for (auto device : deviceManager) {

--- a/src/protocol/FirmwareUpdate.cpp
+++ b/src/protocol/FirmwareUpdate.cpp
@@ -492,6 +492,7 @@ namespace fwUpdate {
     bool FirmwareUpdateDevice::fwUpdate_resetEngine() {
         resend_count = 0;
         pause_requested = false;
+        slowdown_requested = false;   // nor does a slowdown request
         chunks_held = false;  // a hold belonging to the previous session does not gate this one
         resend_pending_id = CHUNK_ID_PAUSE;
         resend_stragglers = 0;
@@ -635,7 +636,17 @@ namespace fwUpdate {
             if (pause_requested) {
                 pause_requested = false;
                 fwUpdate_sendRetryFrom(CHUNK_ID_PAUSE, REASON_TOO_FAST);
+            } else if (slowdown_requested) {
+                // Naming a real chunk rather than CHUNK_ID_PAUSE is what makes the host MEASURE the
+                // rate it achieved and pace itself to it from then on, instead of holding and asking
+                // again next chunk. For a device limited by a rate rather than by an event, that is
+                // the difference between one message and one per chunk for the rest of the transfer.
+                slowdown_requested = false;
+                fwUpdate_sendRetryFrom(last_chunk_id + 1, REASON_TOO_FAST);
             } else {
+                // Neither was asked for, so this is a real write failure. Note REASON_WRITE_ERROR
+                // counts toward the host's give-up accounting, which REASON_TOO_FAST deliberately
+                // does not -- a device that means "not yet" must say so with one of the two above.
                 fwUpdate_sendRetry(REASON_WRITE_ERROR);
             }
             return false;

--- a/src/protocol/FirmwareUpdate.h
+++ b/src/protocol/FirmwareUpdate.h
@@ -472,6 +472,7 @@ namespace fwUpdate {
         uint32_t timeout_duration = 20000;                      //!< the number of millis without any messages, by which we determine a timeout has occurred.  TODO: Should we prod the device (with a required response) at regular multiples of this to effect a keep-alive?
         uint32_t resend_count = 0;                              //!< the number of times a request was sent/received to resend a chunk. This provides an error rate mechanism; Ideal is < 1% of total packets.
         bool pause_requested = false;                           //!< device side: the next auto-retry should ask the host to pause (see fwUpdate_requestChunkPause())
+        bool slowdown_requested = false;                        //!< device side: the next auto-retry should ask the host to send more slowly (see fwUpdate_requestSlowdown())
 
         /**
          * Device side: the host has been asked to hold and has not been resumed yet.
@@ -808,6 +809,27 @@ namespace fwUpdate {
          * bytes the device never stored, and this is what stops it retrying in a tight loop meanwhile.
          */
         void fwUpdate_requestChunkPause() { pause_requested = true; }
+
+        /**
+         * Asks the host to keep sending, but more slowly, and to work out how much more slowly itself.
+         *
+         * Call this from fwUpdate_writeImageChunk() instead of fwUpdate_requestChunkPause() when the
+         * limit is a RATE rather than an event -- a fixed buffer draining at a fixed speed, as opposed
+         * to a frame the device has to acknowledge before it can take the next. The host measures the
+         * rate it actually achieved and paces every subsequent chunk to it, so one request buys a
+         * sustained rate and the device is not consulted again per chunk. A pause, by contrast, costs a
+         * device-to-host message every cycle and leaves the host's pace untouched.
+         *
+         * Which to use is a property of the device, not a preference: measuring an event-driven wait
+         * would fold the acknowledgement into ms/chunk and ratchet the delay to its ceiling, while
+         * pausing on a rate limit re-pays the round trip forever. A device with a knowable rate wants
+         * this one.
+         *
+         * Still return a retryable status, for the same reason fwUpdate_requestChunkPause() does: the
+         * status is what stops the host advancing its chunk counter and hashing bytes that were never
+         * stored.
+         */
+        void fwUpdate_requestSlowdown() { slowdown_requested = true; }
 
         /**
          * Lifts a pause, resuming from @a chunk_id.


### PR DESCRIPTION
The SDK half of SN-8553. Pairs with **inertialsense/imx#1677** and **inertialsense/is-imx#45**, and should merge first.

Five changes, each independently useful.

## `fwUpdate`: let a device ask the host to slow down, not just to stop

`fwUpdate_handleChunk()` could only emit `CHUNK_ID_PAUSE` + `REASON_TOO_FAST` (a hold) or `REASON_WRITE_ERROR` when refusing a chunk. There was no counterpart to `fwUpdate_requestChunkPause()` for the *delay* form, so a device whose constraint is a steady rate rather than an episodic wait could not express it — and falling back on `REASON_WRITE_ERROR` is actively harmful: it takes the crude `chunkDelay × 1.5` branch, forfeits decay progress, and **counts toward `MAX_SAME_CHUNK_RESENDS`**, so 25 refusals of one chunk inside 5 s fails the upload with `ERR_FLASH_WRITE_FAILURE`.

Adds `slowdown_requested`, a protected `fwUpdate_requestSlowdown()`, and a third arm in the refusal branch, symmetric with the existing pause flag.

## `fwUpdate`: apply the derived chunk pace

`nextChunkSend` was armed *after* the local-device early return in `fwUpdate_writeToWire()`, so for any in-process updater the send gate was permanently open and `chunkDelay` had no effect at all — the host ignored every pace it derived. Moved to the top of the function, before the early return.

The `REASON_TOO_FAST` handler also sent the next chunk immediately instead of scheduling it; it now schedules and returns, which is what lets the derivation converge. Measured settling after the fix: 5 requests, 13 → 25 → 33 → 41 → 48 ms, arriving at the analytic rate for the link.

## `fwUpdate`: stop defaulting to the obsolete alternate MD5

`IMG_FLAG_useAlternateMD5` was selected whenever the target's running version could not be read — "for safety" — but no current device computes that hash, so the transfer failed its integrity check at the end having delivered every byte correctly. A version probe that merely timed out was enough to trigger it.

Now requires what actually needs it: a GPX-1.0 running firmware at or below 2.0. Everything else uses the standard MD5.

## `ISDevice`: let a device be told never to validate

A receiver reached through a module, or an IMX in bridge mode, is a legitimate `ISDevice` bound to a port that never carries anything the ISB parser recognises. Validation could not be switched off, so such a device was refused before any command reached it.

Adds `doNotValidate` with `disableValidation()` / `validationDisabled()`, guarded at the top of **both** `validateAsync()` and `validate()`, and `InertialSense` binds an unvalidated device via `registerNewDevice()` when validation is disabled. `COMM_PORT_FLAG__EXPLICIT_READ` does not cover this — it only stops `is_comm_port_parse_messages()` reading the port, which is a different concern.

## `ISComm`: complete `ptype_names[]`

The table was short of `_PTYPE_SIZE`, so `SEPT_SBF` and `SEPT_REPLY` printed as garbage in parse-debug output — read as protocol corruption more than once.

## Validation

Exercised end to end by the two paired PRs: `cltool -uf-cmd target=SEPT,upload=…` installs a 2.95 MB image into a Septentrio mosaic-G5 through an IMX-6 and confirms it (`2951096/2951096` bytes, `FINISHED`, 81.4 s), and directly against a receiver on a USB-UART. 159/159 `is-common` unit tests pass.

`origin/3.1.0-rc` is merged in (`Remove eImx6ImuPopulationType enum definition`, `data_sets.h`), so this is current with its base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)