### PR TITLE
SN-8473: unify serial-port enumeration on SerialPortFactory, deprecate cISSerialPort

### DIFF
--- a/ExampleProjects/Bootloader/ISBootloaderExample.cpp
+++ b/ExampleProjects/Bootloader/ISBootloaderExample.cpp
@@ -21,7 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "../../src/serialPortPlatform.h"
 #include "../../src/ISBootloaderThread.h"
 #include "../../src/ISBootloaderBase.h"
-#include "../../src/ISSerialPort.h"
+#include "../../src/PortFactory.h"
 
 using namespace ISBootloader;
 using namespace std;
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
 
     // For now, we will use all present devices.
     std::vector<std::string> portStrings;
-    cISSerialPort::GetComPorts(portStrings);
+    SerialPortFactory::getComPorts(portStrings);
 
     // Set all files the same, the bootloader logic will identify the file and only put it onto the appropriate devices.
     firmwares_t files;
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
     vector<string> all_ports;                   // List of ports connected
 
     // For now, we will use all present devices.
-    cISSerialPort::GetComPorts(all_ports);
+    SerialPortFactory::getComPorts(all_ports);
 
     // Update the firmware on any port that was open
     std::vector<cISBootloaderThread::confirm_bootload_t> confirm_device_list;
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
 			&confirm_device_list))
 		return -1;   // Error or no devices found
 
-    cISSerialPort::GetComPorts(all_ports);
+    SerialPortFactory::getComPorts(all_ports);
 
     // Update the firmware on any port that wasn't initially deselected
     // update the firmware on any port that was open

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -775,7 +775,7 @@ static int cltool_updateFirmware()
     // partial failure, which it must, since batching removes any per-target accounting here.
     std::vector<std::string> targets;
     if (g_commandLineOptions.comPort == "*")
-        cISSerialPort::GetComPorts(targets);
+        SerialPortFactory::getComPorts(targets);
     else
         splitString(g_commandLineOptions.comPort, ',', targets);
 

--- a/src/ISBootloaderThread.cpp
+++ b/src/ISBootloaderThread.cpp
@@ -12,11 +12,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "ISBootloaderThread.h"
 #include "TcpPortFactory.h"
+#include "PortFactory.h"
 #include "ISBootloaderDFU.h"
 #include "ISBootloaderAPP.h"
 #include "ISBootloaderISB.h"
 #include "ISBootloaderSAMBA.h"
-#include "ISSerialPort.h"
 #include "protocol/FirmwareUpdate.h"
 #include "intel_hex_utils.h"
 
