### PR TITLE
Fix RTK Plots in Log Inspector

### DIFF
--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -52,7 +52,7 @@ class Log:
         self.init_vars()
         self.c_log.init(self, directory, serials)
         self.c_log.load()
-        self.serials = self.c_log.serialNumbers()
+        self.serials = list(self.c_log.serialNumbers())
         # self.sanitize()
         self.data = np.array(self.data, dtype=object)
         self.directory = directory
@@ -62,8 +62,16 @@ class Log:
         if self.numDev == 0:
             print("No devices found in log or no logs found!!!")
             return False
-        if len(self.data[0, DID_DEV_INFO]):
-            self.serials = [self.data[d, DID_DEV_INFO]['serialNumber'][0] for d in range(self.numDev)]
+        # Use each device's DID_DEV_INFO serial number when present; otherwise keep the
+        # serial the log reader recovered from the file name. A device can log data
+        # without ever sending DID_DEV_INFO (partial logs, reference/truth data), and the
+        # old code checked only device 0 before indexing every device.
+        if len(self.serials) < self.numDev:
+            self.serials += [0] * (self.numDev - len(self.serials))
+        for d in range(self.numDev):
+            devInfo = self.data[d, DID_DEV_INFO]
+            if len(devInfo):
+                self.serials[d] = devInfo['serialNumber'][0]
 
         for i in range(self.numDev):
             try:

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -71,7 +71,9 @@ class Log:
         for d in range(self.numDev):
             devInfo = self.data[d, DID_DEV_INFO]
             if len(devInfo):
-                self.serials[d] = devInfo['serialNumber'][0]
+                dev_serial = int(devInfo['serialNumber'][0])
+                if dev_serial:
+                    self.serials[d] = dev_serial
 
         for i in range(self.numDev):
             try:


### PR DESCRIPTION
This pull request improves how device serial numbers are handled and assigned in the `logReader.py` module, especially when device information is incomplete or partially missing from logs. The changes ensure that each device is assigned the correct serial number when available, and gracefully handles cases where serial numbers are missing from device info.

**Device serial number handling improvements:**

* Ensured that `self.serials` is always a list by explicitly casting the result of `serialNumbers()` to a list.
* Updated the logic for assigning device serial numbers: now, for each device, if device info (`DID_DEV_INFO`) contains a serial number, it is used; otherwise, the serial from the log file is retained. The code also pads `self.serials` with zeros if there are more devices than serials found, improving robustness when logs are incomplete.