### PR TITLE
SN-8608: render platform type and IMX io-config in device descriptions

### DIFF
--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -797,7 +797,17 @@ std::string ISDevice::getName(const dev_info_t &devInfo, int flags) {
 }
 
 std::string ISDevice::getName(int flags) const {
-    return getName(devInfo, flags);
+    std::string out = getName(devInfo, flags);
+
+    // The carrier board belongs with the hardware it qualifies, so it goes inside the same parens.
+    // Only an instance can render it: the platform is held in flash config, not devInfo, and an
+    // unsynchronized flash config has not been read from the device and so describes nothing.
+    if ((flags & SHOW_PLATFORM) && (imxFlashCfg.checksum != 0xFFFFFFFF)) {
+        std::string platform = utils::platformDescription(imxFlashCfg.platformConfig, flags);
+        if (!platform.empty() && !out.empty() && (out.back() == ')'))
+            out.insert(out.size() - 1, ", " + platform);
+    }
+    return out;
 }
 
 /**
@@ -828,6 +838,15 @@ std::string ISDevice::getFirmwareInfo(int flags) const {
     return getFirmwareInfo(devInfo, flags);
 }
 
+std::string ISDevice::getDescription(const dev_info_t& devInfo, int flags) {
+    // No port, platform or io configuration here: a dev_info_t carries none of them, so this is the
+    // name and firmware only. The instance overload adds the rest.
+    std::string desc = getName(devInfo, flags);
+    if (!(flags & OMIT_FIRMWARE_VERSION))
+        desc += " " + getFirmwareInfo(devInfo, flags);
+    return desc;
+}
+
 std::string ISDevice::getDescription(int flags) const {
     std::string desc = getName(flags);
     if (!(flags & OMIT_FIRMWARE_VERSION)) {
@@ -835,6 +854,16 @@ std::string ISDevice::getDescription(int flags) const {
     }
     if (!(flags & OMIT_PORT_NAME) && portIsValid(port))
         desc += ", " + getPortName() + (isConnected() ? "" : " (Closed)");
+
+    // After the port, so the port and its connection state stay adjacent. Renders nothing unless
+    // the configuration differs from what this device's platform implies, which keeps it absent on
+    // a device configured as its carrier intends. A GPX has no ioConfig, and its imxFlashCfg is
+    // never synchronized, so the checksum gate covers that too.
+    if ((flags & SHOW_IO_CONFIG) && (imxFlashCfg.checksum != 0xFFFFFFFF)) {
+        std::string io = utils::ioConfigDescription(imxFlashCfg.ioConfig, imxFlashCfg.ioConfig2, imxFlashCfg.platformConfig, flags);
+        if (!io.empty())
+            desc += " [" + io + "]";
+    }
     return desc;
 }
 

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -95,6 +95,11 @@ public:
         COMPACT_HARDWARE_VER     = 0x0004,      //!< forces hiding digits 3 & 4 of the hardware version number, digits 1 & 2 are always shown
         COMPACT_SERIALNO         = 0x0008,      //!< disables zero-padding of the serial number
         COMPACT_BUILD_TYPE       = utils::FWI_COMPACT_BUILD_TYPE, //!< formats the build-type (when the firmware version is show) as a single character
+        SHOW_PLATFORM            = 0x0020,      //!< renders the carrier board, from flash config, inside the hardware parens: "SN60246 (IMX-5.0.4, RUG4-X20)". Instance methods only -- see the note on the static overloads
+        SHOW_IO_CONFIG           = 0x0040,      //!< renders the IMX io configuration after the port, bracketed, showing only what deviates from the platform's own configuration. Instance methods only
+
+        // Config Options -- aliases of the utils bits, so the two definitions cannot drift
+        CONFIG_VERBOSE           = utils::CFGI_VERBOSE,           //!< with SHOW_PLATFORM/SHOW_IO_CONFIG, renders every field rather than only deviations, and includes the pin-level detail
 
         // Version Options -- aliases of the utils bits, so the two definitions cannot drift
         OMIT_COMMIT_HASH         = utils::FWI_OMIT_COMMIT_HASH,   //!< suppresses the output of the commit hash/dirty status
@@ -110,9 +115,17 @@ public:
 
     /** @return the formatted unique-identifier string (see getIdAsString()) for the given devInfo, without requiring an ISDevice instance. */
     static std::string getIdAsString(const dev_info_t& devInfo);
-    /** @brief Formats the device-name string (see getName()) for the given devInfo, without requiring an ISDevice instance. @param devInfo the device info to format @param flags a DevInfoFormatFlags bitmask @return the formatted name string */
+    /**
+     * @brief Formats the device-name string (see getName()) for the given devInfo, without requiring an ISDevice instance.
+     * SHOW_PLATFORM has no effect here: the platform is held in flash config, which a dev_info_t does not carry.
+     * @param devInfo the device info to format @param flags a DevInfoFormatFlags bitmask @return the formatted name string
+     */
     static std::string getName(const dev_info_t& devInfo, int flags = (COMPACT_SERIALNO | COMPACT_HARDWARE_VER));
-    /** @brief Formats the device-description string (see getDescription()) for the given devInfo, without requiring an ISDevice instance. @param devInfo the device info to format @param flags a DevInfoFormatFlags bitmask @return the formatted description string */
+    /**
+     * @brief Formats the device-description string (see getDescription()) for the given devInfo, without requiring an ISDevice instance.
+     * SHOW_PLATFORM and SHOW_IO_CONFIG have no effect here: both are held in flash config, which a dev_info_t does not carry.
+     * @param devInfo the device info to format @param flags a DevInfoFormatFlags bitmask @return the formatted description string
+     */
     static std::string getDescription(const dev_info_t& devInfo, int flags = (COMPACT_SERIALNO | COMPACT_HARDWARE_VER | ESSENTIAL_FIRMWARE_INFO));
     /** @brief Formats the firmware-info string (see getFirmwareInfo()) for the given devInfo, without requiring an ISDevice instance. @param devInfo the device info to format @param flags a DevInfoFormatFlags bitmask @return the formatted firmware-info string */
     static std::string getFirmwareInfo(const dev_info_t &devInfo, int flags = 0);

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -17,6 +17,7 @@
 // #include <acc_prof.h>
 
 #include "ISDataMappings.h"