@@ -209,7 +209,7 @@ void cISBootloaderThread::start_threads_for_url_targets(const std::set<std::stri
 {
     for (const std::string& target : targetPorts) {
         // A URL target is one the serial enumeration can never report. Keyed off the scheme separator
-        // rather than "absent from GetComPorts()", so that a serial tty which is momentarily missing
+        // rather than "absent from getComPorts()", so that a serial tty which is momentarily missing
         // from enumeration (mid-reboot) is never mistaken for a URL and bound as a TCP port.
         if (target.find("://") == std::string::npos)
             continue;
@@ -620,11 +620,11 @@ bool cISBootloaderThread::set_mode_and_check_devices(
         if (m_waitAction) m_waitAction();
         SLEEP_MS(100);
 
-        cISSerialPort::GetComPorts(portNames);
+        SerialPortFactory::getComPorts(portNames);
 
         m_port_thread_mutex.lock();
 
-            // GetComPorts() can only report local serial ports, so a requested tcp:// target
+            // getComPorts() can only report local serial ports, so a requested tcp:// target
             // would never appear in portNames and never get a worker. Resolve and adopt those here.
             start_threads_for_url_targets(targetPorts, mode_thread_port_app);
 
@@ -735,11 +735,11 @@ bool cISBootloaderThread::set_mode_and_check_devices(
         if (m_waitAction) m_waitAction();
         SLEEP_MS(10);
 
-        cISSerialPort::GetComPorts(portNames);
+        SerialPortFactory::getComPorts(portNames);
 
         m_port_thread_mutex.lock();
 
-            // GetComPorts() can only report local serial ports, so a requested tcp:// target
+            // getComPorts() can only report local serial ports, so a requested tcp:// target
             // would never appear in portNames and never get a worker. Resolve and adopt those here.
             start_threads_for_url_targets(targetPorts, get_device_isb_version_thread);
 
@@ -923,11 +923,11 @@ is_operation_result cISBootloaderThread::update(
         if (m_waitAction) m_waitAction();
         SLEEP_MS(1000);
 
-        cISSerialPort::GetComPorts(portNames);
+        SerialPortFactory::getComPorts(portNames);
 
         m_port_thread_mutex.lock();
 
-            // GetComPorts() can only report local serial ports, so a requested tcp:// target
+            // getComPorts() can only report local serial ports, so a requested tcp:// target
             // would never appear in portNames and never get a worker. Resolve and adopt those here.
             start_threads_for_url_targets(targetPorts, mode_thread_port_isb, force_isb_update);
 
@@ -1035,11 +1035,11 @@ is_operation_result cISBootloaderThread::update(
 
         m_port_devicesActive = 0;
 
-        cISSerialPort::GetComPorts(portNames);
+        SerialPortFactory::getComPorts(portNames);
 
         m_port_thread_mutex.lock();
 
-            // GetComPorts() can only report local serial ports, so a requested tcp:// target
+            // getComPorts() can only report local serial ports, so a requested tcp:// target
             // would never appear in portNames and never get a worker. Resolve and adopt those here.
             start_threads_for_url_targets(targetPorts, update_thread_port, force_isb_update);
 

--- a/src/ISBootloaderThread.h
+++ b/src/ISBootloaderThread.h
@@ -271,7 +271,7 @@ private:
     /**
      * Starts workers for every requested target that is a URL rather than a local serial port.
      *
-     * The enumeration-driven loops can only ever see what cISSerialPort::GetComPorts() reports, so a
+     * The enumeration-driven loops can only ever see what SerialPortFactory::getComPorts() reports, so a
      * requested `tcp://host:port` target was in the target set but never in the enumerated list, and
      * therefore never got a worker at all -- the work set came back empty and the update reported
      * "No devices were updated". This resolves such targets through TcpPortFactory and adopts them.

--- a/src/ISSerialPort.h
+++ b/src/ISSerialPort.h
@@ -32,8 +32,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 /**
  * cISStream implementation that reads and writes a native serial/COM port using the
  * C serialPort/serialPortPlatform API declared in serialPort.h.
+ *
+ * @deprecated Use SerialPortFactory (PortFactory.h) + port_handle_t instead -- it provides the same
+ * enumeration (SerialPortFactory::getComPorts()) and live I/O (bindPort()/portOpen()/portRead()/
+ * portWrite()/portClose()/releasePort()) without a second, independently-maintained OS-enumeration
+ * implementation. See SN-8473.
  */
-class cISSerialPort : serial_port_t, public cISStream
+class [[deprecated("Use SerialPortFactory (PortFactory.h) + port_handle_t instead; see SN-8473.")]] cISSerialPort : serial_port_t, public cISStream
 {
 private:
     cISSerialPort(const cISSerialPort& copy) = delete; // disable copy constructor

--- a/src/PortFactory.h
+++ b/src/PortFactory.h
@@ -145,6 +145,16 @@ public:
     /** Sets the default blocking mode used when a port is bound without an explicit override. */
     SerialPortFactory& setBlocking(bool block) { portOptions.defaultBlocking = block; return *this; }
 
+    /**
+     * Identifies all serial ports known to the host OS. This does NOT do any port_handle allocation,
+     * validation, or other operation necessary to USE the port - it merely identifies them. This is the
+     * single OS-enumeration implementation for serial ports; use this instead of maintaining a second one.
+     * @param portNames a reference to a vector of strings which will be cleared, and populated with UART/Serial ports known to
+     *  the host operating system.
+     * @return the number of port names populated into the vector.
+     */
+    static int getComPorts(std::vector<std::string>& portNames);
+
 private:
     SerialPortFactory() = default;
     ~SerialPortFactory() = default;
@@ -159,17 +169,6 @@ private:
     static int onPortError(port_handle_t port, int errCode, const char *errMsg);
 
     std::vector<std::string> portNames = {};
-
-    /**
-     * An internal static function which identifies all available serial ports on the host device. It populates a referenced
-     * std::vector<std::string> with their names, as suitable identifiers. This does NOT do any port_handle allocation, validation,
-     * or other operations necessary to USE the port - it merely identifies them.
-     * @param portNames a reference to a vector of strings which will be cleared, and populated with UART/Serial ports known to
-     *  the host operating system.
-     * @return the number of port names populated into the vector.
-     */
-    static int getComPorts(std::vector<std::string>& portNames);
-
 
 #if PLATFORM_IS_LINUX
     static std::string get_driver__linux(const std::string& tty);

--- a/tests/test_PortFactory.cpp
+++ b/tests/test_PortFactory.cpp
@@ -153,3 +153,15 @@ TEST(test_PortFactory, tcpServerPortFactory) {
     portClose(serverPort);
     serverFactory.releasePort(serverPort);
 }
+
+// SN-8473: SerialPortFactory::getComPorts() is now the single OS-enumeration implementation for
+// serial ports (previously duplicated in the now-deprecated cISSerialPort::GetComPorts()). This is
+// a basic coverage test -- it can't assert on which ports exist (that's host-hardware-dependent,
+// and CI runners typically have none), only that enumeration runs cleanly and the returned count
+// is consistent with the populated vector.
+TEST(test_PortFactory, serialPortFactory_getComPorts) {
+    std::vector<std::string> portNames;
+    int count = SerialPortFactory::getComPorts(portNames);
+    EXPECT_EQ(count, (int)portNames.size());
+    EXPECT_GE(count, 0);
+}


### PR DESCRIPTION
## Summary
- Makes `SerialPortFactory::getComPorts()` public -- it was a private duplicate of `cISSerialPort::GetComPorts()` (two independently-maintained OS-enumeration implementations: separate `QueryDosDeviceA` loop on Windows, separate `/sys/class/tty` walk on Linux).
- Migrates all 8 real internal enumeration call sites (`cltool_main.cpp` x1, `ISBootloaderThread.cpp` x4, `ISBootloaderExample.cpp` x3) onto the unified `SerialPortFactory::getComPorts()`.
- Marks `cISSerialPort` `[[deprecated]]` rather than removing it -- it's part of the SDK's public API surface (`inertial-sense-sdk` is the public shared submodule), so outright removal is a breaking change for external integrators. This pass leaves it with **zero internal callers**.
- Adds basic coverage for the new public `getComPorts()` (`tests/test_PortFactory.cpp`) -- none existed for `SerialPortFactory::locatePorts()` either.

Note: the ticket's original inventory listed `InertialSense.cpp` (3 sites) as needing migration; re-scanning `develop` tip found it already clean (0 references) -- likely already fixed elsewhere. It also missed `cltool/src/cltool_main.cpp:778`, which is included here.

## Test plan
- [x] `IS-SDK_unit-tests`: 617 passed, 4 pre-existing skips (unrelated fixtures), 0 failed
- [x] New `test_PortFactory.serialPortFactory_getComPorts` passes
- [x] `cltool`, `ISBootloaderExample` build clean with zero `cISSerialPort` deprecation warnings (confirmed the attribute correctly fires on any *external* use via a throwaway test file)
- [x] Downstream `imx` (EvalTool + cltool) builds clean against this branch -- see companion PR

Companion PRs (same ticket):
- imx: point SDK submodule here temporarily; re-point to `develop` once this merges, before that PR merges
- docs.inertialsense.com: FirmwareUpdate.md sample updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)