+#include "imx_defaults.h"
 #include "util/uri.hpp"
 
 
@@ -1199,4 +1200,227 @@ std::string utils::globToRegex(const std::string& globs) {
     }
 
     return pattern.empty() ? "(.+)" : pattern;
+}
+
+/** Bit groups of ioConfig/ioConfig2 that render as a single token, so a changed subfield renders its whole group. */
+#define IOCFG_GNSS1_GROUP  ((uint32_t)((IO_CONFIG_GNSS_TYPE_MASK << IO_CONFIG_GNSS1_TYPE_OFFSET) | (IO_CONFIG_GNSS_SOURCE_MASK << IO_CONFIG_GNSS1_SOURCE_OFFSET) | IO_CFG_GNSS1_PPS_SOURCE_BITMASK | IO_CONFIG_GNSS1_NO_INIT))
+#define IOCFG_GNSS2_GROUP  ((uint32_t)((IO_CONFIG_GNSS_TYPE_MASK << IO_CONFIG_GNSS2_TYPE_OFFSET) | (IO_CONFIG_GNSS_SOURCE_MASK << IO_CONFIG_GNSS2_SOURCE_OFFSET) | IO_CONFIG_GNSS2_NO_INIT))
+#define IOCFG2_GNSS2_GROUP ((uint8_t)(IO_CFG2_GNSS2_PPS_SOURCE_BITMASK | IO_CFG2_USE_GNSS2_AS_SOURCE))
+
+const char* utils::platformTypeName(uint8_t platformType) {
+    switch (platformType) {
+        case PLATFORM_CFG_TYPE_NONE:                return "none";
+        case PLATFORM_CFG_TYPE_BRK_GPX:             return "BRK-GPX";
+        case PLATFORM_CFG_TYPE_BRK_2_X20:           return "BRK-X20";
+        case PLATFORM_CFG_TYPE_BRK_2_SG5:           return "BRK-SG5";
+        case PLATFORM_CFG_TYPE_RUG4_X20:            return "RUG4-X20";
+        case PLATFORM_CFG_TYPE_RUG4_SG5:            return "RUG4-SG5";
+        case PLATFORM_CFG_TYPE_RUG4_GPX:            return "RUG4-GPX";
+        case PLATFORM_CFG_TYPE_RUGn_G0:             return "RUGn-G0";
+        case PLATFORM_CFG_TYPE_RUG3_G1:             return "RUG3-G1";
+        case PLATFORM_CFG_TYPE_RUG3_G2:             return "RUG3-G2";
+        case PLATFORM_CFG_TYPE_EVB2_G2:             return "EVB2-G2";
+        case PLATFORM_CFG_TYPE_TBED3:               return "TBED3";
+        case PLATFORM_CFG_TYPE_IG1_0_G2:            return "IG1.0-G2";
+        case PLATFORM_CFG_TYPE_IG1_G1:              return "IG1.1-G1";
+        case PLATFORM_CFG_TYPE_IG1_G2:              return "IG1.1-G2";
+        case PLATFORM_CFG_TYPE_IG2:                 return "IG2";
+        case PLATFORM_CFG_TYPE_LAMBDA_G1:           return "LAMBDA-G1";
+        case PLATFORM_CFG_TYPE_LAMBDA_G2:           return "LAMBDA-G2";
+        case PLATFORM_CFG_TYPE_TBED2_G1_W_LAMBDA:   return "TBED2-G1-LAMBDA";
+        case PLATFORM_CFG_TYPE_TBED2_G2_W_LAMBDA:   return "TBED2-G2-LAMBDA";
+        case PLATFORM_CFG_TYPE_IG2_1:               return "IG2.1";
+        default:                                    return nullptr;   // includes 4, an unassigned gap
+    }
+}
+
+std::string utils::platformDescription(uint32_t platformConfig, int flags) {
+    uint8_t type = (uint8_t)(platformConfig & PLATFORM_CFG_TYPE_MASK);
+    if (type == PLATFORM_CFG_TYPE_NONE)
+        return std::string();
+
+    const char* name = platformTypeName(type);
+    std::string out = name ? name : string_format("PT-%u", (unsigned)type);
+
+    if (flags & CFGI_VERBOSE) {
+        uint8_t preset = (uint8_t)((platformConfig & PLATFORM_CFG_PRESET_MASK) >> PLATFORM_CFG_PRESET_OFFSET);
+        out += string_format(":%u", (unsigned)preset);
+        if (platformConfig & PLATFORM_CFG_TYPE_FROM_MANF_OTP)
+            out += " (OTP)";
+    }
+    return out;
+}
+
+/** @return the eIoConfig GNSS type name, or "Tn" for a value the enum does not define */
+static std::string gnssTypeName(uint32_t type) {
+    switch (type) {
+        case IO_CONFIG_GNSS_TYPE_NONE:          return "none";
+        case IO_CONFIG_GNSS_TYPE_UBLOX:         return "uBlox";
+        case IO_CONFIG_GNSS_TYPE_NMEA:          return "NMEA";
+        case IO_CONFIG_GNSS_TYPE_GPX:           return "GPX";
+        case IO_CONFIG_GNSS_TYPE_SEPTENTRIO:    return "Septentrio";
+        case IO_CONFIG_GNSS_TYPE_ISB:           return "ISB";
+        default:                                return utils::string_format("T%u", (unsigned)type);
+    }
+}
+
+/** @return the eIoConfig GNSS source name, or "Sn" for a value the enum does not define (1 and 2 are unassigned) */
+static std::string gnssSourceName(uint32_t source) {
+    switch (source) {
+        case IO_CONFIG_GNSS_SOURCE_DISABLE: return "off";
+        case IO_CONFIG_GNSS_SOURCE_SER0:    return "Ser0";
+        case IO_CONFIG_GNSS_SOURCE_SER1:    return "Ser1";
+        case IO_CONFIG_GNSS_SOURCE_SER2:    return "Ser2";
+        default:                            return utils::string_format("S%u", (unsigned)source);
+    }
+}
+
+/** @return the pin name carrying GNSS1's timepulse, or "Pn" for a value the enum does not define */
+static std::string pps1PinName(uint32_t src) {
+    switch (src) {
+        case IO_CFG_GNSS1_PPS_SOURCE_DISABLED:  return "off";
+        case IO_CFG_GNSS1_PPS_SOURCE_G15:       return "G15";
+        case IO_CFG_GNSS1_PPS_SOURCE_G2:        return "G2";
+        case IO_CFG_GNSS1_PPS_SOURCE_G5:        return "G5";
+        case IO_CFG_GNSS1_PPS_SOURCE_G12:       return "G12";
+        case IO_CFG_GNSS1_PPS_SOURCE_G9:        return "G9";
+        default:                                return utils::string_format("P%u", (unsigned)src);
+    }
+}
+
+/** @return the pin name carrying GNSS2's timepulse */
+static std::string pps2PinName(uint32_t src) {
+    switch (src) {
+        case IO_CFG2_GNSS2_PPS_SOURCE_DISABLED: return "off";
+        case IO_CFG2_GNSS2_PPS_SOURCE_G8:       return "G8";
+        case IO_CFG2_GNSS2_PPS_SOURCE_G11:      return "G11";
+        case IO_CFG2_GNSS2_PPS_SOURCE_G13:      return "G13";
+        default:                                return utils::string_format("P%u", (unsigned)src);
+    }
+}
+
+std::string utils::ioConfigDescription(uint32_t ioConfig, uint8_t ioConfig2, uint32_t platformConfig, int flags) {
+    // The baseline the platform implies. IO_CONFIG_DEFAULT first, because the mapper is an overlay
+    // that sets only the platform-derived GNSS fields -- the same order nvm_flash_cfg_defaults()
+    // uses. Without the seed, the pin-function fields of a stock board read as deviations.
+    uint32_t baseIo = IO_CONFIG_DEFAULT;
+    uint8_t baseIo2 = 0;
+    imxPlatformConfigToFlashCfgIoConfig(&baseIo, &baseIo2, platformConfig);
+
+    const bool verbose = (flags & CFGI_VERBOSE) != 0;
+    const uint32_t deltaIo = ioConfig ^ baseIo;
+    const uint8_t deltaIo2 = (uint8_t)(ioConfig2 ^ baseIo2);
+    std::vector<std::string> parts;
+
+    const uint32_t g1type = IO_CONFIG_GNSS1_TYPE(ioConfig);
+    const uint32_t g2type = IO_CONFIG_GNSS2_TYPE(ioConfig);
+
+    if (verbose && (g1type == IO_CONFIG_GNSS_TYPE_NONE) && (g2type == IO_CONFIG_GNSS_TYPE_NONE))
+        parts.push_back("no GNSS");
+
+    if (verbose || (deltaIo & IOCFG_GNSS1_GROUP)) {
+        if (verbose || (g1type != IO_CONFIG_GNSS_TYPE_NONE)) {
+            std::string s = "GNSS1=" + gnssTypeName(g1type) + "@" + gnssSourceName(IO_CONFIG_GNSS1_SOURCE(ioConfig));
+            uint32_t pps = IO_CFG_GNSS1_PPS_SOURCE(ioConfig);
+            if (verbose || (pps != IO_CFG_GNSS1_PPS_SOURCE_DISABLED))
+                s += " PPS1=" + pps1PinName(pps);
+            if (ioConfig & IO_CONFIG_GNSS1_NO_INIT)
+                s += " no-init";
+            parts.push_back(s);
+        }
+    }
+
+    if (verbose || (deltaIo & IOCFG_GNSS2_GROUP) || (deltaIo2 & IOCFG2_GNSS2_GROUP)) {
+        if (verbose || (g2type != IO_CONFIG_GNSS_TYPE_NONE)) {
+            std::string s = "GNSS2=" + gnssTypeName(g2type) + "@" + gnssSourceName(IO_CONFIG_GNSS2_SOURCE(ioConfig));
+            uint32_t pps2 = IO_CFG2_GNSS2_PPS_SOURCE(ioConfig2);
+            if (verbose || (pps2 != IO_CFG2_GNSS2_PPS_SOURCE_DISABLED))
+                s += " PPS2=" + pps2PinName(pps2);
+            if (ioConfig & IO_CONFIG_GNSS2_NO_INIT)
+                s += " no-init";
+            if (ioConfig2 & IO_CFG2_USE_GNSS2_AS_SOURCE)
+                s += " nmea-src";
+            parts.push_back(s);
+        }
+    }
+
+    // SPI is selected by a value of the G5,G8 field and overrides G6,G7, so it renders as its own
+    // token and suppresses the G6,G7 one rather than printing a contradiction.
+    const bool spi = ((ioConfig & IO_CONFIG_G5G8_MASK) == IO_CONFIG_G5G8_G6G7_SPI_ENABLE);
+    const bool spiBase = ((baseIo & IO_CONFIG_G5G8_MASK) == IO_CONFIG_G5G8_G6G7_SPI_ENABLE);
+    if (verbose || (spi != spiBase)) {
+        if (spi)
+            parts.push_back("SPI");
+    }
+
+    if (verbose || (deltaIo & IO_CONFIG_G1G2_MASK)) {
+        const char* fn = "off";
+        switch (ioConfig & IO_CONFIG_G1G2_MASK) {
+            case IO_CONFIG_G1G2_STROBE_INPUT_G2:    fn = "strobe-G2"; break;
+            case IO_CONFIG_G1G2_CAN_BUS:            fn = "CAN";       break;
+            case IO_CONFIG_G1G2_COM2:               fn = "COM2";      break;
+            case IO_CONFIG_G1G2_I2C:                fn = "I2C";       break;
+            default: break;
+        }
+        parts.push_back(std::string("G1G2=") + fn);
+    }
+
+    if (!spi && (verbose || (deltaIo & IO_CONFIG_G6G7_MASK)))
+        parts.push_back(std::string("G6G7=") + (((ioConfig & IO_CONFIG_G6G7_MASK) == IO_CONFIG_G6G7_COM1) ? "COM1" : "off"));
+
+    if (verbose || (deltaIo & IO_CONFIG_G9_MASK)) {
+        const char* fn = "off";
+        switch (ioConfig & IO_CONFIG_G9_MASK) {
+            case IO_CONFIG_G9_STROBE_INPUT:         fn = "strobe-in"; break;
+            case IO_CONFIG_G9_STROBE_OUTPUT_NAV:    fn = "nav-out";   break;
+            case IO_CONFIG_G9_SPI_DRDY:             fn = "SPI-DRDY";  break;
+            default: break;
+        }
+        parts.push_back(std::string("G9=") + fn);
+    }
+
+    // Pin-level detail below is VERBOSE-only: a strobe or encoder difference is rarely what a reader
+    // of a device description is after, and including it crowds out the GNSS routing that usually is.
+    if (verbose) {
+        const char* g5g8 = "off";
+        switch (ioConfig & IO_CONFIG_G5G8_MASK) {
+            case IO_CONFIG_G5G8_STROBE_INPUT_G5:    g5g8 = "strobe-G5";    break;
+            case IO_CONFIG_G5G8_STROBE_INPUT_G8:    g5g8 = "strobe-G8";    break;
+            case IO_CONFIG_G5G8_STROBE_INPUT_G5_G8: g5g8 = "strobe-G5+G8"; break;
+            case IO_CONFIG_G5G8_G6G7_SPI_ENABLE:    g5g8 = "SPI";          break;
+            case IO_CONFIG_G5G8_QDEC_INPUT:         g5g8 = "QDEC";         break;
+            default: break;
+        }
+        parts.push_back(std::string("G5G8=") + g5g8);
+        parts.push_back(std::string("G15=") + ((ioConfig & IO_CONFIG_G15_STROBE_INPUT) ? "strobe-in" : "off"));
+        parts.push_back(std::string("strobe=") + ((ioConfig & IO_CONFIG_STROBE_TRIGGER_HIGH) ? "rising" : "falling"));
+        parts.push_back(std::string("G11=") + (((ioConfig2 >> IO_CFG2_G11_OFFSET) & IO_CFG2_G11_MASK) ? "strobe-in" : "SWDIO"));
+        parts.push_back(string_format("G12=%u", (unsigned)((ioConfig2 >> IO_CFG2_G12_OFFSET) & IO_CFG2_G12_MASK)));
+        parts.push_back(string_format("G13=%u", (unsigned)((ioConfig2 >> IO_CFG2_G13_OFFSET) & IO_CFG2_G13_MASK)));
+        // Marked unresolved: this field is an input only when no preset is selected, and nothing
+        // keeps it in step with an active preset.
+        parts.push_back(string_format("ioexp~0x%02X",
+            (unsigned)((platformConfig & PLATFORM_CFG_RUG_IOEXP_BIT_MASK) >> PLATFORM_CFG_RUG_IOEXP_BIT_OFFSET)));
+    }
+
+    std::string out;
+    for (size_t i = 0; i < parts.size(); i++)
+        out += (i ? ", " : "") + parts[i];
+    return out;
+}
+
+std::string utils::imxConfigDescription(const nvm_flash_cfg_t& cfg, int flags) {
+    // An unsynchronised flash config has not been read from the device, so none of its fields
+    // describe anything yet.
+    if (cfg.checksum == 0xFFFFFFFF)
+        return std::string();
+
+    std::string out = platformDescription(cfg.platformConfig, flags);
+    std::string io = ioConfigDescription(cfg.ioConfig, cfg.ioConfig2, cfg.platformConfig, flags);
+    if (!io.empty()) {
+        if (!out.empty())
+            out += " ";
+        out += "[" + io + "]";
+    }
+    return out;
 }

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -178,28 +178,31 @@ std::string utils::getCurrentTimestamp(uint32_t opts) {
  */
 
 std::string utils::raw_hexdump(const char* raw_data, int bytesLen, int bytesPerLine) {
-    char buf[2048];
-    char* ptrEnd = buf + 2048;
-    char* ptr = buf;
+    if ((raw_data == nullptr) || (bytesLen <= 0) || (bytesPerLine <= 0))
+        return std::string();
 
-#if DISPLAY_DELTA_TIME==1
-    static double lastTime[2] = { 0 };
-    double dtMs = 1000.0*(wheel.timeOfWeek - lastTime[i]);
-    lastTime[i] = wheel.timeOfWeek;
-    ptr += SNPRINTF(ptr, ptrEnd - ptr, " %4.1lfms", dtMs);
-#else
-#endif
-    int lines = (bytesLen / bytesPerLine) + (bytesLen % bytesPerLine > 0 ? 1 : 0);
-    for (int j = 0; j < lines; j++) {
-        int linelen = (j == lines-1) ? bytesLen % bytesPerLine : bytesPerLine;
-        ptr += SNPRINTF(ptr, ptrEnd - ptr, "    ");
-        for (int i = 0; i < linelen; i++) {
-            ptr += SNPRINTF(ptr, ptrEnd - ptr, "%02x ", (uint8_t)raw_data[(j * bytesPerLine) + i]);
+    // Accumulated into the returned string rather than a fixed buffer: the output length is a
+    // function of bytesLen, which the caller chooses, so any fixed size is a cap this signature
+    // gives no way to report. Callers dump whole packets and comparison windows, which routinely
+    // run to hundreds of bytes.
+    std::string out;
+    out.reserve((size_t)((bytesLen / bytesPerLine) + 1) * (size_t)((bytesPerLine * 3) + 5));
+
+    for (int i = 0; i < bytesLen; i += bytesPerLine) {
+        // Length of THIS line, so a bytesLen that is an exact multiple of bytesPerLine still emits
+        // its final full line.
+        const int lineLen = ((bytesLen - i) < bytesPerLine) ? (bytesLen - i) : bytesPerLine;
+        char hex[4];    //!< "ff " plus the terminator
+
+        out += "    ";
+        for (int j = 0; j < lineLen; j++) {
+            SNPRINTF(hex, sizeof(hex), "%02x ", (uint8_t)raw_data[i + j]);
+            out += hex;
         }
-        ptr += SNPRINTF(ptr, ptrEnd - ptr, "\n");
+        out += "\n";
     }
 
-    return std::string(buf);
+    return out;
 }
 
 /**

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -363,6 +363,76 @@ namespace utils {
     std::string getFirmwareInfoAsString(const dev_info_t& devInfo, uint16_t flags = 0);
 
     /**
+     * Bits controlling the platform/io-config renderers below. Canonical here, in the same 16-bit
+     * space as devFirmwareInfoFlags_e; ISDevice::DevInfoFormatFlags aliases these so the two cannot
+     * drift, and the values are fixed because callers pass them.
+     */
+    enum devConfigInfoFlags_e : uint16_t {
+        CFGI_VERBOSE = 0x0080,  //!< render every field rather than only those deviating from the platform baseline, and include the pin-level detail
+    };
+
+    /**
+     * @param platformType a platform/carrier type, already masked with PLATFORM_CFG_TYPE_MASK
+     * @return the canonical short name for the type (e.g. "RUG4-X20"), or nullptr when the value is
+     *   not a defined ePlatformConfig type -- note that 4 is an unassigned gap in that enum
+     */
+    const char* platformTypeName(uint8_t platformType);
+
+    /**
+     * Renders the carrier board a device is configured as, from nvm_flash_cfg_t::platformConfig.
+     *
+     * Sourced from flash config rather than manufacturing OTP because flash config is what the
+     * firmware runs on, and it can differ from the OTP value. An undefined type renders "PT-nn" so
+     * an unrecognised board is still identifiable rather than silently dropped.
+     *
+     * The carrier-specific preset id is not rendered: it selects an io configuration, and the
+     * resulting ioConfig -- which ioConfigDescription() renders -- is the observable that matters.
+     * Neither is the RUG I/O-expander field, which is only an input when no preset is selected and
+     * which nothing keeps in sync with an active preset.
+     *
+     * @param platformConfig nvm_flash_cfg_t::platformConfig
+     * @param flags a devConfigInfoFlags_e bitmask; CFGI_VERBOSE also renders the preset id and
+     *   whether the type is write-protected from OTP
+     * @return the rendered name, or an empty string for PLATFORM_CFG_TYPE_NONE
+     */
+    std::string platformDescription(uint32_t platformConfig, int flags = 0);
+
+    /**
+     * Renders the IMX io configuration, from nvm_flash_cfg_t::ioConfig and ::ioConfig2.
+     *
+     * By default only fields DEVIATING from what the platform implies are rendered, so a board
+     * configured as its carrier intends renders an empty string and anything present is a
+     * deliberate difference. Granularity is per group: when any field of a group differs, the whole
+     * group is rendered, because "GNSS2=uBlox@Ser0" reads better than a single changed subfield.
+     *
+     * The baseline is IO_CONFIG_DEFAULT overlaid by imxPlatformConfigToFlashCfgIoConfig(), matching
+     * the order nvm_flash_cfg_defaults() uses. That mapper only sets the platform-derived (GNSS)
+     * fields, so without the IO_CONFIG_DEFAULT seed the pin-function fields of every stock board
+     * would read as deviations.
+     *
+     * IMX only: gpx_flash_cfg_t has no ioConfig.
+     *
+     * @param ioConfig  nvm_flash_cfg_t::ioConfig
+     * @param ioConfig2 nvm_flash_cfg_t::ioConfig2, which carries GNSS2's timepulse source and the
+     *   G11-G13 pin functions
+     * @param platformConfig nvm_flash_cfg_t::platformConfig, supplying the comparison baseline
+     * @param flags a devConfigInfoFlags_e bitmask; CFGI_VERBOSE renders every field and the
+     *   pin-level detail
+     * @return the rendered configuration, or an empty string when nothing deviates
+     */
+    std::string ioConfigDescription(uint32_t ioConfig, uint8_t ioConfig2, uint32_t platformConfig, int flags = 0);
+
+    /**
+     * Renders the platform and io configuration of an IMX flash config together, as
+     * "<platform> [<ioConfig>]" with either part omitted when it renders empty.
+     * @param cfg the flash configuration to describe; an unsynchronised cfg (checksum
+     *   0xFFFFFFFF) describes nothing, since its fields have not been read from the device
+     * @param flags a devConfigInfoFlags_e bitmask
+     * @return the rendered string, empty when neither part has anything to say
+     */
+    std::string imxConfigDescription(const nvm_flash_cfg_t& cfg, int flags = 0);
+
+    /**
      * Renders the requested build-related fields of devInfo (commit hash, build key/number,
      * build date, build time) as a single delimited string, per the DV_BIT_ flags requested.
      * @param devInfo the dev_info_t supplying the build fields

--- a/tests/test_platform_ioconfig.cpp
+++ b/tests/test_platform_ioconfig.cpp
@@ -1,0 +1,220 @@
+/**
+ * @file test_platform_ioconfig.cpp
+ * @brief Platform and IMX io-configuration rendering: utils::platformTypeName/platformDescription/
+ *        ioConfigDescription/imxConfigDescription.
+ *
+ * The io renderer shows only what DEVIATES from the configuration its platform implies, so most of
+ * these cases assert an empty string -- a board configured as its carrier intends has nothing to say,
+ * and anything rendered is a deliberate difference.
+ *
+ * That comparison rests on one detail worth pinning: imxPlatformConfigToFlashCfgIoConfig() is an
+ * overlay that sets only the platform-derived GNSS fields, so the baseline must be seeded with
+ * IO_CONFIG_DEFAULT first. Without the seed the pin-function fields of every stock board read as
+ * deviations, which the StockBoardsRenderNothing cases below would catch.
+ *
+ * The five StockBoards/DeviatingBoards vectors are captured from real hardware (an IMX-5+GPX-1, an
+ * IMX-6+u-blox-X20 on a RUG-4, an IMX-6+Septentrio on a BRK, an IG-1.1 and an IG-2), which is why
+ * they cover Ser0/Ser2 sourcing, mixed sourcing, a non-zero ioConfig2 and CAN.
+ *
+ * No hardware, no ports -- rendering is pure computation.
+ */
+
+#include <gtest/gtest.h>
+
+#include "data_sets.h"
+#include "ISDevice.h"
+#include "util/util.h"
+
+namespace {
+
+/** Builds a synchronized flash config carrying just the fields these renderers read. */
+static nvm_flash_cfg_t makeCfg(uint32_t platformConfig, uint32_t ioConfig, uint8_t ioConfig2) {
+    nvm_flash_cfg_t cfg = {};
+    cfg.checksum = 0;                  // anything but 0xFFFFFFFF: synchronized
+    cfg.platformConfig = platformConfig;
+    cfg.ioConfig = ioConfig;
+    cfg.ioConfig2 = ioConfig2;
+    return cfg;
+}
+
+TEST(platform_ioconfig, PlatformTypeNames) {
+    EXPECT_STREQ("none",            utils::platformTypeName(PLATFORM_CFG_TYPE_NONE));
+    EXPECT_STREQ("BRK-GPX",         utils::platformTypeName(PLATFORM_CFG_TYPE_BRK_GPX));
+    EXPECT_STREQ("BRK-X20",         utils::platformTypeName(PLATFORM_CFG_TYPE_BRK_2_X20));
+    EXPECT_STREQ("BRK-SG5",         utils::platformTypeName(PLATFORM_CFG_TYPE_BRK_2_SG5));
+    EXPECT_STREQ("RUG4-X20",        utils::platformTypeName(PLATFORM_CFG_TYPE_RUG4_X20));
+    EXPECT_STREQ("RUG4-GPX",        utils::platformTypeName(PLATFORM_CFG_TYPE_RUG4_GPX));
+    EXPECT_STREQ("RUG3-G2",         utils::platformTypeName(PLATFORM_CFG_TYPE_RUG3_G2));
+    EXPECT_STREQ("IG1.0-G2",        utils::platformTypeName(PLATFORM_CFG_TYPE_IG1_0_G2));
+    EXPECT_STREQ("IG1.1-G2",        utils::platformTypeName(PLATFORM_CFG_TYPE_IG1_G2));
+    EXPECT_STREQ("IG2",             utils::platformTypeName(PLATFORM_CFG_TYPE_IG2));
+    EXPECT_STREQ("IG2.1",           utils::platformTypeName(PLATFORM_CFG_TYPE_IG2_1));
+    EXPECT_STREQ("TBED2-G1-LAMBDA", utils::platformTypeName(PLATFORM_CFG_TYPE_TBED2_G1_W_LAMBDA));
+
+    // 4 is an unassigned gap in ePlatformConfig, and anything at/after COUNT is undefined.
+    EXPECT_EQ(nullptr, utils::platformTypeName(4));
+    EXPECT_EQ(nullptr, utils::platformTypeName(PLATFORM_CFG_TYPE_COUNT));
+    EXPECT_EQ(nullptr, utils::platformTypeName(42));
+}
+
+TEST(platform_ioconfig, PlatformDescription) {
+    EXPECT_EQ("",          utils::platformDescription(PLATFORM_CFG_TYPE_NONE));
+    EXPECT_EQ("RUG4-X20",  utils::platformDescription(0x00760705));   // preset and ioexp are not rendered
+    EXPECT_EQ("IG2",       utils::platformDescription(0x00000090));   // nor is the OTP-lock bit
+    EXPECT_EQ("IG1.1-G2",  utils::platformDescription(0x0000008F));
+    EXPECT_EQ("BRK-SG5",   utils::platformDescription(0x00000003));
+
+    // An unrecognised type stays identifiable rather than being dropped.
+    EXPECT_EQ("PT-42",     utils::platformDescription(42));
+    EXPECT_EQ("PT-4",      utils::platformDescription(4));
+
+    // VERBOSE adds the preset id and the OTP write-protect.
+    EXPECT_EQ("RUG4-X20:7", utils::platformDescription(0x00760705, utils::CFGI_VERBOSE));
+    EXPECT_EQ("IG2:0 (OTP)", utils::platformDescription(0x00000090, utils::CFGI_VERBOSE));
+}
+
+// Captured from real boards; each is configured as its platform intends, so each renders nothing.
+TEST(platform_ioconfig, StockBoardsRenderNothing) {
+    EXPECT_EQ("", utils::ioConfigDescription(0x026D2040, 0x00, 0x00760705));  // RUG4-X20, preset 7
+    EXPECT_EQ("", utils::ioConfigDescription(0x06DB2046, 0x00, 0x00000090));  // IG2, OTP-locked
+    EXPECT_EQ("", utils::ioConfigDescription(0x06DB2046, 0x00, 0x00000010));  // IG2, unlocked
+}
+
+TEST(platform_ioconfig, DeviatingBoards) {
+    // IG-1.1 with G1,G2 turned off where the platform implies COM2.
+    EXPECT_EQ("G1G2=off", utils::ioConfigDescription(0x026B2040, 0x00, 0x0000008F));
+
+    // BRK-SG5 with CAN enabled on G1,G2. Its PPS2=G13 comes from ioConfig2 and matches the
+    // platform, so the GNSS2 group stays silent.
+    EXPECT_EQ("G1G2=CAN", utils::ioConfigDescription(0x091B2044, 0xC0, 0x00000003));
+}
+
+TEST(platform_ioconfig, GnssGroupsRenderWholeGroup) {
+    // Move GNSS2 off the RUG-4's Ser2. Only the source changed, but the whole group renders.
+    uint32_t io = 0x026D2040;
+    SET_IO_CFG_GNSS2_SOURCE(io, IO_CONFIG_GNSS_SOURCE_SER0);
+    EXPECT_EQ("GNSS2=uBlox@Ser0", utils::ioConfigDescription(io, 0x00, 0x00760705));
+
+    // A type change renders the group the same way.
+    io = 0x026D2040;
+    SET_IO_CFG_GNSS1_TYPE(io, IO_CONFIG_GNSS_TYPE_NMEA);
+    EXPECT_EQ("GNSS1=NMEA@Ser2 PPS1=G15", utils::ioConfigDescription(io, 0x00, 0x00760705));
+}
+
+TEST(platform_ioconfig, UnknownEnumValuesRenderNumerically) {
+    // Neither 1 nor 2 is a defined GNSS source, and types at/after 6 are undefined. Rendering the
+    // raw value keeps an unexpected configuration visible instead of silently dropping it.
+    uint32_t io = 0x026D2040;
+    SET_IO_CFG_GNSS1_TYPE(io, 6);
+    SET_IO_CFG_GNSS1_SOURCE(io, 2);
+    EXPECT_EQ("GNSS1=T6@S2 PPS1=G15", utils::ioConfigDescription(io, 0x00, 0x00760705));
+}
+
+TEST(platform_ioconfig, SpiSuppressesG6G7) {
+    // SPI is a value of the G5,G8 field and overrides G6,G7, so it renders as its own token and the
+    // G6,G7 one is withheld rather than printing a contradiction.
+    uint32_t io = 0x06DB2046;
+    io = (io & ~(uint32_t)IO_CONFIG_G5G8_MASK) | IO_CONFIG_G5G8_G6G7_SPI_ENABLE;
+    std::string out = utils::ioConfigDescription(io, 0x00, 0x00000090);
+    EXPECT_NE(std::string::npos, out.find("SPI"));
+    EXPECT_EQ(std::string::npos, out.find("G6G7"));
+}
+
+TEST(platform_ioconfig, VerboseRendersEveryField) {
+    std::string out = utils::ioConfigDescription(0x026D2040, 0x00, 0x00760705, utils::CFGI_VERBOSE);
+    // Matching fields appear under VERBOSE even though they are not deviations.
+    EXPECT_NE(std::string::npos, out.find("GNSS1=uBlox@Ser2 PPS1=G15"));
+    EXPECT_NE(std::string::npos, out.find("GNSS2=uBlox@Ser2"));
+    EXPECT_NE(std::string::npos, out.find("G6G7=COM1"));
+    // Pin detail is VERBOSE-only.
+    EXPECT_NE(std::string::npos, out.find("strobe="));
+    EXPECT_NE(std::string::npos, out.find("G15="));
+    EXPECT_NE(std::string::npos, out.find("ioexp~0x76"));
+
+    // A board with no GNSS says so under VERBOSE, and says nothing without it.
+    EXPECT_NE(std::string::npos,
+              utils::ioConfigDescription(IO_CONFIG_DEFAULT, 0x00, PLATFORM_CFG_TYPE_NONE,
+                                         utils::CFGI_VERBOSE).find("no GNSS"));
+    EXPECT_EQ("", utils::ioConfigDescription(IO_CONFIG_DEFAULT, 0x00, PLATFORM_CFG_TYPE_NONE));
+}
+
+TEST(platform_ioconfig, ImxConfigDescriptionCombinesBothParts) {
+    // Stock board: platform only, no io stanza.
+    EXPECT_EQ("RUG4-X20", utils::imxConfigDescription(makeCfg(0x00760705, 0x026D2040, 0x00)));
+
+    // Deviating board: both parts, io bracketed.
+    EXPECT_EQ("BRK-SG5 [G1G2=CAN]", utils::imxConfigDescription(makeCfg(0x00000003, 0x091B2044, 0xC0)));
+
+    // Bare module configured as a bare module: neither part has anything to say.
+    EXPECT_EQ("", utils::imxConfigDescription(makeCfg(PLATFORM_CFG_TYPE_NONE, IO_CONFIG_DEFAULT, 0x00)));
+
+    // An unsynchronised flash config has not been read from the device, so it describes nothing --
+    // even though its zeroed fields would otherwise render as deviations.
+    nvm_flash_cfg_t unsynced = makeCfg(0x00760705, 0x026D2040, 0x00);
+    unsynced.checksum = 0xFFFFFFFF;
+    EXPECT_EQ("", utils::imxConfigDescription(unsynced));
+}
+
+/** A device carrying a devInfo and a synchronized IMX flash config, with no port bound. */
+static ISDevice makeDevice(uint32_t platformConfig, uint32_t ioConfig, uint8_t ioConfig2) {
+    dev_info_t di = {};
+    di.hardwareType = IS_HARDWARE_TYPE_IMX;
+    di.hardwareVer[0] = 5;  di.hardwareVer[1] = 0;  di.hardwareVer[2] = 4;
+    di.serialNumber = 60246;
+    di.firmwareVer[0] = 3;  di.firmwareVer[1] = 1;  di.firmwareVer[2] = 0;
+
+    ISDevice dev(di);
+    dev.imxFlashCfg = makeCfg(platformConfig, ioConfig, ioConfig2);
+    return dev;
+}
+
+TEST(platform_ioconfig, ISDeviceFlagsDefaultOff) {
+    ISDevice dev = makeDevice(0x00000003, 0x091B2044, 0xC0);   // BRK-SG5 with CAN: plenty to say
+
+    // Nothing is added unless asked for, so existing output is untouched.
+    EXPECT_EQ("SN60246 (IMX-5.0.4)", dev.getName(ISDevice::COMPACT_SERIALNO));
+    EXPECT_EQ(std::string::npos, dev.getDescription(ISDevice::COMPACT_SERIALNO).find('['));
+    EXPECT_EQ(std::string::npos, dev.getDescription(ISDevice::COMPACT_SERIALNO).find("BRK"));
+}
+
+TEST(platform_ioconfig, ISDeviceShowPlatformSitsInsideTheParens) {
+    ISDevice dev = makeDevice(0x00760705, 0x026D2040, 0x00);   // stock RUG4-X20
+    EXPECT_EQ("SN60246 (IMX-5.0.4, RUG4-X20)",
+              dev.getName(ISDevice::COMPACT_SERIALNO | ISDevice::SHOW_PLATFORM));
+
+    // A stock board deviates in nothing, so asking for the io config adds no stanza.
+    EXPECT_EQ(std::string::npos,
+              dev.getDescription(ISDevice::COMPACT_SERIALNO | ISDevice::SHOW_IO_CONFIG).find('['));
+}
+
+TEST(platform_ioconfig, ISDeviceShowsBothWhenConfigDeviates) {
+    ISDevice dev = makeDevice(0x00000003, 0x091B2044, 0xC0);   // BRK-SG5, CAN on G1,G2
+    std::string out = dev.getDescription(ISDevice::COMPACT_SERIALNO | ISDevice::ESSENTIAL_FIRMWARE_INFO |
+                                         ISDevice::SHOW_PLATFORM | ISDevice::SHOW_IO_CONFIG);
+    EXPECT_NE(std::string::npos, out.find("(IMX-5.0.4, BRK-SG5)"));
+    EXPECT_NE(std::string::npos, out.find("[G1G2=CAN]"));
+}
+
+TEST(platform_ioconfig, ISDeviceRendersNothingWhenFlashConfigUnsynchronized) {
+    ISDevice dev = makeDevice(0x00000003, 0x091B2044, 0xC0);
+    dev.imxFlashCfg.checksum = 0xFFFFFFFF;
+
+    int flags = ISDevice::COMPACT_SERIALNO | ISDevice::SHOW_PLATFORM | ISDevice::SHOW_IO_CONFIG;
+    EXPECT_EQ("SN60246 (IMX-5.0.4)", dev.getName(flags));
+    EXPECT_EQ(std::string::npos, dev.getDescription(flags).find('['));
+}
+
+TEST(platform_ioconfig, StaticOverloadsIgnoreTheFlags) {
+    dev_info_t di = {};
+    di.hardwareType = IS_HARDWARE_TYPE_IMX;
+    di.hardwareVer[0] = 5;
+    di.serialNumber = 60246;
+
+    // A dev_info_t carries no flash config, so neither group is renderable from the statics.
+    int flags = ISDevice::COMPACT_SERIALNO | ISDevice::SHOW_PLATFORM | ISDevice::SHOW_IO_CONFIG;
+    EXPECT_EQ(ISDevice::getName(di, ISDevice::COMPACT_SERIALNO), ISDevice::getName(di, flags));
+    EXPECT_EQ(ISDevice::getDescription(di, ISDevice::COMPACT_SERIALNO),
+              ISDevice::getDescription(di, flags));
+}
+
+}  // namespace


### PR DESCRIPTION
Jira: [SN-8608](https://inertialsense.atlassian.net/browse/SN-8608)

A device description named the module but not the board it was on, so nothing in a log or test result said which hardware was targeted. On a bench carrying an IMX-5+GPX-1, an IMX-6+u-blox-X20 on a RUG-4 and an IMX-6+Septentrio on a BRK, those lines differed only by serial number.

Rendered from the five boards on my bench, through this code path:

```
SN63736     (IMX-5.0, IG1.1-G2) fw3.1.0 [G1G2=off]
SN942757193 (IMX-6.0, RUG4-X20) fw3.1.0
SN519465    (IMX-5.0, IG2)      fw3.1.0
SN942753848 (IMX-6.0, BRK-SG5)  fw3.1.0 [G1G2=CAN]
SN63809     (IMX-5.0, IG2)      fw3.1.0
```

Three stock boards are silent; the two that differ say how.

## What it adds

Four renderers in `utils`, plus `SHOW_PLATFORM` (0x0020) / `SHOW_IO_CONFIG` (0x0040) / `CONFIG_VERBOSE` in `ISDevice::DevInfoFormatFlags`:

```cpp
const char* platformTypeName(uint8_t platformType);
std::string platformDescription(uint32_t platformConfig, int flags = 0);
std::string ioConfigDescription(uint32_t ioConfig, uint8_t ioConfig2, uint32_t platformConfig, int flags = 0);
std::string imxConfigDescription(const nvm_flash_cfg_t& cfg, int flags = 0);
```

Both flags **default off**, so no existing description output changes.

## Design points worth a reviewer's attention

**Flash config, not OTP.** Both groups read only `nvm_flash_cfg_t` (`platformConfig`, `ioConfig`/`ioConfig2`), because flash config is what the firmware runs on and can differ from manufacturing OTP. OTP remains the ci_hdw fixture's business, for provenance and recovery.

**Deviation-only rendering.** The io stanza shows only fields differing from what the platform implies, at group granularity, so a correctly configured board renders nothing and anything printed is worth reading.

**The baseline must be seeded with `IO_CONFIG_DEFAULT`** before the overlay, matching `nvm_flash_cfg_defaults()`:

```cpp
uint32_t expected = IO_CONFIG_DEFAULT;  uint8_t expected2 = 0;
imxPlatformConfigToFlashCfgIoConfig(&expected, &expected2, platformConfig);
```

`imxPlatformConfigToFlashCfgIoConfig()` is an overlay, not a complete generator — it sets only the platform-derived GNSS fields. Without the seed, the pin-function fields of every stock board read as deviations. This was found by diffing the mapper against real boards, and `StockBoardsRenderNothing` pins it.

**Deliberately not rendered:** the carrier preset id (it only selects an io configuration; the resulting `ioConfig` is the observable) and the RUG I/O-expander field (an input only when no preset is selected, and `RUG.cpp` overrides `s_ioBits` from the preset table without writing back, so nothing keeps the field in step with an active preset).

**Static overloads.** The platform is rendered by the instance `getName()`, which is what produces the parens. The static `dev_info_t` overloads cannot render either group and now say so at their declarations.

## Incidental fix

`ISDevice::getDescription(const dev_info_t&, int)` was **declared in the header but never defined** — a latent link error for any caller. Nothing called it, so it went unnoticed; the tests here are the first caller. Now implemented as name + firmware (a `dev_info_t` has no port, platform or io config).

## Testing

620 tests, **616 passed, 4 skipped (pre-existing), 0 failed**. 14 are new.

Five test vectors are captured from real hardware, covering u-blox / GPX / Septentrio types, Ser0 and Ser2 sourcing, mixed sourcing (GNSS1@Ser0 + GNSS2@Ser2), PPS1=G15, a non-zero `ioConfig2` (`0xC0` = PPS2 on G13, matching the BRK-2 routing the enum documents), CAN on G1G2, G1G2 disabled, and both OTP-locked and unlocked platforms. **No hardware required.**

Not covered by real hardware: `BRK_GPX` (1), `BRK_2_X20` (2), any RUG-3, an SPI-enabled board, a GPX-1 as its own device.

## Reviewer notes

- **Pin detail is `VERBOSE`-only** by design, which means a deviation confined to `G15` / `G5G8` / strobe edge / QDEC won't appear by default. It never happens on the five real boards, but it is a blind spot; happy to include those groups when they deviate if reviewers prefer.
- `tests/CMakeLists.txt` globs `test_*.cpp` without `CONFIGURE_DEPENDS`, so a newly added test is silently skipped until CMake reconfigures. Not changed here, but it cost me a confusing "0 tests" run.
- Related: SN-8469 (removing the `RUG4_GPX` 4.0 special case in `rug.cpp` — the reason preset 7 maps to different expander bits on Rugged-4.0 vs 4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SN-8608]: https://inertialsense.atlassian.net/browse/SN-8608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