### PR TITLE
SN-8626: .dat (LOGTYPE_DAT) reader support in ISLogReader

### DIFF
--- a/src/DeviceLogSerial.cpp
+++ b/src/DeviceLogSerial.cpp
@@ -63,13 +63,33 @@ void cDeviceLogSerial::InitDeviceForReading()
 }
 
 bool cDeviceLogSerial::CloseAllFiles() {
-    cDeviceLog::CloseAllFiles();
-
-    // Write remaining data to file
+    // D-119/SN-8626 (mirrors cDeviceLogRaw's SN-8328 fix): flush the buffered
+    // chunk to disk BEFORE the base class writes/finalizes the .idx.
+    // WriteChunkToFile() lazily creates the real segment file via
+    // OpenNewSaveFile(), which is the only place m_fileName is assigned. If the
+    // base's CloseAllFiles() ran first (as this did before), a log small enough
+    // that no chunk was ever flushed during logging would still have an empty
+    // m_fileName at finalize time -- writeIndexChunk()/finalizeIndex() would
+    // land on an orphan "./.idx", and the subsequent lazy OpenNewSaveFile()
+    // would reset the index state and re-emit an empty, non-finalized
+    // <segment>.idx (0 records).
     FlushToFile();
+
+    // Flush any remaining buffered index records and finalize the .idx header
+    // against the now-existing segment file.
+    cDeviceLog::CloseAllFiles();
 
     // Close file
     CloseISLogFile(m_pFile);
+
+    // D-119/SN-8626: this segment is finalized. Reset the physical-offset
+    // accounting so the NEXT segment's records index from 0 -- otherwise
+    // SaveData()'s m_lastIndexOffset computation (below) would use this
+    // now-closed file's stale size for the first record(s) of the next
+    // segment. (The base's lazy OpenNewSaveFile() also zeroes m_fileSize, but
+    // that fires only at the next chunk flush -- too late for records indexed
+    // in between.)
+    m_fileSize = 0;
 
     return true;
 }
@@ -88,6 +108,33 @@ bool cDeviceLogSerial::FlushToFile() {
 
 
 bool cDeviceLogSerial::SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf, protocol_type_t ptype) {
+    // D-119/SN-8626: ensure this record's chunk fits BEFORE indexing it (moved up
+    // from below cDeviceLog::SaveData()'s call, which stamps the .idx offset from
+    // m_lastIndexOffset). Indexing must see the post-flush/post-rotation chunk
+    // state, or a record that triggers a flush gets stamped with the PRE-flush
+    // offset -- wrong by a full chunk. Mirrors cDeviceLogRaw's SN-8328 ordering.
+    int32_t dataBytes = sizeof(p_data_hdr_t) + dataHdr->size;
+    int32_t buffFree = m_chunk.GetBuffFree();
+    if (dataBytes > buffFree) {
+        // Save chunk to file and clear
+        if (!WriteChunkToFile()) {
+            return false;
+        } else if (m_fileSize >= m_maxFileSize) {
+            // Close existing file
+            CloseAllFiles();
+        }
+    }
+
+    // D-119/SN-8626: stamp this record's TRUE physical .dat file offset before
+    // indexing. Unlike .raw (whose on-disk chunks carry no header), .dat's
+    // chunks ARE header-prefixed on disk (WriteChunkToFile's default
+    // writeHeader=true) -- the still-buffered m_chunk will itself be preceded by
+    // a not-yet-written sChunkHeader once flushed, so that header's size counts
+    // toward this record's eventual on-disk position even though it hasn't been
+    // written yet.
+    m_lastIndexOffset = static_cast<uint64_t>(m_fileSize) + sizeof(sChunkHeader)
+                       + static_cast<uint64_t>(m_chunk.GetDataSize());
+
     cDeviceLog::SaveData(dataHdr, dataBuf, ptype);
 
     dev_info_t tmpInfo = {};
@@ -123,19 +170,6 @@ bool cDeviceLogSerial::SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf, p
         }
     } else
         m_chunk.m_hdr.devSerialNum = m_devSerialNo;
-
-    // Ensure data will fit in chunk.  If not, create new chunk
-    int32_t dataBytes = sizeof(p_data_hdr_t) + dataHdr->size;
-    int32_t buffFree = m_chunk.GetBuffFree();
-    if (dataBytes > buffFree) {
-        // Save chunk to file and clear
-        if (!WriteChunkToFile()) {
-            return false;
-        } else if (m_fileSize >= m_maxFileSize) {
-            // Close existing file
-            CloseAllFiles();
-        }
-    }
 
     // Add data header and data buffer to chunk
     m_logSize += dataHdr->size;

--- a/src/ISDeviceLog.cpp
+++ b/src/ISDeviceLog.cpp
@@ -73,6 +73,27 @@ ISExpected<ISDeviceLog>
         }
     }
 
+    // D-119 / SN-8626: reject a device log composed of mixed .raw/.dat segments. Nothing today
+    // requires mixing formats within one composed log, and the simpler invariant is safer —
+    // same pattern as the deviceId check above.
+    auto formatName = [](ISLogReader::SegmentFormat f) noexcept {
+        return f == ISLogReader::SegmentFormat::Dat ? ".dat" : ".raw";
+    };
+    const ISLogReader::SegmentFormat expectedFormat = readers.front().format();
+    for (std::size_t i = 1; i < readers.size(); ++i) {
+        const ISLogReader::SegmentFormat got = readers[i].format();
+        if (got != expectedFormat) {
+            log_error(IS_LOG_ISLOG, "ISDeviceLog::fromSegments: format mismatch — "
+                      "first segment is %s, segment %zu (%s) is %s",
+                      formatName(expectedFormat), i,
+                      segmentPaths[i].filename().string().c_str(), formatName(got));
+            return fail(ISErrorCode::Unsupported,
+                std::string{"ISDeviceLog::fromSegments: mixed segment formats — first segment is "}
+                + formatName(expectedFormat) + ", segment " + std::to_string(i) + " is "
+                + formatName(got));
+        }
+    }
+
     // Order by segment-start timestamp. Use header.first_timestamp_ms
     // when present (D-01 writer fills this; D-04 scan-rebuild does too)
     // and fall back to the path's lexicographic order otherwise — the

--- a/src/ISDeviceLog.h
+++ b/src/ISDeviceLog.h
@@ -86,6 +86,17 @@ public:
     uint64_t deviceId() const noexcept { return deviceId_; }
 
     /**
+     * @return  Shared on-disk format of every segment in this composition
+     *          (D-119 / SN-8626). `fromSegments` rejects a mix of `.raw`
+     *          and `.dat` segments, so any segment's `format()` — here,
+     *          the first — is representative of the whole log. Consumers
+     *          that branch on record-byte layout (`ISRecordView::bytes()`
+     *          means something different per format) check this once per
+     *          log rather than per record.
+     */
+    ISLogReader::SegmentFormat format() const noexcept { return segments_.front().format(); }
+
+    /**
      * Returns the full `dev_info_t` from the first segment that carries one.
      *
      * Not simply `segments_.front()` as `hdwId()` does: a composition is

--- a/src/ISLog.cpp
+++ b/src/ISLog.cpp
@@ -28,14 +28,19 @@ ISLog& ISLog::operator=(ISLog&&) noexcept    = default;
 
 namespace {
 
-bool isRawExtension(const fs::path& p) {
+// D-119 / SN-8626/SN-8627: a directory scan must discover `.dat` segments too, not just `.raw` --
+// LogLoader::loadDirectory routes through this function, and before this fix a directory holding
+// only `.dat`+`.idx` files (a real manufacturing/calibration capture, not a synthetic test fixture)
+// failed outright with "no .raw files", well before any `.dat`-aware code got a chance to run.
+bool isSupportedSegmentExtension(const fs::path& p) {
     // Linux is case-sensitive; Windows / default macOS are not.
-    // Accept ".raw" and ".RAW" (and any case in between).
+    // Accept ".raw"/".RAW" and ".dat"/".DAT" (and any case in between).
     auto ext = p.extension().string();
     if (ext.size() != 4) return false;
     if (ext[0] != '.') return false;
     auto low = [](char c){ return static_cast<char>(std::tolower(static_cast<unsigned char>(c))); };
-    return low(ext[1]) == 'r' && low(ext[2]) == 'a' && low(ext[3]) == 'w';
+    const char a = low(ext[1]), b = low(ext[2]), c = low(ext[3]);
+    return (a == 'r' && b == 'a' && c == 'w') || (a == 'd' && b == 'a' && c == 't');
 }
 
 } // namespace
@@ -56,18 +61,18 @@ ISExpected<ISLog> ISLog::openDirectory(const fs::path& logDir) {
                     "ISLog::openDirectory: not a directory: " + logDir.string());
     }
 
-    // Walk non-recursively for `.raw` files. Drive the iterator explicitly with
+    // Walk non-recursively for `.raw`/`.dat` files. Drive the iterator explicitly with
     // the error_code-taking increment: the ec-form constructor only makes
     // construction non-throwing; a range-for's implicit operator++ can still
     // throw filesystem_error (e.g. the directory mutates mid-scan).
-    std::vector<fs::path> rawFiles;
+    std::vector<fs::path> segmentFiles;
     fs::directory_iterator it(logDir, ec);
     const fs::directory_iterator end;
     for (; !ec && it != end; it.increment(ec)) {
         const auto& entry = *it;
         if (!entry.is_regular_file()) continue;
-        if (isRawExtension(entry.path())) {
-            rawFiles.push_back(entry.path());
+        if (isSupportedSegmentExtension(entry.path())) {
+            segmentFiles.push_back(entry.path());
         }
     }
     if (ec) {
@@ -77,19 +82,19 @@ ISExpected<ISLog> ISLog::openDirectory(const fs::path& logDir) {
                     "ISLog::openDirectory: directory iteration failed: "
                     + ec.message());
     }
-    if (rawFiles.empty()) {
-        log_warn(IS_LOG_ISLOG, "no .raw files in %s", logDir.string().c_str());
+    if (segmentFiles.empty()) {
+        log_warn(IS_LOG_ISLOG, "no .raw/.dat files in %s", logDir.string().c_str());
         return fail(ISErrorCode::NotFound,
-                    "ISLog::openDirectory: no .raw files in " + logDir.string());
+                    "ISLog::openDirectory: no .raw/.dat files in " + logDir.string());
     }
-    log_more_info(IS_LOG_ISLOG, "discovered %zu .raw segment(s)", rawFiles.size());
+    log_more_info(IS_LOG_ISLOG, "discovered %zu segment(s)", segmentFiles.size());
 
     // Sort lexicographically so per-device segment order is stable.
-    std::sort(rawFiles.begin(), rawFiles.end());
+    std::sort(segmentFiles.begin(), segmentFiles.end());
 
     // Open each segment, group by device-id.
     std::map<uint64_t, std::vector<fs::path>> byDevice;
-    for (const auto& path : rawFiles) {
+    for (const auto& path : segmentFiles) {
         auto r = ISLogReader::openSegment(path);
         if (!r) {
             log_error(IS_LOG_ISLOG, "openSegment failed for %s: %s",
@@ -106,7 +111,7 @@ ISExpected<ISLog> ISLog::openDirectory(const fs::path& logDir) {
 
     ISLog out;
     out.directory_   = logDir;
-    out.allSegments_ = std::move(rawFiles);
+    out.allSegments_ = std::move(segmentFiles);
 
     out.orderedIds_.reserve(byDevice.size());
     for (auto& [devId, paths] : byDevice) {

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -21,6 +21,12 @@
 #include "ISDataMappings.h"
 #include "data_sets.h"
 
+// D-119 / SN-8626 / D0082: `sChunkHeader` + `DATA_CHUNK_MARKER` are the on-disk `.dat` chunk-
+// framing primitives (POD struct + constant) — consulted for byte layout only. Deliberately NOT
+// `cDeviceLogSerial`/`cDeviceLog`/`cISLogger` (still off-limits per this file's D-02 DoD #3 note
+// above): DataChunk.h doesn't pull those in.
+#include "DataChunk.h"
+
 #include <algorithm>
 #include <array>
 #include <cerrno>
@@ -28,6 +34,7 @@
 #include <cstring>
 #include <fstream>
 #include <iomanip>
+#include <optional>
 #include <sstream>
 #include <system_error>
 
@@ -81,6 +88,41 @@ bool hasSiblingSuccessor(const fs::path& rawPath) noexcept {
     const fs::path sibling =
         rawPath.parent_path() / (stem.substr(0, und + 1) + nextSeq.str() + rawPath.extension().string());
     return fs::exists(sibling, ec);
+}
+
+/**
+ * @brief Recognizes a segment's on-disk format from its extension (D-119 / SN-8626).
+ * @param path  Segment file path.
+ * @return      `Raw` for `.raw`, `Dat` for `.dat`; `std::nullopt` for anything else.
+ */
+std::optional<ISLogReader::SegmentFormat> formatFromExtension(const fs::path& path) noexcept {
+    const std::string ext = path.extension().string();
+    if (ext == ".raw") return ISLogReader::SegmentFormat::Raw;
+    if (ext == ".dat") return ISLogReader::SegmentFormat::Dat;
+    return std::nullopt;
+}
+
+/**
+ * @brief Extracts a serial number from a cISLogger-convention filename stem (`LOG_SN<n>_...`).
+ *
+ * Shared by `.raw`'s and `.dat`'s `deriveDeviceId*` filename fallback (D-119) — the convention
+ * is format-agnostic.
+ *
+ * @param stem  Filename stem (extension already stripped).
+ * @return      Parsed serial number, or `std::nullopt` if the filename doesn't match.
+ */
+std::optional<uint64_t> parseSerialFromFilenameStem(const std::string& stem) noexcept {
+    const std::size_t snPos = stem.find("SN");
+    if (snPos == std::string::npos) return std::nullopt;
+    std::size_t i = snPos + 2;
+    uint64_t value = 0;
+    bool any = false;
+    while (i < stem.size() && std::isdigit(static_cast<unsigned char>(stem[i]))) {
+        value = value * 10 + static_cast<uint64_t>(stem[i] - '0');
+        ++i;
+        any = true;
+    }
+    return any ? std::optional<uint64_t>(value) : std::nullopt;
 }
 
 } // namespace
@@ -310,16 +352,22 @@ ISExpected<ISLogReader> ISLogReader::construct(std::unique_ptr<ISLogSource> rawS
     r.rawSource_ = std::move(rawSource);
     r.rawPath_   = rawPath;
 
+    // D-119 / SN-8626: recognize the segment's on-disk format up front — everything below
+    // (sidecar naming, scan-rebuild dispatch, device-id derivation) branches on it.
+    auto fmt = formatFromExtension(rawPath);
+    if (!fmt) {
+        return fail(ISErrorCode::Unsupported,
+                    "ISLogReader::construct: unrecognized segment extension: " + rawPath.string());
+    }
+    r.format_ = *fmt;
+
     // -----------------------------------------------------------------
-    // Sidecar discovery: replace ".raw" with ".idx" (matches the writer convention from cDeviceLog::OpenNewSaveFile /
-    // m_fileName + ".idx").
+    // Sidecar discovery: replace the segment extension with ".idx" (matches the writer convention
+    // from cDeviceLog::OpenNewSaveFile / m_fileName + ".idx"). The extension is guaranteed
+    // recognized at this point, so this is an unconditional substitution.
     // -----------------------------------------------------------------
     fs::path idxPath = rawPath;
-    if (idxPath.extension() == ".raw") {
-        idxPath.replace_extension(".idx");
-    } else {
-        idxPath += ".idx";   // defensive — writer always uses .raw today
-    }
+    idxPath.replace_extension(".idx");
     r.idxPath_ = idxPath;
 
     // -----------------------------------------------------------------
@@ -470,9 +518,13 @@ ISExpected<ISLogReader> ISLogReader::construct(std::unique_ptr<ISLogSource> rawS
     }
 
     if (!r.hadOnDiskIndex_) {
-        // Default header; counters get filled in by buildIndexFromScan.
+        // Default header; counters get filled in by buildIndexFromScan[Dat].
         r.header_ = idx::makeDefaultHeader(0, idx::TimestampUnits::HostUptimeMs, idx::HeaderTimeSource::Mixed);
-        r.buildIndexFromScan();
+        if (r.format_ == SegmentFormat::Dat) {
+            r.buildIndexFromScanDat();
+        } else {
+            r.buildIndexFromScan();
+        }
 
         // Document the rebuild for the caller.
         const char* reasonStr = "unknown";
@@ -484,8 +536,9 @@ ISExpected<ISLogReader> ISLogReader::construct(std::unique_ptr<ISLogSource> rawS
             case RebuildReason::ReadError:  reasonStr = "read-error"; break;
             case RebuildReason::None:       reasonStr = "n/a";        break;
         }
-        r.warnings_.push_back(std::string{"sidecar: rebuilt from .raw scan (reason: "} + reasonStr + ")");
-        log_warn(IS_LOG_ISLOG, "%s: sidecar rebuilt from .raw scan (reason: %s)", rawPath.filename().c_str(), reasonStr);
+        const char* segKind = (r.format_ == SegmentFormat::Dat) ? ".dat" : ".raw";
+        r.warnings_.push_back(std::string{"sidecar: rebuilt from "} + segKind + " scan (reason: " + reasonStr + ")");
+        log_warn(IS_LOG_ISLOG, "%s: sidecar rebuilt from %s scan (reason: %s)", rawPath.filename().c_str(), segKind, reasonStr);
 
         // Persist the rebuilt sidecar. Suppressed when the build flips IS_LOG_READER_NO_PERSIST_INDEX (e.g. tests,
         // customers who don't want surprise writes to log dirs) or when the .raw sits on read-only media.
@@ -619,6 +672,115 @@ void ISLogReader::buildIndexFromScan() {
     }
 }
 
+void ISLogReader::buildIndexFromScanDat() {
+    records_.clear();
+    byDid_.clear();
+    isTruncated_ = false;
+    truncationOffset_ = rawSource_ ? rawSource_->size() : 0;
+
+    if (!rawSource_ || rawSource_->size() == 0) {
+        return;
+    }
+
+    const uint8_t*    base  = rawSource_->data();
+    const std::size_t total = rawSource_->size();
+
+    // Mirrors buildIndexFromScan()'s sibling-discrimination: a trailing partial chunk/record at
+    // the end of a segment is normal mid-rotation truncation if the next segment picks up where
+    // this one left off, and genuine data loss otherwise. See hasSiblingSuccessor's doc (SN-8005)
+    // — it's already extension-agnostic.
+    auto reportTruncation = [&](std::size_t offset, const char* what) {
+        isTruncated_      = true;
+        truncationOffset_ = offset;
+        const std::size_t trailingBytes = total - offset;
+        if (hasSiblingSuccessor(rawPath_)) {
+            warnings_.push_back(std::string{"trailing partial "} + what + " at end of segment ("
+                                + std::to_string(trailingBytes) + " bytes); continues in next segment");
+            log_info(IS_LOG_ISLOG,
+                     "%s: trailing partial %s (%zu bytes) at offset %zu (file size %zu); data continues in successor segment",
+                     rawPath_.filename().c_str(), what, trailingBytes, offset, total);
+        } else {
+            warnings_.push_back(std::string{"truncation ("} + what + "): stopped at offset "
+                                + std::to_string(offset) + " (file size " + std::to_string(total) + ")");
+            log_warn(IS_LOG_ISLOG, "%s: truncated (%s), stopped at offset %zu (file size %zu)",
+                     rawPath_.filename().c_str(), what, offset, total);
+        }
+    };
+
+    std::size_t pos = 0;
+    while (pos < total) {
+        if (total - pos < sizeof(sChunkHeader)) {
+            reportTruncation(pos, "chunk header");
+            break;
+        }
+        sChunkHeader hdr{};
+        std::memcpy(&hdr, base + pos, sizeof(sChunkHeader));
+        if (hdr.marker != DATA_CHUNK_MARKER || hdr.dataSize != ~hdr.invDataSize) {
+            // Same validation cDataChunk::ReadFromFile applies on the real read path.
+            reportTruncation(pos, "chunk header");
+            break;
+        }
+
+        const std::size_t chunkDataStart = pos + sizeof(sChunkHeader);
+        const std::size_t chunkDataSize  = hdr.dataSize;
+        if (chunkDataStart + chunkDataSize > total) {
+            reportTruncation(pos, "chunk body");
+            break;
+        }
+
+        // Walk (p_data_hdr_t + payload) pairs within this chunk's body. cDeviceLogSerial::SaveData
+        // never splits a header/payload pair across a chunk boundary (it flushes first if one
+        // wouldn't fit), so in a well-formed .dat this inner loop always ends exactly at
+        // chunkDataStart + chunkDataSize.
+        std::size_t bodyPos = chunkDataStart;
+        const std::size_t bodyEnd = chunkDataStart + chunkDataSize;
+        bool bodyTruncated = false;
+        while (bodyPos < bodyEnd) {
+            if (bodyEnd - bodyPos < sizeof(p_data_hdr_t)) {
+                reportTruncation(bodyPos, "record header");
+                bodyTruncated = true;
+                break;
+            }
+            p_data_hdr_t recHdr{};
+            std::memcpy(&recHdr, base + bodyPos, sizeof(p_data_hdr_t));
+            const std::size_t payloadStart = bodyPos + sizeof(p_data_hdr_t);
+            if (payloadStart + recHdr.size > bodyEnd) {
+                reportTruncation(bodyPos, "record payload");
+                bodyTruncated = true;
+                break;
+            }
+
+            const uint8_t* payloadPtr = base + payloadStart;
+            const double   tsSec = cISDataMappings::Timestamp(&recHdr, payloadPtr);
+            const uint64_t tsMs  = static_cast<uint64_t>(tsSec * 1000.0);
+
+            idx::is_log_idx_record_v2_t rec{};
+            rec.timestamp = tsMs;
+            rec.offset    = static_cast<uint64_t>(bodyPos);   // the p_data_hdr_t's own start — see recordEndOffset()
+            rec.did       = recHdr.id;
+            rec.flags     = 0;
+            rec.reserved  = 0;
+            records_.push_back(rec);
+
+            bodyPos = payloadStart + recHdr.size;
+        }
+        if (bodyTruncated) break;
+
+        pos = bodyEnd;
+    }
+
+    byDid_.reserve(64);
+    for (std::size_t i = 0; i < records_.size(); ++i) {
+        byDid_[records_[i].did].push_back(i);
+    }
+    if (!records_.empty()) {
+        header_.total_records      = records_.size();
+        header_.first_timestamp_ms = records_.front().timestamp;
+        header_.last_timestamp_ms  = records_.back().timestamp;
+        header_.flags |= idx::IS_LOG_IDX_HDR_FLAG_FINALIZED;
+    }
+}
+
 bool ISLogReader::persistIndex() const {
     if (idxPath_.empty() || records_.empty()) return false;
 
@@ -678,6 +840,13 @@ void ISLogReader::deriveDeviceId(const fs::path& rawPath) {
     hdwId_      = 0;
     devInfo_    = dev_info_t{};
     hasDevInfo_ = false;
+
+    // D-119 / SN-8626: .dat gets its own equivalent below — its .idx `offset` is directly usable
+    // (no comm-parse needed to recover the payload), unlike .raw's.
+    if (format_ == SegmentFormat::Dat) {
+        deriveDeviceIdDat(rawPath);
+        return;
+    }
 
     // 1) Walk the raw bytes via `is_comm_parse_byte` looking for a `dev_info_t`-bearing packet. We can't shortcut to
     //    the record's `.offset` because that is the ISB packet *start* (framing + header + payload + checksum), not
@@ -749,18 +918,58 @@ void ISLogReader::deriveDeviceId(const fs::path& rawPath) {
     // 2) Filename fallback. cltool/cISLogger emits names of the form `LOG_SN<n>_<timestamp>_<seq>.raw`. Extract the
     //    digits between "SN" and the next underscore. The fallback can recover the serial number but not the hardware
     //    id, so `hdwId_` stays 0.
-    const std::string stem = rawPath.stem().string();   // strips ".raw"
-    const std::size_t snPos = stem.find("SN");
-    if (snPos != std::string::npos) {
-        std::size_t i = snPos + 2;
-        uint64_t value = 0;
-        bool any = false;
-        while (i < stem.size() && std::isdigit(static_cast<unsigned char>(stem[i]))) {
-            value = value * 10 + static_cast<uint64_t>(stem[i] - '0');
-            ++i;
-            any = true;
+    if (auto sn = parseSerialFromFilenameStem(rawPath.stem().string())) {
+        deviceId_ = *sn;
+    }
+}
+
+void ISLogReader::deriveDeviceIdDat(const fs::path& rawPath) {
+    // Unlike .raw, a .dat record's .idx `offset` IS its p_data_hdr_t start — no wire framing sits
+    // between it and the payload, so no comm-parser is needed to recover either. By the time this
+    // runs, `records_` is already populated (from a trusted on-disk .idx, or from
+    // buildIndexFromScanDat() moments ago) — walk that instead of re-parsing chunk headers.
+    if (rawSource_ && rawSource_->size() > 0) {
+        const uint8_t*    base  = rawSource_->data();
+        const std::size_t total = rawSource_->size();
+
+        dev_info_t peripheral{};
+        bool       havePeripheral = false;
+
+        // Same DID-ranking / zero-serial-skip rules as the .raw path above (SN-8445).
+        for (const auto& rec : records_) {
+            const bool isPrimary    = (rec.did == DID_DEV_INFO);
+            const bool isPeripheral = (rec.did == DID_GPX_DEV_INFO || rec.did == DID_EVB_DEV_INFO);
+            if (!isPrimary && !isPeripheral) continue;
+
+            const std::size_t off = static_cast<std::size_t>(rec.offset);
+            if (off + sizeof(p_data_hdr_t) > total) continue;
+            p_data_hdr_t hdr{};
+            std::memcpy(&hdr, base + off, sizeof(p_data_hdr_t));
+            const std::size_t payloadStart = off + sizeof(p_data_hdr_t);
+            if (hdr.size != sizeof(dev_info_t) || payloadStart + hdr.size > total) continue;
+
+            dev_info_t info{};
+            std::memcpy(&info, base + payloadStart, sizeof(info));
+            if (info.serialNumber == 0) continue;   // see the .raw path's comment above
+
+            if (isPrimary) {
+                adoptDevInfo(info);
+                return;
+            }
+            if (!havePeripheral) {
+                peripheral     = info;
+                havePeripheral = true;
+            }
         }
-        if (any) deviceId_ = value;
+
+        if (havePeripheral) {
+            adoptDevInfo(peripheral);
+            return;
+        }
+    }
+
+    if (auto sn = parseSerialFromFilenameStem(rawPath.stem().string())) {
+        deviceId_ = *sn;
     }
 }
 
@@ -791,6 +1000,27 @@ std::vector<ISLogReader::did_t> ISLogReader::presentDids() const {
 }
 
 std::size_t ISLogReader::recordEndOffset(std::size_t recordIdx) const noexcept {
+    if (recordIdx >= records_.size()) {
+        return rawSource_ ? rawSource_->size() : 0;
+    }
+
+    if (format_ == SegmentFormat::Dat) {
+        // .dat records are self-delimiting (p_data_hdr_t.size), so the end offset needs no
+        // inference from neighboring records — re-read the 5-byte header at this record's own
+        // offset (the same bytes buildIndexFromScanDat() already validated) rather than growing
+        // is_log_idx_record_v2_t with a .dat-only field.
+        const std::size_t off   = static_cast<std::size_t>(records_[recordIdx].offset);
+        const uint8_t*    base  = rawSource_ ? rawSource_->data() : nullptr;
+        const std::size_t total = rawSource_ ? rawSource_->size() : 0;
+        if (!base || off + sizeof(p_data_hdr_t) > total) {
+            return total;
+        }
+        p_data_hdr_t hdr{};
+        std::memcpy(&hdr, base + off, sizeof(p_data_hdr_t));
+        const std::size_t end = off + sizeof(p_data_hdr_t) + hdr.size;
+        return end <= total ? end : total;
+    }
+
     if (recordIdx + 1 < records_.size()) {
         // Records share an arrival-order array but their .raw offsets are per-arrival-chunk (the writer increments
         // m_lastIndexOffset after each SaveData call). We use a sorted scan to find the smallest offset strictly

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
@@ -92,13 +93,26 @@ bool hasSiblingSuccessor(const fs::path& rawPath) noexcept {
 
 /**
  * @brief Recognizes a segment's on-disk format from its extension (D-119 / SN-8626).
+ *
+ * Case-insensitive, matching `ISLog::openDirectory`'s existing `isRawExtension` contract
+ * (ISLog.cpp) — that scan already discovers `.RAW`/`.Raw`/mixed-case files on
+ * case-sensitive filesystems (Linux) and hands them to `openSegment`/`construct`, so this
+ * must accept whatever it accepts or a directory scan silently rejects files its own
+ * discovery pass just found. Copilot review (PR #1298): the original strict `==` compare
+ * regressed that contract for `.dat` too, once this function started gating both extensions.
+ *
  * @param path  Segment file path.
- * @return      `Raw` for `.raw`, `Dat` for `.dat`; `std::nullopt` for anything else.
+ * @return      `Raw` for `.raw`, `Dat` for `.dat` (any case); `std::nullopt` for anything else.
  */
 std::optional<ISLogReader::SegmentFormat> formatFromExtension(const fs::path& path) noexcept {
     const std::string ext = path.extension().string();
-    if (ext == ".raw") return ISLogReader::SegmentFormat::Raw;
-    if (ext == ".dat") return ISLogReader::SegmentFormat::Dat;
+    if (ext.size() != 4 || ext[0] != '.') return std::nullopt;
+    const auto low = [](char c) noexcept {
+        return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    };
+    const char a = low(ext[1]), b = low(ext[2]), c = low(ext[3]);
+    if (a == 'r' && b == 'a' && c == 'w') return ISLogReader::SegmentFormat::Raw;
+    if (a == 'd' && b == 'a' && c == 't') return ISLogReader::SegmentFormat::Dat;
     return std::nullopt;
 }
 

--- a/src/ISLogReader.h
+++ b/src/ISLogReader.h
@@ -1,11 +1,19 @@
 /**
  * @file ISLogReader.h
- * @brief Segment-level reader for SDK 3.0 — reads `.raw` + v2 `.idx`.
+ * @brief Segment-level reader for SDK 3.0 — reads `.raw` or `.dat`, both
+ *        indexed via the same v2 `.idx` sidecar schema.
  *
  * D-02 / SN-7893 / D0019 / D0020 / D0021 / D0022 / D0049 / D0051: the
  * type-erased core of the new SDK reader. Operates on **one segment**
- * (one `.raw` file) at a time; segment-grouping into device logs and
- * sessions sits above this class (D-05).
+ * (one `.raw` or `.dat` file) at a time; segment-grouping into device
+ * logs and sessions sits above this class (D-05).
+ *
+ * D-119 / SN-8626 / D0082: `.dat` (`LOGTYPE_DAT`, `cDeviceLogSerial`'s
+ * chunk-header-framed, already-parsed `p_data_hdr_t`/payload format) is
+ * supported as a second segment format alongside `.raw`, dispatched
+ * internally via `format()` — never as a subclass (see D0082 for why).
+ * `cDeviceLogSerial`/`DataChunk.h` are consulted only for the on-disk
+ * byte layout, never as an interface template.
  *
  * Backing storage is memory-mapped where the host filesystem supports
  * it; falls back to buffered I/O otherwise. Records are exposed as
@@ -68,6 +76,20 @@ class ISTimeResolver;
 class ISLogReader {
 public:
     using did_t = uint32_t;
+
+    /**
+     * @brief On-disk segment format this reader was opened against.
+     *
+     * Recognized by extension at `openSegment()` time (D-119 / SN-8626).
+     * `.raw` and `.dat` share the same `.idx` v2 sidecar schema and the
+     * same public API — this enum only gates a handful of internal byte-
+     * layout decisions (`buildIndexFromScan*`, `recordEndOffset`,
+     * `deriveDeviceId*`). See D0082.
+     */
+    enum class SegmentFormat : uint8_t {
+        Raw,   ///< Undecoded, multi-protocol byte stream (`cDeviceLogRaw`, `.raw`).
+        Dat,   ///< Chunk-header-framed, already-parsed records (`cDeviceLogSerial`, `.dat`).
+    };
 
     // -----------------------------------------------------------------
     // Gap detection (SN-8345) — coverage gaps on the resolved timeline
@@ -147,13 +169,16 @@ public:
     /**
      * @brief Open a single segment.
      *
-     * Sidecar discovery rule: replace the `.raw` suffix with `.idx`
-     * (e.g. `LOG_..._0001.raw` → `LOG_..._0001.idx`) — matches the
-     * writer convention (cf. `cDeviceLog::OpenNewSaveFile`).
+     * The segment format is recognized by extension: `.raw` or `.dat`
+     * (D-119 / SN-8626). Sidecar discovery rule: replace the segment
+     * extension with `.idx` (e.g. `LOG_..._0001.raw` → `LOG_..._0001.idx`,
+     * `LOG_..._0001.dat` → `LOG_..._0001.idx`) — matches the writer
+     * convention (cf. `cDeviceLog::OpenNewSaveFile`).
      *
-     * @param raw  Path to the `.raw` segment file.
+     * @param raw  Path to the segment file (`.raw` or `.dat`).
      * @return     Reader on success; `ISErrorCode` on failure:
-     *             `NotFound`, `PermissionDenied`, `Corrupted`, `Io`.
+     *             `NotFound`, `PermissionDenied`, `Corrupted`, `Io`,
+     *             `Unsupported` (unrecognized extension).
      */
     static ISExpected<ISLogReader> openSegment(const std::filesystem::path& raw);
 
@@ -236,7 +261,9 @@ public:
     uint64_t fileSize() const noexcept;
 
     /**
-     * Direct accessor for the segment's underlying byte buffer.
+     * Direct accessor for the segment's underlying byte buffer. Despite
+     * the name, this aliases whatever backing file was opened — `.raw`
+     * or `.dat` (D-119) — the name predates `.dat` support.
      *
      * Most callers should iterate via `records()` / `allRecords()`
      * — this hatch is for code that needs to re-parse the raw stream
@@ -353,6 +380,13 @@ public:
      * which recovers nothing else.
      */
     bool hasDevInfo() const noexcept { return hasDevInfo_; }
+
+    /**
+     * @return  The on-disk format this segment was opened as (D-119 /
+     *          SN-8626). `ISDeviceLog::fromSegments` uses this to reject
+     *          a device log composed of mixed `.raw`/`.dat` segments.
+     */
+    SegmentFormat format() const noexcept { return format_; }
 
     // -----------------------------------------------------------------
     // Iteration
@@ -601,9 +635,25 @@ private:
     /**
      * Lazy fallback when the `.idx` sidecar is missing. D-02 lands
      * an empty stub here; D-04 will populate the index by scanning
-     * the `.raw` and persisting the result.
+     * the `.raw` and persisting the result. `.raw`-specific — see
+     * @ref buildIndexFromScanDat for the `.dat` equivalent (D-119).
      */
     void buildIndexFromScan();
+
+    /**
+     * @brief `.dat` equivalent of @ref buildIndexFromScan (D-119 / SN-8626).
+     *
+     * `.dat`'s on-disk shape (`sChunkHeader`-framed chunks of
+     * `p_data_hdr_t`/payload pairs — see `DeviceLogSerial.h`) is
+     * self-delimiting, so this walks chunk/record headers directly
+     * instead of running `.raw`'s `is_comm_parse_byte` state machine.
+     * Populates `records_`/`byDid_` exactly like the `.raw` scan; a
+     * malformed/truncated chunk or record stops the scan and marks
+     * `isTruncated_`/`truncationOffset_`, mirroring D-04's `.raw`
+     * behavior (including the sibling-segment discrimination via
+     * `hasSiblingSuccessor`).
+     */
+    void buildIndexFromScanDat();
 
     /**
      * @brief Resolves the device id from the segment's `dev_info_t` records, falling back to filename parsing.
@@ -612,11 +662,26 @@ private:
      * attached peripheral and are adopted only when the segment carries no primary record — which is the GPX-only
      * capture case. Records with a zero serial are skipped rather than treated as terminal.
      *
+     * Dispatches to @ref deriveDeviceIdDat for `.dat` segments (D-119); the body below is `.raw`-specific.
+     *
      * @param rawPath  Path the segment was opened from. Used only for the filename-fallback path.
      * @note SN-8445 / SN-8463. The ranking (rather than first-match) is what keeps the segments of one mixed
      *       IMX+GPX log agreeing on a device id, which `ISDeviceLog::fromSegments` requires.
      */
     void deriveDeviceId(const std::filesystem::path& rawPath);
+
+    /**
+     * @brief `.dat` equivalent of the `.raw`-specific body of @ref deriveDeviceId (D-119 / SN-8626).
+     *
+     * Unlike `.raw` (whose `.idx` record `offset` is the packet START, not the payload — recovering the payload
+     * requires re-running the full comm parser), a `.dat` record's `offset` IS its `p_data_hdr_t` start with no wire
+     * framing in between. This walks the already-built `records_` (populated by the time this runs, whether from a
+     * trusted on-disk `.idx` or from @ref buildIndexFromScanDat) rather than re-parsing chunk headers from scratch.
+     * Same DID-ranking / zero-serial-skip rules as the `.raw` path (SN-8445), same filename fallback.
+     *
+     * @param rawPath  Path the segment was opened from. Used only for the filename-fallback path.
+     */
+    void deriveDeviceIdDat(const std::filesystem::path& rawPath);
 
     /**
      * @brief Adopts a `dev_info_t` as this segment's identity.
@@ -631,9 +696,13 @@ private:
 
     /**
      * Computes the end-of-bytes offset for the record at the given
-     * index. Used by `viewAt` to derive `bytes().second`. Records
-     * sharing an offset (chunk-input artifact from the writer)
-     * resolve to the same end offset.
+     * index. Used by `viewAt` to derive `bytes().second`.
+     *
+     * `.raw`: records sharing an offset (chunk-input artifact from the
+     * writer) resolve to the same end offset — see the `.cpp` for the
+     * "next differing offset" scan. `.dat` (D-119): each record is
+     * self-delimiting (`p_data_hdr_t.size`), so the end is computed
+     * directly with no scan.
      *
      * @param recordIdx  Index into `records_`.
      * @return           Byte offset one past the last byte of the
@@ -676,6 +745,7 @@ private:
     std::vector<std::size_t>               allIndices_;        // 0..N-1
     static const std::vector<std::size_t>  kEmptyIndices_;
 
+    SegmentFormat                          format_             = SegmentFormat::Raw;
     bool                                   hadOnDiskIndex_     = false;
     bool                                   isTruncated_        = false;
     uint64_t                               truncationOffset_   = 0;

--- a/src/ISLogReader.h
+++ b/src/ISLogReader.h
@@ -388,6 +388,15 @@ public:
      */
     SegmentFormat format() const noexcept { return format_; }
 
+    /**
+     * @return  The path this segment was opened from. Kyle 2026-09-07 (Option B):
+     *          `ISTimeResolver`'s file-timestamp-anchor fallback (for a log with no
+     *          payload-level sync at all) parses this path's filename/ancestor
+     *          directory names for a timestamp, falling back to the file's
+     *          last-write time when none parse.
+     */
+    const std::filesystem::path& path() const noexcept { return rawPath_; }
+
     // -----------------------------------------------------------------
     // Iteration
     // -----------------------------------------------------------------

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -58,8 +58,8 @@ public:
     /** @brief Selects which `cDeviceLog` subclass (and on-disk format) new devices are logged with. */
     enum eLogType
     {
-        LOGTYPE_DAT = 0,    //!< raw serial byte stream, unparsed (cDeviceLogSerial, `.dat`)
-        LOGTYPE_RAW,        //!< packetized serial stream; supports multiple packet types (cDeviceLogRaw, `.raw`)
+        LOGTYPE_DAT = 0,    //!< already-parsed data sets (p_data_hdr_t + payload), chunk-header-framed (cDeviceLogSerial, `.dat`)
+        LOGTYPE_RAW,        //!< undecoded, multi-protocol serial byte stream (cDeviceLogRaw, `.raw`)
         LOGTYPE_CSV,        //!< one CSV file per data set (cDeviceLogCSV, `.csv`)
         LOGTYPE_KML,        //!< KML flight-path visualization, write-only (cDeviceLogKML, `.kml`)
         LOGTYPE_JSON,       //!< one JSON-lines file per data set (cDeviceLogJSON, `.json`)

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -134,6 +134,78 @@ int64_t medianOf(std::vector<int64_t> v) {
     return v[v.size() / 2];
 }
 
+/**
+ * @brief `.dat` equivalent of `scanSegmentForSyncs` (D-119 / SN-8626 / D0082).
+ *
+ * `.dat` has no wire protocol to parse (D0082): each `ISRecordView::bytes()` is already a bare
+ * `p_data_hdr_t` + payload, and `reader.allRecords()` already walks them cleanly (no NMEA/RTCM3/
+ * UBX noise to skip, unlike `.raw`'s byte-by-byte comm scan). Same DID_SYS_PARAMS / ToW-bearing
+ * logic as the `.raw` path below — see its comments for the "why" of each step.
+ */
+void scanSegmentForSyncsDat(const ISLogReader& reader,
+                            uint64_t deviceId,
+                            std::vector<ISSyncPoint>& out,
+                            std::vector<int64_t>& upOffsetsOut,
+                            uint64_t& arrivalIndex,
+                            double& prevUpTimeSec,
+                            std::vector<SessionAccum>& sessAccum) {
+    uint64_t lastNonSyncHostTimeMs = 0;
+
+    for (auto v : reader.allRecords()) {
+        const auto bytes = v.bytes();
+        if (!bytes.first || bytes.second < sizeof(p_data_hdr_t)) continue;
+        p_data_hdr_t hdr{};
+        std::memcpy(&hdr, bytes.first, sizeof(hdr));
+        if (sizeof(p_data_hdr_t) + hdr.size > bytes.second) continue;
+        const uint8_t* payloadPtr = bytes.first + sizeof(p_data_hdr_t);
+
+        const uint64_t thisArrival = arrivalIndex++;
+
+        if (hdr.id == DID_SYS_PARAMS && hdr.offset == 0 && hdr.size >= sizeof(sys_params_t)) {
+            sys_params_t sp2{};
+            std::memcpy(&sp2, payloadPtr, sizeof(sp2));
+            if (sp2.upTime > 0.0) {
+                if (prevUpTimeSec >= 0.0 && sp2.upTime < prevUpTimeSec - 0.5) {
+                    sessAccum.push_back(SessionAccum{ thisArrival, {} });
+                }
+                prevUpTimeSec = sp2.upTime;
+            }
+            const bool towValid =
+                (sp2.hdwStatus & HDW_STATUS_GNSS_TIME_OF_WEEK_VALID) != 0;
+            if (towValid && sp2.timeOfWeekMs > 0 && sp2.upTime > 0.0) {
+                const int64_t upMs = static_cast<int64_t>(sp2.upTime * 1000.0);
+                const int64_t off  = static_cast<int64_t>(sp2.timeOfWeekMs) - upMs;
+                upOffsetsOut.push_back(off);
+                if (!sessAccum.empty()) sessAccum.back().upOffsets.push_back(off);
+            }
+        }
+
+        const double tsSec = cISDataMappings::Timestamp(&hdr, payloadPtr);
+
+        if (!isToWBearing(hdr.id)) {
+            if (tsSec > 0.0) {
+                lastNonSyncHostTimeMs = static_cast<uint64_t>(tsSec * 1000.0);
+            }
+            continue;
+        }
+        if (tsSec <= 0.0) continue;
+
+        const uint64_t towMs = static_cast<uint64_t>(tsSec * 1000.0);
+        ISSyncPoint sp{};
+        sp.hostTimeMs       = towMs;
+        sp.payloadToWMs     = towMs;
+        sp.deviceId         = deviceId;
+        sp.sourceDid        = hdr.id;
+        sp.actualHostTimeMs = lastNonSyncHostTimeMs;
+        if (hdr.size >= sizeof(uint32_t)) {
+            uint32_t weekRaw = 0;
+            std::memcpy(&weekRaw, payloadPtr, sizeof(weekRaw));
+            sp.gpsWeek = weekRaw;
+        }
+        out.push_back(sp);
+    }
+}
+
 void scanSegmentForSyncs(const ISLogReader& reader,
                          uint64_t deviceId,
                          std::vector<ISSyncPoint>& out,
@@ -141,6 +213,13 @@ void scanSegmentForSyncs(const ISLogReader& reader,
                          uint64_t& arrivalIndex,
                          double& prevUpTimeSec,
                          std::vector<SessionAccum>& sessAccum) {
+    // D-119 / SN-8626: .dat has no wire protocol for this function's is_comm_parse_byte scan to
+    // find anything in — route to the .dat-native equivalent instead.
+    if (reader.format() == ISLogReader::SegmentFormat::Dat) {
+        scanSegmentForSyncsDat(reader, deviceId, out, upOffsetsOut, arrivalIndex, prevUpTimeSec, sessAccum);
+        return;
+    }
+
     auto bytes = reader.rawBytes();
     if (!bytes.first || bytes.second == 0) return;
 

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -17,9 +17,15 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstring>
+#include <ctime>
+#include <filesystem>
 #include <map>
+#include <optional>
+#include <regex>
+#include <system_error>
 
 namespace inertial_sense {
 
@@ -178,6 +184,25 @@ void scanSegmentForSyncsDat(const ISLogReader& reader,
                 upOffsetsOut.push_back(off);
                 if (!sessAccum.empty()) sessAccum.back().upOffsets.push_back(off);
             }
+            // Kyle 2026-09-07 (Option A): DID_SYS_PARAMS wasn't in kToWBearingDids, so even a
+            // synced SYS_PARAMS record (towValid) never became a sync point itself -- only used
+            // above to calibrate OTHER DIDs' uptime->ToW bridge. A log with SYS_PARAMS as its
+            // ONLY DID ever carrying a valid GPS time (no INS/GNSS at all) therefore had zero
+            // sync points regardless. Push it as a genuine anchor too, same identity convention
+            // as the generic ToW-bearing path below (hostTimeMs == payloadToWMs -- a "sync"
+            // record's .idx timestamp field IS the ToW, no separate host-time stored). No
+            // gpsWeek: sys_params_t carries no week field, unlike ins_x_t/gnss_pos_t, so this
+            // sync point can bridge host-uptime->ToW but never itself supply the epoch anchor
+            // (chooseAnchorWeek skips week==0 candidates).
+            if (towValid && sp2.timeOfWeekMs > 0) {
+                ISSyncPoint sysSp{};
+                sysSp.hostTimeMs       = sp2.timeOfWeekMs;
+                sysSp.payloadToWMs     = sp2.timeOfWeekMs;
+                sysSp.deviceId         = deviceId;
+                sysSp.sourceDid        = DID_SYS_PARAMS;
+                sysSp.actualHostTimeMs = lastNonSyncHostTimeMs;
+                out.push_back(sysSp);
+            }
         }
 
         const double tsSec = cISDataMappings::Timestamp(&hdr, payloadPtr);
@@ -280,6 +305,18 @@ void scanSegmentForSyncs(const ISLogReader& reader,
                 upOffsetsOut.push_back(off);                       // global (SN-8323) offset samples
                 if (!sessAccum.empty()) sessAccum.back().upOffsets.push_back(off);  // per-session (SN-8339)
             }
+            // Kyle 2026-09-07 (Option A) -- same rationale as scanSegmentForSyncsDat's mirror of
+            // this block: DID_SYS_PARAMS wasn't in kToWBearingDids, so even a synced record never
+            // became a sync point itself, only used to calibrate OTHER DIDs' bridge. Push it too.
+            if (towValid && sp2.timeOfWeekMs > 0) {
+                ISSyncPoint sysSp{};
+                sysSp.hostTimeMs       = sp2.timeOfWeekMs;
+                sysSp.payloadToWMs     = sp2.timeOfWeekMs;
+                sysSp.deviceId         = deviceId;
+                sysSp.sourceDid        = DID_SYS_PARAMS;
+                sysSp.actualHostTimeMs = lastNonSyncHostTimeMs;
+                out.push_back(sysSp);
+            }
         }
 
         // Probe every record for a payload-side timestamp. ToW-bearing
@@ -374,6 +411,138 @@ uint32_t chooseAnchorWeek(const std::vector<ISSyncPoint>& syncs) {
         }
     }
     return bestWeek;
+}
+
+// ============================================================
+// Option B (Kyle 2026-09-07): file-timestamp anchor fallback
+// ============================================================
+//
+// A log that never receives an external clock sync (no INS/GNSS DID, and no
+// DID_SYS_PARAMS record ever reports HDW_STATUS_GNSS_TIME_OF_WEEK_VALID --
+// Option A above still leaves such a log with zero sync points) has no
+// payload-derived basis for a wall-clock anchor at all. Rather than resolve
+// every record to SessionOnly/Unknown (which RawSeriesBuilder then drops
+// entirely -- the log becomes completely unplottable), recover ONE coarse
+// anchor from the log's own file: the segment's filename or an ancestor
+// directory name, if it looks like cISLogger's own `..._YYYYMMDD_HHMMSS_..`
+// convention (the common case -- this IS how cltool/cISLogger names a
+// session), else the segment file's last-write time.
+
+namespace fs = std::filesystem;
+
+//! Days from the Unix epoch (1970-01-01) to (y, m, d), proleptic Gregorian.
+//! Howard Hinnant's civil_from_days algorithm (public domain), needed because
+//! this file is pure C++17 -- no <chrono> calendar support until C++20.
+int64_t daysFromCivil(int64_t y, unsigned m, unsigned d) noexcept {
+    y -= (m <= 2);
+    const int64_t era = (y >= 0 ? y : y - 399) / 400;
+    const unsigned yoe = static_cast<unsigned>(y - era * 400);
+    const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+    const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    return era * 146097 + static_cast<int64_t>(doe) - 719468;
+}
+
+//! Matches cISLogger's `..._YYYYMMDD_HHMMSS_...` (or trailing `_YYYYMMDD_HHMMSS`)
+//! naming convention in a filename stem or directory name and converts it to
+//! Unix-epoch ms. Basic range-sanity-checked (year/month/day/hour/min/sec) to
+//! avoid treating an unrelated 8+6-digit run (e.g. a serial number followed by
+//! a counter) as a timestamp. Treated as UTC -- the writer stamps local wall-
+//! clock at capture time with no timezone recorded, and this anchor is already
+//! explicitly a coarse approximation (FileTimeAnchored / TimeConfidence::Unknown),
+//! so a timezone-sized offset doesn't change the plottability outcome.
+std::optional<uint64_t> parseTimestampFromName(const std::string& name) noexcept {
+    static const std::regex re(R"((\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2}))");
+    std::smatch m;
+    if (!std::regex_search(name, m, re)) return std::nullopt;
+
+    const int year  = std::stoi(m[1].str());
+    const int month = std::stoi(m[2].str());
+    const int day   = std::stoi(m[3].str());
+    const int hour  = std::stoi(m[4].str());
+    const int min   = std::stoi(m[5].str());
+    const int sec   = std::stoi(m[6].str());
+    if (year < 2000 || year > 2100)  return std::nullopt;
+    if (month < 1 || month > 12)     return std::nullopt;
+    if (day < 1 || day > 31)         return std::nullopt;
+    if (hour > 23 || min > 59 || sec > 59) return std::nullopt;
+
+    const int64_t days = daysFromCivil(year, static_cast<unsigned>(month),
+                                       static_cast<unsigned>(day));
+    const int64_t secs = days * 86400 + hour * 3600 + min * 60 + sec;
+    if (secs < 0) return std::nullopt;
+    return static_cast<uint64_t>(secs) * 1000ull;
+}
+
+//! Tries `path`'s filename stem, then each ancestor directory name (up to 4
+//! levels, past which a match is unlikely to actually describe this capture),
+//! returning the first that parses as a timestamp.
+std::optional<uint64_t> anchorFromPathNames(const fs::path& path) noexcept {
+    if (auto v = parseTimestampFromName(path.stem().string())) return v;
+    fs::path dir = path.parent_path();
+    for (int depth = 0; depth < 4 && !dir.empty(); ++depth) {
+        if (auto v = parseTimestampFromName(dir.filename().string())) return v;
+        if (dir == dir.parent_path()) break;   // reached root
+        dir = dir.parent_path();
+    }
+    return std::nullopt;
+}
+
+//! `path`'s last-write time as Unix-epoch ms, or nullopt on any filesystem error.
+//! `std::filesystem::file_time_type`'s clock is unspecified pre-C++20, but on
+//! every platform this project targets (libstdc++/libc++) it IS
+//! `std::chrono::system_clock` in practice; this is the standard C++17
+//! workaround (comparing against `system_clock::now()`/`file_time_type::clock::
+//! now()` taken back-to-back) rather than an unavailable `clock_cast` (C++20).
+std::optional<uint64_t> fileLastWriteTimeMs(const fs::path& path) noexcept {
+    std::error_code ec;
+    const auto ftime = fs::last_write_time(path, ec);
+    if (ec) return std::nullopt;
+    const auto sctp = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+        ftime - fs::file_time_type::clock::now() + std::chrono::system_clock::now());
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        sctp.time_since_epoch()).count();
+    if (ms < 0) return std::nullopt;
+    return static_cast<uint64_t>(ms);
+}
+
+//! Largest non-zero raw `.idx` timestamp observed across every segment of
+//! `log` -- used only as the ctime fallback's session-length estimate (see
+//! `deriveFileAnchorMs`). A second full pass over the log, but this only runs
+//! when the primary sync scan already found ZERO sync points, which is rare.
+uint64_t maxRawTimestampMs(const ISDeviceLog& log) noexcept {
+    uint64_t best = 0;
+    for (std::size_t s = 0; s < log.segmentCount(); ++s) {
+        for (auto v : log.segment(s).allRecords()) {
+            best = std::max(best, v.timestamp().value);
+        }
+    }
+    return best;
+}
+
+//! Kyle 2026-09-07 (Option B): the wall-clock instant corresponding to
+//! host-uptime == 0 for `log`, recovered from its own file when the log has
+//! no payload-level sync to derive one from. Tries the EARLIEST segment's
+//! filename/ancestor-directory names first (cISLogger stamps the session
+//! start into the name, so this needs no adjustment); falls back to that
+//! segment's last-write time, adjusted backward by the log's observed
+//! session span (last-write time approximates when the file was CLOSED, not
+//! opened) so the anchor still lands near session start rather than session
+//! end.
+//!
+//! @return  Anchor in Unix-epoch ms, or `std::nullopt` if neither the name
+//!          nor the filesystem produced anything usable (caller's existing
+//!          SessionOnly/Unknown fallback still applies in that case).
+std::optional<uint64_t> deriveFileAnchorMs(const ISDeviceLog& log) {
+    if (log.segmentCount() == 0) return std::nullopt;
+    const fs::path& firstSegPath = log.segment(0).path();
+
+    if (auto v = anchorFromPathNames(firstSegPath)) return v;
+
+    if (auto ctimeMs = fileLastWriteTimeMs(firstSegPath)) {
+        const uint64_t spanMs = maxRawTimestampMs(log);
+        return (*ctimeMs > spanMs) ? (*ctimeMs - spanMs) : *ctimeMs;
+    }
+    return std::nullopt;
 }
 
 } // namespace
@@ -519,9 +688,24 @@ ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
         }
     }
 
+    // Kyle 2026-09-07 (Option B): a log with zero sync points (no INS/GNSS, and
+    // Option A above found no synced DID_SYS_PARAMS either) has no payload basis
+    // for a wall-clock anchor at all -- recover one from the log's own file
+    // rather than leave every record SessionOnly/Unknown (RawSeriesBuilder drops
+    // those outright).
+    uint64_t fileAnchorMs  = 0;
+    bool     haveFileAnchor = false;
+    if (syncs.empty()) {
+        if (auto anchor = deriveFileAnchorMs(log)) {
+            fileAnchorMs   = *anchor;
+            haveFileAnchor = true;
+        }
+    }
+
     return ISTimeResolver{ std::move(syncs), std::move(discs), anchorWeek,
                            anchorTowStart, anchorTowEnd,
                            uptimeToTowOffsetMs, haveUptimeOffset,
+                           fileAnchorMs, haveFileAnchor,
                            std::move(sessions) };
 }
 
@@ -556,7 +740,14 @@ TimeStamp ISTimeResolver::resolveImpl(uint64_t hostTimeMs, uint64_t deviceId,
     }
 
     if (syncPoints_.empty()) {
-        // No anchors. Best we can do is a SessionOnly tag with the
+        // No payload-derived anchors. Kyle 2026-09-07 (Option B): if build() found
+        // a usable file-timestamp anchor (the log's filename/directory name, or its
+        // last-write time), every input here IS host-uptime domain (there's no
+        // sync point to have classified it otherwise) -- add the anchor directly.
+        if (haveFileAnchor_) {
+            return TimeStamp::fromFileTimeAnchored(fileAnchorMs_ + hostTimeMs, deviceId);
+        }
+        // No anchor of any kind. Best we can do is a SessionOnly tag with the
         // input value passed through.
         return TimeStamp::fromSessionOnly(hostTimeMs, deviceId);
     }

--- a/src/ISTimeResolver.h
+++ b/src/ISTimeResolver.h
@@ -245,6 +245,8 @@ private:
                             uint64_t anchorTowEnd,
                             int64_t  uptimeToTowOffsetMs,
                             bool     haveUptimeOffset,
+                            uint64_t fileAnchorMs,
+                            bool     haveFileAnchor,
                             std::vector<Session> sessions = {}) noexcept
         : syncPoints_(std::move(syncs)),
           discontinuities_(std::move(discs)),
@@ -253,6 +255,8 @@ private:
           anchorTowEnd_(anchorTowEnd),
           uptimeToTowOffsetMs_(uptimeToTowOffsetMs),
           haveUptimeOffset_(haveUptimeOffset),
+          fileAnchorMs_(fileAnchorMs),
+          haveFileAnchor_(haveFileAnchor),
           sessions_(std::move(sessions)) {}
 
     //! Core detection: scans all segments for sync points AND (SN-8323 uptime
@@ -294,6 +298,15 @@ private:
     int64_t                     uptimeToTowOffsetMs_ = 0;
     //! True when a synced DID_SYS_PARAMS gave a usable uptime->ToW offset.
     bool                        haveUptimeOffset_ = false;
+    //! Kyle 2026-09-07 (Option B): wall-clock instant (Unix-epoch ms) corresponding
+    //! to host-uptime == 0, recovered from the log's own file (filename/directory
+    //! name, or last-write time) when the log has zero sync points of any kind.
+    //! Only meaningful when `haveFileAnchor_` is true; see `deriveFileAnchorMs`.
+    uint64_t                    fileAnchorMs_ = 0;
+    //! True when `build()` found a usable file-timestamp anchor (Option B). Only
+    //! ever set when `syncPoints_` is empty -- a log with any real sync point
+    //! never needs this fallback.
+    bool                        haveFileAnchor_ = false;
     //! SN-8339: per-power-on sessions (reboot = SYS_PARAMS.upTime drop in
     //! arrival order). Size 1 for a single-boot log; the arrival-keyed resolve()
     //! overload uses per-session offsets when size > 1.

--- a/src/ISTimeStamp.h
+++ b/src/ISTimeStamp.h
@@ -35,6 +35,14 @@ enum class TimeSource : uint8_t {
     ResolvedViaSync,    ///< Reconstructed by `ISTimeResolver` (D-07) from sync edges.
     HostReceived,       ///< Host clock at the moment the packet arrived.
     SessionOnly,        ///< Sample index converted to ms; carries no real-world anchor.
+    /// Bug report / Kyle 2026-09-07 (Option B): the log carries NO payload-level sync at all (no
+    /// ToW-bearing DID ever fixed) -- `ISTimeResolver` falls back to a single coarse wall-clock
+    /// anchor recovered from the log's own filename/folder timestamp, or the segment file's
+    /// last-write time when the name doesn't parse. Distinct from `SessionOnly` specifically so
+    /// consumers that filter out "carries no real-world anchor" records (RawSeriesBuilder) don't
+    /// also drop these -- an approximate anchor is far more useful than nothing for a
+    /// manufacturing/bench-calibration log that never received an external clock sync.
+    FileTimeAnchored,
 };
 
 /**
@@ -104,6 +112,14 @@ struct TimeStamp {
     /// sample index in time units, not anchored to any wall clock.
     static constexpr TimeStamp fromSessionOnly(uint64_t ms, uint64_t deviceId) noexcept {
         return TimeStamp{ ms, TimeSource::SessionOnly, TimeConfidence::Unknown, deviceId };
+    }
+
+    /// `FileTimeAnchored` source. Confidence is `Unknown` — same rationale as
+    /// `SessionOnly` (no basis for a finer-grained judgement), but a DIFFERENT
+    /// `source` so `RawSeriesBuilder`'s "carries no real-world anchor, drop it"
+    /// filter (keyed on both fields) does not also discard these.
+    static constexpr TimeStamp fromFileTimeAnchored(uint64_t ms, uint64_t deviceId) noexcept {
+        return TimeStamp{ ms, TimeSource::FileTimeAnchored, TimeConfidence::Unknown, deviceId };
     }
 };
 

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -140,6 +140,27 @@ TEST(ISLog, IgnoresNonRawFiles) {
     teardown(f);
 }
 
+// D-119 / SN-8626/SN-8627: openDirectory's file-discovery scan was `.raw`-only until this test was
+// added -- a directory holding ONLY `.dat`+`.idx` segments (no `.raw` at all, e.g. a real
+// manufacturing/calibration capture) failed outright with "no .raw files", before any of the
+// per-segment `.dat` support landed by those stories ever got a chance to run. Caught against a
+// real capture, not a synthetic fixture (Logalyzer bug report, 2026-09-07): LogLoader::
+// loadDirectory routes through this exact function.
+TEST(ISLog, OpenDirectoryDiscoversDatFiles) {
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf), "/tmp/test_log_datdir_%d_%ld",
+                  ::getpid(), static_cast<long>(::time(nullptr)));
+    ISFileManager::DeleteDirectory(dirBuf);
+    GenerateDataLogFiles(1, dirBuf, cISLogger::LOGTYPE_DAT, 1.0f);
+
+    auto log = ISLog::openDirectory(dirBuf);
+    ASSERT_TRUE(log.has_value()) << log.error().message;
+    EXPECT_EQ(log->deviceIds().size(), 1u);
+    EXPECT_GT(log->recordCount(), 0u);
+
+    ISFileManager::DeleteDirectory(dirBuf);
+}
+
 TEST(ISLog, SpanStartEndStraddleAllDevices) {
     auto f = buildMultiDeviceFixture("span", 1.0f);
     ASSERT_FALSE(f.messages.empty());

--- a/tests/test_log_bounds.cpp
+++ b/tests/test_log_bounds.cpp
@@ -207,9 +207,14 @@ TEST_F(LogBoundsTest, WholeLogSpanIsFirstToLastResolved) {
     EXPECT_EQ(hi - lo, 20'000u);
 }
 
-TEST_F(LogBoundsTest, NoGpsRecordsSpanIsEmptyNotCrash) {
-    // A log with no ToW-bearing records → resolver has no anchors → every
-    // record resolves SessionOnly/Unknown → resolved span is empty, no crash.
+TEST_F(LogBoundsTest, NoGpsRecordsSpanFallsBackToFileAnchor) {
+    // A log with no ToW-bearing records and no synced SYS_PARAMS -> zero sync
+    // points. Kyle 2026-09-07 (Option B): the resolver now recovers a coarse
+    // wall-clock anchor from the log's own file (filename timestamp, or
+    // last-write time) rather than leaving every record SessionOnly/Unknown --
+    // so this log's resolved span is a real (if approximate) non-empty instant,
+    // not the old "empty span, no crash" sentinel. No crash either way; that
+    // guarantee still holds, it's just no longer the interesting part.
     std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
     imu_t imu{}; imu.time = 1.0; imu.I.acc[2] = 9.8f;
     recs.emplace_back(DID_IMU, bytesOf(imu));
@@ -220,8 +225,8 @@ TEST_F(LogBoundsTest, NoGpsRecordsSpanIsEmptyNotCrash) {
     auto r = ISTimeResolver::build(log.value());
     ASSERT_TRUE(r.has_value());
     auto [lo, hi] = resolvedSpan(log.value(), *r);
-    EXPECT_EQ(lo, 0u);
-    EXPECT_EQ(hi, 0u);
+    EXPECT_EQ(lo, hi);   // exactly one record
+    EXPECT_GT(lo, 0u);   // anchored (via filename or ctime), not empty
 }
 
 // -------------------- J-2: per-DID bounds, clean --------------------

--- a/tests/test_log_reader_dat.cpp
+++ b/tests/test_log_reader_dat.cpp
@@ -1,0 +1,373 @@
+/**
+ * @file test_log_reader_dat.cpp
+ * @brief D-119 / SN-8626 acceptance tests for `.dat` (LOGTYPE_DAT) support in `ISLogReader`.
+ *
+ * Mirrors test_log_reader.cpp's fixture strategy (generate a fresh log per test via the existing
+ * test_data_utils helpers, assert against the result, wipe the temp dir on teardown) — see that
+ * file's header comment for the rationale (host-time-dependent generator, so no committed binary
+ * fixture).
+ *
+ * Two fixture styles are used here:
+ *   - GenerateDataLogFiles(..., LOGTYPE_DAT, ...) for tests that only need *a* .dat log (open,
+ *     header/counts, truncation, sidecar reuse) — same helper test_ISLogger.cpp's dat_conversion
+ *     test already exercises against the legacy cDeviceLogSerial::ReadData() path.
+ *   - A decode-and-refeed helper (decodeIsbMessages) for the record-for-record equivalence test
+ *     and the multi-segment test, which both need the *same* underlying messages available in
+ *     both .raw's wire-format form and .dat's parsed (p_data_hdr_t, payload) form.
+ */
+
+#include <gtest/gtest.h>
+
+// com_manager.h FIRST — see test_log_reader.cpp's comment on the ISFirmwareUpdater.h extern-C wrap.
+#include "com_manager.h"
+
+#include "DeviceLog.h"
+#include "ISComm.h"
+#include "ISFileManager.h"
+#include "ISLogIndex.h"
+#include "ISLogReader.h"
+#include "ISLogger.h"
+#include "data_sets.h"
+#include "test_data_utils.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <list>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+using namespace inertial_sense;
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint16_t kFixtureHwId   = ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0);
+constexpr uint32_t kFixtureSerial = 583201u;
+constexpr float    kFixtureSizeMB = 1.0f;
+
+fs::path uniqueTempDir(const std::string& hint) {
+    char buf[256];
+    std::snprintf(buf, sizeof(buf), "/tmp/test_log_reader_dat_%s_%d_%ld",
+                  hint.c_str(), ::getpid(), static_cast<long>(::time(nullptr)));
+    return fs::path{buf};
+}
+
+// ============================================================
+// Fixture style A: GenerateDataLogFiles — "just give me a .dat log"
+// ============================================================
+
+struct DatFixture {
+    fs::path directory;
+    fs::path datFile;
+    fs::path idxFile;
+};
+
+DatFixture generateDatFixture(const std::string& dirHint) {
+    DatFixture f;
+    f.directory = uniqueTempDir(dirHint);
+    ISFileManager::DeleteDirectory(f.directory.string());
+
+    GenerateDataLogFiles(1, f.directory.string(), cISLogger::LOGTYPE_DAT, kFixtureSizeMB);
+
+    std::vector<ISFileManager::file_info_t> datFiles, idxFiles;
+    ISFileManager::GetAllFilesInDirectory(f.directory.string(), true, "\\.dat$", datFiles);
+    ISFileManager::GetAllFilesInDirectory(f.directory.string(), true, "\\.idx$", idxFiles);
+    if (datFiles.empty() || idxFiles.empty()) return f;
+
+    std::sort(datFiles.begin(), datFiles.end(),
+              [](const auto& a, const auto& b) { return a.name < b.name; });
+    f.datFile = datFiles.front().name;
+    f.idxFile = idxFiles.front().name;
+    return f;
+}
+
+void teardownDatFixture(DatFixture& f) {
+    if (!f.directory.empty() && fs::exists(f.directory)) {
+        ISFileManager::DeleteDirectory(f.directory.string());
+    }
+}
+
+class LogReaderDatTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        f_ = generateDatFixture(::testing::UnitTest::GetInstance()->current_test_info()->name());
+        ASSERT_FALSE(f_.datFile.empty()) << "fixture generation produced no .dat";
+        ASSERT_TRUE(fs::exists(f_.idxFile)) << "expected .idx alongside .dat";
+    }
+    void TearDown() override { teardownDatFixture(f_); }
+
+    DatFixture f_;
+};
+
+// ============================================================
+// Fixture style B: decode-and-refeed — .raw and .dat from the SAME messages
+// ============================================================
+
+struct DecodedRecord {
+    p_data_hdr_t         hdr{};
+    std::vector<uint8_t> payload;
+};
+
+/**
+ * @brief Decodes GenerateRawLogData()'s wire-format messages into parsed (header, payload) pairs.
+ *
+ * Only ISB (_PTYPE_INERTIAL_SENSE_DATA / _CMD) messages decode to a p_data_hdr_t — a .dat log has
+ * no representation for NMEA/RTCM3/u-blox (DeviceLogSerial's SaveData() only ever receives
+ * already-parsed p_data_hdr_t/payload; see D0082 / DeviceLogSerial.h), so those are skipped here
+ * exactly as ISLogReader's own .raw scan skips them when building records_ (see
+ * ISLogReader::buildIndexFromScan — non-ISB packets consume bytes but are never indexed either).
+ * A single is_comm_instance_t is fed the full concatenated stream (not reset between messages) so
+ * multi-byte framing spanning message boundaries decodes exactly as it would from one .raw file.
+ */
+std::vector<DecodedRecord> decodeIsbMessages(const std::list<std::vector<uint8_t>*>& wireMessages) {
+    std::vector<DecodedRecord> out;
+
+    is_comm_instance_t comm{};
+    uint8_t commBuf[PKT_BUF_SIZE];
+    is_comm_init(&comm, commBuf, sizeof(commBuf), nullptr);
+    is_comm_enable_protocol(&comm, _PTYPE_INERTIAL_SENSE_DATA);
+    is_comm_enable_protocol(&comm, _PTYPE_NMEA);
+    is_comm_enable_protocol(&comm, _PTYPE_RTCM3);
+    is_comm_enable_protocol(&comm, _PTYPE_UBLOX);
+
+    for (auto* msg : wireMessages) {
+        for (uint8_t b : *msg) {
+            protocol_type_t ptype = is_comm_parse_byte(&comm, b);
+            if (ptype == _PTYPE_INERTIAL_SENSE_DATA || ptype == _PTYPE_INERTIAL_SENSE_CMD) {
+                DecodedRecord rec;
+                rec.hdr = comm.rxPkt.dataHdr;
+                rec.payload.assign(comm.rxPkt.data.ptr, comm.rxPkt.data.ptr + rec.hdr.size);
+                out.push_back(std::move(rec));
+            }
+        }
+    }
+    return out;
+}
+
+/** @brief Writes `wireMessages` to a fresh `.raw` log under `directory`. Returns the segment paths (sorted). */
+std::vector<fs::path> writeRawSegments(const fs::path& directory,
+                                       const std::list<std::vector<uint8_t>*>& wireMessages,
+                                       uint32_t maxFileSize = 0) {
+    ISFileManager::DeleteDirectory(directory.string());
+    {
+        cISLogger logger;
+        cISLogger::sSaveOptions opts;
+        opts.logType               = cISLogger::LOGTYPE_RAW;
+        opts.useSubFolderTimestamp = false;
+        if (maxFileSize) opts.maxFileSize = maxFileSize;
+        if (!logger.InitSave(directory.string(), opts)) return {};
+        auto dev = logger.registerDevice(kFixtureHwId, kFixtureSerial);
+        if (!dev) return {};
+        logger.EnableLogging(true);
+        for (auto* msg : wireMessages) {
+            logger.LogData(dev, static_cast<int>(msg->size()), msg->data());
+        }
+        logger.CloseAllFiles();
+    }
+    std::vector<ISFileManager::file_info_t> files;
+    ISFileManager::GetAllFilesInDirectory(directory.string(), true, "\\.raw$", files);
+    std::sort(files.begin(), files.end(), [](const auto& a, const auto& b) { return a.name < b.name; });
+    std::vector<fs::path> out;
+    for (auto& fi : files) out.emplace_back(fi.name);
+    return out;
+}
+
+/** @brief Writes `decoded` records to a fresh `.dat` log under `directory`. Returns the segment paths (sorted). */
+std::vector<fs::path> writeDatSegments(const fs::path& directory,
+                                       const std::vector<DecodedRecord>& decoded,
+                                       uint32_t maxFileSize = 0) {
+    ISFileManager::DeleteDirectory(directory.string());
+    {
+        cISLogger logger;
+        cISLogger::sSaveOptions opts;
+        opts.logType               = cISLogger::LOGTYPE_DAT;
+        opts.useSubFolderTimestamp = false;
+        if (maxFileSize) opts.maxFileSize = maxFileSize;
+        if (!logger.InitSave(directory.string(), opts)) return {};
+        auto dev = logger.registerDevice(kFixtureHwId, kFixtureSerial);
+        if (!dev) return {};
+        logger.EnableLogging(true);
+        for (const auto& rec : decoded) {
+            // Copy the header — LogData() takes a non-const pointer.
+            p_data_hdr_t hdr = rec.hdr;
+            logger.LogData(dev, &hdr, rec.payload.data());
+        }
+        logger.CloseAllFiles();
+    }
+    std::vector<ISFileManager::file_info_t> files;
+    ISFileManager::GetAllFilesInDirectory(directory.string(), true, "\\.dat$", files);
+    std::sort(files.begin(), files.end(), [](const auto& a, const auto& b) { return a.name < b.name; });
+    std::vector<fs::path> out;
+    for (auto& fi : files) out.emplace_back(fi.name);
+    return out;
+}
+
+} // namespace
+
+// ============================================================
+// Open / header / DID-list — same shape as test_log_reader.cpp's .raw coverage
+// ============================================================
+
+TEST_F(LogReaderDatTest, OpenSegmentSucceeds) {
+    auto r = ISLogReader::openSegment(f_.datFile);
+    ASSERT_TRUE(r.has_value()) << "openSegment failed: " << r.error().message;
+    EXPECT_EQ(r->format(), ISLogReader::SegmentFormat::Dat);
+    EXPECT_GT(r->recordCount(), 0u);
+    EXPECT_FALSE(r->isTruncated());
+}
+
+TEST_F(LogReaderDatTest, HeaderAndCountsMatchFixture) {
+    auto r = ISLogReader::openSegment(f_.datFile);
+    ASSERT_TRUE(r.has_value());
+
+    const uint64_t total_records = r->header().total_records;
+    const uint64_t segEnd        = r->segmentEndTimestamp();
+    const uint64_t segStart      = r->segmentStartTimestamp();
+    EXPECT_EQ(r->recordCount(), total_records);
+    EXPECT_GT(segEnd, 0u);
+    EXPECT_LE(segStart, segEnd);
+
+    auto dids = r->presentDids();
+    EXPECT_FALSE(dids.empty());
+    EXPECT_TRUE(std::is_sorted(dids.begin(), dids.end()));
+}
+
+TEST_F(LogReaderDatTest, RecordsByDidCountsMatchAggregate) {
+    auto r = ISLogReader::openSegment(f_.datFile);
+    ASSERT_TRUE(r.has_value());
+
+    std::size_t accum = 0;
+    for (auto did : r->presentDids()) {
+        accum += r->records(did).size();
+    }
+    EXPECT_EQ(accum, r->recordCount());
+}
+
+// ============================================================
+// Sidecar rebuild-and-reuse (D-119 AC: mirrors .raw + .idx v2 behavior)
+// ============================================================
+
+TEST_F(LogReaderDatTest, SidecarRebuildThenReuse) {
+    // Fixture already has a writer-produced .idx; delete it to force a scan-rebuild on first open.
+    std::error_code ec;
+    fs::remove(f_.idxFile, ec);
+    ASSERT_FALSE(fs::exists(f_.idxFile));
+
+    auto first = ISLogReader::openSegment(f_.datFile);
+    ASSERT_TRUE(first.has_value()) << first.error().message;
+    EXPECT_FALSE(first->hadOnDiskIndex());
+    EXPECT_GT(first->recordCount(), 0u);
+    ASSERT_TRUE(fs::exists(f_.idxFile)) << "rebuilt sidecar should have been persisted";
+
+    auto second = ISLogReader::openSegment(f_.datFile);
+    ASSERT_TRUE(second.has_value()) << second.error().message;
+    EXPECT_TRUE(second->hadOnDiskIndex());
+    EXPECT_EQ(second->recordCount(), first->recordCount());
+}
+
+// ============================================================
+// Truncation (D-119 AC: mirrors D-04's .raw truncated-tail handling)
+// ============================================================
+
+TEST_F(LogReaderDatTest, TruncatedMidChunkDetected) {
+    std::error_code ec;
+    fs::remove(f_.idxFile, ec);   // force a scan so truncation is actually detected, not trusted-from-sidecar
+
+    const auto fullSize = fs::file_size(f_.datFile);
+    ASSERT_GT(fullSize, 100u);
+
+    // Truncate partway through — with a ~1 MB fixture spanning many 128 KB chunks, cutting at the
+    // halfway point lands inside a chunk's body (a record header or payload), not exactly on a
+    // chunk boundary.
+    {
+        std::error_code truncEc;
+        fs::resize_file(f_.datFile, fullSize / 2, truncEc);
+        ASSERT_FALSE(truncEc) << truncEc.message();
+    }
+
+    auto r = ISLogReader::openSegment(f_.datFile);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    EXPECT_TRUE(r->isTruncated());
+    EXPECT_LE(r->truncationOffset(), fullSize / 2);
+    EXPECT_GT(r->recordCount(), 0u) << "records before the truncation point should still be readable";
+}
+
+// ============================================================
+// Record-for-record equivalence vs. .raw (D-119 AC)
+// ============================================================
+
+TEST(LogReaderDat, RawAndDatAgreeOnSameMessages) {
+    std::list<std::vector<uint8_t>*> wireMessages;
+    GenerateRawLogData(wireMessages, kFixtureSizeMB);
+    ASSERT_FALSE(wireMessages.empty());
+
+    auto decoded = decodeIsbMessages(wireMessages);
+    ASSERT_FALSE(decoded.empty()) << "no ISB records decoded from the synthetic wire stream";
+
+    const fs::path rawDir = uniqueTempDir("equiv_raw");
+    const fs::path datDir = uniqueTempDir("equiv_dat");
+
+    auto rawSegments = writeRawSegments(rawDir, wireMessages);
+    auto datSegments = writeDatSegments(datDir, decoded);
+
+    for (auto* msg : wireMessages) delete msg;
+
+    ASSERT_FALSE(rawSegments.empty());
+    ASSERT_FALSE(datSegments.empty());
+
+    auto rawReader = ISLogReader::openSegment(rawSegments.front());
+    auto datReader = ISLogReader::openSegment(datSegments.front());
+    ASSERT_TRUE(rawReader.has_value()) << rawReader.error().message;
+    ASSERT_TRUE(datReader.has_value()) << datReader.error().message;
+    EXPECT_EQ(rawReader->format(), ISLogReader::SegmentFormat::Raw);
+    EXPECT_EQ(datReader->format(), ISLogReader::SegmentFormat::Dat);
+
+    // .raw's scan never indexes NMEA/RTCM3/UBX packets either (see buildIndexFromScan), so
+    // rawReader->allRecords() is already exactly the ISB subsequence — directly comparable to
+    // datReader's full record set with no extra filtering.
+    std::vector<std::pair<uint32_t, uint64_t>> rawSeq, datSeq;
+    for (auto v : rawReader->allRecords()) rawSeq.emplace_back(v.did(), v.timestamp().value);
+    for (auto v : datReader->allRecords()) datSeq.emplace_back(v.did(), v.timestamp().value);
+
+    ASSERT_EQ(rawSeq.size(), datSeq.size());
+    for (std::size_t i = 0; i < rawSeq.size(); ++i) {
+        EXPECT_EQ(rawSeq[i].first, datSeq[i].first)   << "DID mismatch at record " << i;
+        EXPECT_EQ(rawSeq[i].second, datSeq[i].second) << "timestamp mismatch at record " << i;
+    }
+
+    ISFileManager::DeleteDirectory(rawDir.string());
+    ISFileManager::DeleteDirectory(datDir.string());
+}
+
+// ============================================================
+// Multi-file rotation (D-119 AC)
+// ============================================================
+
+TEST(LogReaderDat, MultiSegmentDatReadableAcrossFiles) {
+    std::list<std::vector<uint8_t>*> wireMessages;
+    GenerateRawLogData(wireMessages, 2.0f);   // 2 MB — enough to force rollover at the small cap below
+    ASSERT_FALSE(wireMessages.empty());
+
+    auto decoded = decodeIsbMessages(wireMessages);
+    for (auto* msg : wireMessages) delete msg;
+    ASSERT_FALSE(decoded.empty());
+
+    const fs::path dir = uniqueTempDir("multiseg");
+    auto segments = writeDatSegments(dir, decoded, /*maxFileSize=*/262144u);   // 256 KB segments
+    ASSERT_GE(segments.size(), 2u) << "expected rollover to produce multiple .dat segments";
+
+    std::size_t totalRecords = 0;
+    for (const auto& seg : segments) {
+        auto r = ISLogReader::openSegment(seg);
+        ASSERT_TRUE(r.has_value()) << r.error().message;
+        EXPECT_EQ(r->format(), ISLogReader::SegmentFormat::Dat);
+        totalRecords += r->recordCount();
+    }
+    EXPECT_EQ(totalRecords, decoded.size());
+
+    ISFileManager::DeleteDirectory(dir.string());
+}

--- a/tests/test_log_reader_dat.cpp
+++ b/tests/test_log_reader_dat.cpp
@@ -229,13 +229,22 @@ TEST_F(LogReaderDatTest, OpenSegmentSucceeds) {
 // Exercises uppercase/mixed-case for each extension directly against openSegment, one level below
 // the directory scan that would otherwise mask the regression by never trying an uppercase name.
 TEST_F(LogReaderDatTest, OpenSegmentAcceptsMixedCaseExtension) {
-    std::error_code ec;
-
     // Same stem as f_.datFile -> replace_extension(".idx") resolves to f_.idxFile, already on
     // disk from fixture generation, so only the .dat itself needs copying under the new name.
     const fs::path upperDat = f_.datFile.parent_path() / (f_.datFile.stem().string() + ".DAT");
-    fs::copy_file(f_.datFile, upperDat, ec);
-    ASSERT_FALSE(ec) << ec.message();
+
+    // Windows CI failure (2026-09-08): NTFS/APFS are case-insensitive, so upperDat and
+    // f_.datFile already name the SAME file there -- fs::exists(upperDat) is true before any
+    // copy, and copy_file(f_.datFile, upperDat) then fails with "file exists" (source and
+    // destination are equivalent). That IS the case-insensitive-filesystem behavior this test
+    // wants to exercise (a plain path-string case change reaches the same on-disk bytes with no
+    // extra step) -- skip the copy rather than treating it as an error. Linux's ext4 is
+    // case-sensitive, so upperDat doesn't exist yet there and genuinely needs a real copy.
+    if (!fs::exists(upperDat)) {
+        std::error_code ec;
+        fs::copy_file(f_.datFile, upperDat, ec);
+        ASSERT_FALSE(ec) << ec.message();
+    }
 
     auto r = ISLogReader::openSegment(upperDat);
     ASSERT_TRUE(r.has_value()) << "openSegment(.DAT) failed: " << r.error().message;

--- a/tests/test_log_reader_dat.cpp
+++ b/tests/test_log_reader_dat.cpp
@@ -28,6 +28,7 @@
 #include "ISLogIndex.h"
 #include "ISLogReader.h"
 #include "ISLogger.h"
+#include "ISTimeResolver.h"
 #include "data_sets.h"
 #include "test_data_utils.h"
 
@@ -411,4 +412,57 @@ TEST(LogReaderDat, MixedFormatSegmentsRejected) {
 
     ISFileManager::DeleteDirectory(rawDir.string());
     ISFileManager::DeleteDirectory(datDir.string());
+}
+
+// ============================================================
+// ISTimeResolver on .dat (D0066 compliance — D-119 / SN-8626)
+// ============================================================
+
+// Regression for a bug caught only by full end-to-end integration testing (Logalyzer's
+// RawSeriesBuilder + LogLoader), not by this file's own reader-level tests: ISTimeResolver's
+// sync-point detection (scanSegmentForSyncs) used to unconditionally re-scan
+// `reader.rawBytes()` via `is_comm_parse_byte` -- which finds nothing in a `.dat` file (no wire
+// protocol to parse, D0082), so EVERY `.dat` record resolved as SessionOnly/Unknown regardless of
+// how many valid ToW-bearing records it had. Without scanSegmentForSyncsDat's fix, `.dat` support
+// would open and index correctly but never produce a usable chart -- every series would be
+// filtered out by the resolver. This test would have caught that at the SDK level.
+TEST(LogReaderDat, TimeResolverFindsSyncPointsInDatLog) {
+    std::list<std::vector<uint8_t>*> wireMessages;
+    GenerateRawLogData(wireMessages, kFixtureSizeMB);
+    ASSERT_FALSE(wireMessages.empty());
+
+    auto decoded = decodeIsbMessages(wireMessages);
+    for (auto* msg : wireMessages) delete msg;
+    ASSERT_FALSE(decoded.empty());
+
+    const fs::path dir = uniqueTempDir("resolver");
+    auto segments = writeDatSegments(dir, decoded);
+    ASSERT_FALSE(segments.empty());
+
+    auto log = ISDeviceLog::fromSegments(segments);
+    ASSERT_TRUE(log.has_value()) << log.error().message;
+    ASSERT_EQ(log->format(), ISLogReader::SegmentFormat::Dat);
+
+    auto syncs = ISTimeResolver::detectSyncPoints(*log);
+    ASSERT_FALSE(syncs.empty())
+        << "no sync points found in a .dat log -- scanSegmentForSyncs isn't reaching .dat records";
+
+    auto resolverR = ISTimeResolver::build(*log);
+    ASSERT_TRUE(resolverR.has_value()) << resolverR.error().message;
+    const auto& resolver = *resolverR;
+
+    // At least one ToW-bearing record must resolve as PayloadToW/Exact -- SessionOnly/Unknown
+    // across the board is exactly the symptom the bug above produced.
+    bool foundAnchored = false;
+    for (auto v : log->allRecords()) {
+        if (v.timestamp().value == 0) continue;
+        const auto resolved = resolver.resolve(v.timestamp().value, log->deviceId());
+        if (resolved.source == TimeSource::PayloadToW && resolved.confidence == TimeConfidence::Exact) {
+            foundAnchored = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundAnchored) << "no .dat record resolved as PayloadToW/Exact";
+
+    ISFileManager::DeleteDirectory(dir.string());
 }

--- a/tests/test_log_reader_dat.cpp
+++ b/tests/test_log_reader_dat.cpp
@@ -222,6 +222,26 @@ TEST_F(LogReaderDatTest, OpenSegmentSucceeds) {
     EXPECT_FALSE(r->isTruncated());
 }
 
+// Copilot review (PR #1298): formatFromExtension() originally did a strict `==` compare, which
+// regressed ISLog::openDirectory's pre-existing case-insensitive `.raw`/`.RAW` contract
+// (ISLog.cpp's isRawExtension) for BOTH extensions once this function started gating `.dat` too.
+// Exercises uppercase/mixed-case for each extension directly against openSegment, one level below
+// the directory scan that would otherwise mask the regression by never trying an uppercase name.
+TEST_F(LogReaderDatTest, OpenSegmentAcceptsMixedCaseExtension) {
+    std::error_code ec;
+
+    // Same stem as f_.datFile -> replace_extension(".idx") resolves to f_.idxFile, already on
+    // disk from fixture generation, so only the .dat itself needs copying under the new name.
+    const fs::path upperDat = f_.datFile.parent_path() / (f_.datFile.stem().string() + ".DAT");
+    fs::copy_file(f_.datFile, upperDat, ec);
+    ASSERT_FALSE(ec) << ec.message();
+
+    auto r = ISLogReader::openSegment(upperDat);
+    ASSERT_TRUE(r.has_value()) << "openSegment(.DAT) failed: " << r.error().message;
+    EXPECT_EQ(r->format(), ISLogReader::SegmentFormat::Dat);
+    EXPECT_GT(r->recordCount(), 0u);
+}
+
 TEST_F(LogReaderDatTest, HeaderAndCountsMatchFixture) {
     auto r = ISLogReader::openSegment(f_.datFile);
     ASSERT_TRUE(r.has_value());
@@ -412,6 +432,85 @@ TEST(LogReaderDat, MixedFormatSegmentsRejected) {
 
     ISFileManager::DeleteDirectory(rawDir.string());
     ISFileManager::DeleteDirectory(datDir.string());
+}
+
+// ============================================================
+// Device-info extraction from a TRUSTED on-disk index (D-119 AC)
+// ============================================================
+
+// Copilot review (PR #1298): none of the tests above actually exercise
+// deriveDeviceIdDat()'s offset-based dev_info_t read against a writer-produced
+// .idx that's trusted as-is (hadOnDiskIndex() == true, no rebuild) --
+// GenerateDataLogFiles()'s synthetic messages never include DID_DEV_INFO, so
+// every test above that opens its fixture unmodified silently falls through
+// to the filename "SN<n>" fallback (deriveDeviceId()'s step 2), which sets
+// deviceId_ but leaves hdwId_ at 0 -- it can't detect a wrong `.idx` offset
+// because it never reads through one. This test writes a real DID_DEV_INFO
+// record via the production LOGTYPE_DAT path (mirrors Logalyzer's
+// writeDatFixture in test_raw_series_builder.cpp) and opens the segment
+// WITHOUT touching its .idx, so deriveDeviceIdDat() must decode dev_info_t at
+// records_[i].offset to pass -- hdwId() only comes from that path (the
+// filename fallback never sets it), so a wrong offset reads garbage bytes,
+// fails the `hdr.size == sizeof(dev_info_t)` guard, and this test fails.
+TEST(LogReaderDat, DeviceInfoDerivedFromTrustedOnDiskIndex) {
+    const fs::path dir = uniqueTempDir("devinfo_trusted");
+    ISFileManager::DeleteDirectory(dir.string());
+
+    {
+        cISLogger logger;
+        cISLogger::sSaveOptions opts;
+        opts.logType               = cISLogger::LOGTYPE_DAT;
+        opts.useSubFolderTimestamp = false;
+        ASSERT_TRUE(logger.InitSave(dir.string(), opts));
+        auto dev = logger.registerDevice(kFixtureHwId, kFixtureSerial);
+        ASSERT_TRUE(dev != nullptr);
+        logger.EnableLogging(true);
+
+        dev_info_t info{};
+        info.serialNumber   = kFixtureSerial;
+        info.hardwareType   = IS_HARDWARE_TYPE_IMX;
+        info.hardwareVer[0] = 5;
+        p_data_hdr_t hdr{};
+        hdr.id   = DID_DEV_INFO;
+        hdr.size = sizeof(info);
+        logger.LogData(dev, &hdr, reinterpret_cast<const uint8_t*>(&info));
+
+        // A few ordinary records after it so DID_DEV_INFO isn't the only/last
+        // thing in the chunk -- exercises the offset arithmetic for a record
+        // that isn't chunk-start.
+        ins_2_t ins{};
+        ins.week        = 2300;
+        ins.timeOfWeek  = 100.0;
+        p_data_hdr_t insHdr{};
+        insHdr.id   = DID_INS_2;
+        insHdr.size = sizeof(ins);
+        for (int i = 0; i < 5; ++i) {
+            logger.LogData(dev, &insHdr, reinterpret_cast<const uint8_t*>(&ins));
+        }
+
+        logger.CloseAllFiles();
+    }
+
+    std::vector<ISFileManager::file_info_t> datFiles, idxFiles;
+    ISFileManager::GetAllFilesInDirectory(dir.string(), true, "\\.dat$", datFiles);
+    ISFileManager::GetAllFilesInDirectory(dir.string(), true, "\\.idx$", idxFiles);
+    ASSERT_FALSE(datFiles.empty());
+    ASSERT_FALSE(idxFiles.empty()) << "expected a writer-produced .idx alongside the .dat";
+
+    // Deliberately do NOT delete the .idx -- openSegment must trust it as-is.
+    auto r = ISLogReader::openSegment(datFiles.front().name);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    EXPECT_TRUE(r->hadOnDiskIndex())
+        << "this test only proves what it claims to if the on-disk .idx was trusted, not rebuilt";
+
+    EXPECT_TRUE(r->hasDevInfo());
+    EXPECT_EQ(r->hdwId(), kFixtureHwId)
+        << "hdwId() is only ever set by the offset-based dev_info_t decode -- a wrong .idx offset "
+           "leaves it at 0 regardless of the filename-fallback serial";
+    EXPECT_EQ(r->devInfo().serialNumber, kFixtureSerial);
+    EXPECT_EQ(r->deviceId(), kFixtureSerial);
+
+    ISFileManager::DeleteDirectory(dir.string());
 }
 
 // ============================================================

--- a/tests/test_log_reader_dat.cpp
+++ b/tests/test_log_reader_dat.cpp
@@ -23,6 +23,7 @@
 
 #include "DeviceLog.h"
 #include "ISComm.h"
+#include "ISDeviceLog.h"
 #include "ISFileManager.h"
 #include "ISLogIndex.h"
 #include "ISLogReader.h"
@@ -370,4 +371,44 @@ TEST(LogReaderDat, MultiSegmentDatReadableAcrossFiles) {
     EXPECT_EQ(totalRecords, decoded.size());
 
     ISFileManager::DeleteDirectory(dir.string());
+}
+
+// ============================================================
+// ISDeviceLog::format() + mixed-format rejection (D-119 AC)
+// ============================================================
+
+TEST(LogReaderDat, DeviceLogFormatIsDat) {
+    auto f = generateDatFixture("device_log_format");
+    ASSERT_FALSE(f.datFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({f.datFile});
+    ASSERT_TRUE(log.has_value()) << log.error().message;
+    EXPECT_EQ(log->format(), ISLogReader::SegmentFormat::Dat);
+
+    teardownDatFixture(f);
+}
+
+TEST(LogReaderDat, MixedFormatSegmentsRejected) {
+    std::list<std::vector<uint8_t>*> wireMessages;
+    GenerateRawLogData(wireMessages, kFixtureSizeMB);
+    ASSERT_FALSE(wireMessages.empty());
+    auto decoded = decodeIsbMessages(wireMessages);
+    ASSERT_FALSE(decoded.empty());
+
+    const fs::path rawDir = uniqueTempDir("mixed_raw");
+    const fs::path datDir = uniqueTempDir("mixed_dat");
+    auto rawSegments = writeRawSegments(rawDir, wireMessages);
+    auto datSegments = writeDatSegments(datDir, decoded);
+    for (auto* msg : wireMessages) delete msg;
+    ASSERT_FALSE(rawSegments.empty());
+    ASSERT_FALSE(datSegments.empty());
+
+    // Same device (kFixtureHwId/kFixtureSerial are shared constants) but mixed formats — must be
+    // rejected even though the device-id check alone would pass.
+    auto log = ISDeviceLog::fromSegments({rawSegments.front(), datSegments.front()});
+    ASSERT_FALSE(log.has_value());
+    EXPECT_EQ(log.error().code, ISErrorCode::Unsupported);
+
+    ISFileManager::DeleteDirectory(rawDir.string());
+    ISFileManager::DeleteDirectory(datDir.string());
 }

--- a/tests/test_log_reader_dat.cpp
+++ b/tests/test_log_reader_dat.cpp
@@ -515,6 +515,67 @@ TEST(LogReaderDat, DeviceInfoDerivedFromTrustedOnDiskIndex) {
 }
 
 // ============================================================
+// ISTimeResolver Option A on .dat (Kyle 2026-09-07)
+// ============================================================
+
+// The bug report that prompted Option A was against a .dat manufacturing/
+// calibration capture (thermal-chamber run, no INS/GNSS record at all) --
+// scanSegmentForSyncsDat mirrors scanSegmentForSyncs's Option A fix
+// line-for-line, but exercised through the .dat-native decode path rather
+// than the .raw comm-parser, since that's the format this bug actually
+// surfaced against.
+TEST(LogReaderDat, SyncedSysParamsAloneEstablishesSyncPointsInDatLog) {
+    const fs::path dir = uniqueTempDir("sysparams_only_dat");
+    ISFileManager::DeleteDirectory(dir.string());
+
+    {
+        cISLogger logger;
+        cISLogger::sSaveOptions opts;
+        opts.logType               = cISLogger::LOGTYPE_DAT;
+        opts.useSubFolderTimestamp = false;
+        ASSERT_TRUE(logger.InitSave(dir.string(), opts));
+        auto dev = logger.registerDevice(kFixtureHwId, kFixtureSerial);
+        ASSERT_TRUE(dev != nullptr);
+        logger.EnableLogging(true);
+
+        for (uint32_t towMs : { 200'000'000u, 200'010'000u, 200'020'000u }) {
+            sys_params_t sp{};
+            sp.timeOfWeekMs = towMs;
+            sp.upTime       = (towMs - 200'000'000u) / 1000.0 + 5.0;
+            sp.hdwStatus    = HDW_STATUS_GNSS_TIME_OF_WEEK_VALID;
+            p_data_hdr_t hdr{};
+            hdr.id   = DID_SYS_PARAMS;
+            hdr.size = sizeof(sp);
+            logger.LogData(dev, &hdr, reinterpret_cast<const uint8_t*>(&sp));
+        }
+        logger.CloseAllFiles();
+    }
+
+    std::vector<ISFileManager::file_info_t> datFiles;
+    ISFileManager::GetAllFilesInDirectory(dir.string(), true, "\\.dat$", datFiles);
+    ASSERT_FALSE(datFiles.empty());
+
+    auto log = ISDeviceLog::fromSegments({ datFiles.front().name });
+    ASSERT_TRUE(log.has_value()) << log.error().message;
+
+    auto syncs = ISTimeResolver::detectSyncPoints(*log);
+    ASSERT_FALSE(syncs.empty())
+        << "a synced DID_SYS_PARAMS record should establish a sync point on its own, "
+           "even with no INS/GNSS DID present";
+    for (const auto& sp : syncs) {
+        EXPECT_EQ(sp.sourceDid, static_cast<uint32_t>(DID_SYS_PARAMS));
+    }
+
+    auto resolverR = ISTimeResolver::build(*log);
+    ASSERT_TRUE(resolverR.has_value());
+    const TimeStamp t = resolverR->resolve(200'010'000u, log->deviceId());
+    EXPECT_EQ(t.source, TimeSource::PayloadToW);
+    EXPECT_EQ(t.confidence, TimeConfidence::Exact);
+
+    ISFileManager::DeleteDirectory(dir.string());
+}
+
+// ============================================================
 // ISTimeResolver on .dat (D0066 compliance — D-119 / SN-8626)
 // ============================================================
 

--- a/tests/test_log_reader_dat.cpp
+++ b/tests/test_log_reader_dat.cpp
@@ -40,8 +40,6 @@
 #include <string>
 #include <vector>
 
-#include <unistd.h>
-
 using namespace inertial_sense;
 namespace fs = std::filesystem;
 
@@ -51,11 +49,14 @@ constexpr uint16_t kFixtureHwId   = ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0);
 constexpr uint32_t kFixtureSerial = 583201u;
 constexpr float    kFixtureSizeMB = 1.0f;
 
+// Portable unique temp directory (works on POSIX + Windows CI) — mirrors test_log_bounds.cpp's
+// makeTempDir(). Copilot review (PR #1298): the original ::getpid()/hardcoded-"/tmp" version
+// wasn't excluded from the Windows build in tests/CMakeLists.txt like test_log_reader.cpp is, so
+// it would have broken that build; ported to std::filesystem::temp_directory_path() instead of
+// adding this file to that exclusion list, since nothing else here needs POSIX.
 fs::path uniqueTempDir(const std::string& hint) {
-    char buf[256];
-    std::snprintf(buf, sizeof(buf), "/tmp/test_log_reader_dat_%s_%d_%ld",
-                  hint.c_str(), ::getpid(), static_cast<long>(::time(nullptr)));
-    return fs::path{buf};
+    static unsigned counter = 0;
+    return fs::temp_directory_path() / ("test_log_reader_dat_" + hint + "_" + std::to_string(counter++));
 }
 
 // ============================================================

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -25,9 +25,12 @@
 #include "ISTimeResolver.h"
 #include "data_sets.h"
 
+#include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
 #include <filesystem>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -163,6 +166,29 @@ std::vector<uint8_t> bytesOf(const T& t) {
     return out;
 }
 
+// Kyle 2026-09-07 (Option B tests): renames `f.rawFile` (and its `.idx` sidecar,
+// if the writer produced one) to `<newStem>.raw`/`.idx` in the same directory,
+// so a test can deliberately control the exact name `ISTimeResolver`'s
+// file-timestamp-anchor fallback sees, rather than relying on cISLogger's own
+// real-time-stamped filename (which the OTHER file-anchor tests exercise
+// incidentally).
+fs::path renameFixtureTo(FixturePaths& f, const std::string& newStem) {
+    const fs::path newRaw = f.directory / (newStem + ".raw");
+    std::error_code ec;
+    fs::rename(f.rawFile, newRaw, ec);
+    if (ec) return {};
+    const fs::path oldIdx = f.rawFile; // same object, extension replaced below
+    fs::path oldIdxPath = oldIdx;
+    oldIdxPath.replace_extension(".idx");
+    if (fs::exists(oldIdxPath)) {
+        fs::path newIdx = newRaw;
+        newIdx.replace_extension(".idx");
+        fs::rename(oldIdxPath, newIdx, ec);
+    }
+    f.rawFile = newRaw;
+    return newRaw;
+}
+
 void teardown(FixturePaths& f) {
     if (!f.directory.empty() && fs::exists(f.directory)) {
         ISFileManager::DeleteDirectory(f.directory.string());
@@ -176,11 +202,18 @@ protected:
 };
 
 // ---------------------------------------------------------------------------
-// Empty log → no sync points → SessionOnly/Unknown for any query.
+// Empty log → no sync points → falls back to a file-timestamp anchor.
 // ---------------------------------------------------------------------------
-TEST_F(TimeResolverTest, EmptyLogResolvesAsSessionOnly) {
+TEST_F(TimeResolverTest, EmptyLogFallsBackToFileTimeAnchor) {
     // Fixture with only ToW-LESS records (DID_IMU, which the resolver's
-    // allowlist excludes). detectSyncPoints should find zero anchors.
+    // allowlist excludes) and no DID_SYS_PARAMS at all. detectSyncPoints
+    // should find zero anchors -- Kyle 2026-09-07 (Option B): rather than
+    // SessionOnly/Unknown for every query (which RawSeriesBuilder then drops
+    // outright), the resolver now recovers a coarse wall-clock anchor from
+    // the log's own file (filename timestamp, or last-write time) and
+    // reports it as FileTimeAnchored -- still Unknown confidence (no basis
+    // for anything finer), but a DIFFERENT source than SessionOnly so
+    // consumers that filter "carries no real-world anchor" don't drop it.
     std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
     recs.emplace_back(DID_IMU, bytesOf(makeImu(1.0)));
     recs.emplace_back(DID_IMU, bytesOf(makeImu(2.0)));
@@ -195,11 +228,75 @@ TEST_F(TimeResolverTest, EmptyLogResolvesAsSessionOnly) {
 
     EXPECT_TRUE(resolverR->syncPoints().empty());
 
-    TimeStamp t = resolverR->resolve(50000, kFixtureSerial);
-    EXPECT_EQ(t.source, TimeSource::SessionOnly);
+    TimeStamp t1 = resolverR->resolve(50000, kFixtureSerial);
+    EXPECT_EQ(t1.source, TimeSource::FileTimeAnchored);
+    EXPECT_EQ(t1.confidence, TimeConfidence::Unknown);
+    EXPECT_EQ(t1.deviceId, kFixtureSerial);
+    EXPECT_GT(t1.value, 50000u);   // anchored, not a raw passthrough of the input
+
+    // The anchor is additive: two queries a known delta apart resolve that
+    // same delta apart.
+    TimeStamp t2 = resolverR->resolve(60000, kFixtureSerial);
+    EXPECT_EQ(t2.value - t1.value, 10000u);
+}
+
+// Kyle 2026-09-07 (Option B), filename tier: a segment renamed to look like
+// cISLogger's own `..._YYYYMMDD_HHMMSS_..` convention resolves via that name.
+// A deliberately old, fixed date (nothing "now" could coincidentally produce)
+// proves which tier fired, rather than the other file-anchor tests' incidental
+// use of cISLogger's own real-time-stamped auto-generated filename.
+TEST_F(TimeResolverTest, FileAnchorParsesTimestampFromFilename) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    recs.emplace_back(DID_IMU, bytesOf(makeImu(1.0)));
+    f = buildFixture("filename_anchor", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+    ASSERT_FALSE(renameFixtureTo(f, "LOG_SN12345_20200615_101530_0001").empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value()) << log.error().message;
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+    ASSERT_TRUE(resolver->syncPoints().empty());
+
+    std::tm tm{};
+    tm.tm_year = 2020 - 1900; tm.tm_mon = 6 - 1; tm.tm_mday = 15;
+    tm.tm_hour = 10;          tm.tm_min = 15;    tm.tm_sec  = 30;
+    const int64_t expectedMs = static_cast<int64_t>(timegm(&tm)) * 1000;
+
+    const TimeStamp t = resolver->resolve(0, kFixtureSerial);
+    EXPECT_EQ(t.source, TimeSource::FileTimeAnchored);
     EXPECT_EQ(t.confidence, TimeConfidence::Unknown);
-    EXPECT_EQ(t.value, 50000u);
-    EXPECT_EQ(t.deviceId, kFixtureSerial);
+    EXPECT_EQ(static_cast<int64_t>(t.value), expectedMs);
+}
+
+// Kyle 2026-09-07 (Option B), ctime tier: a name with no digits at all falls
+// back to the segment file's last-write time.
+TEST_F(TimeResolverTest, FileAnchorFallsBackToLastWriteTimeWhenNameDoesNotParse) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    recs.emplace_back(DID_IMU, bytesOf(makeImu(1.0)));
+    f = buildFixture("ctime_anchor", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+    ASSERT_FALSE(renameFixtureTo(f, "nogpslog").empty());
+
+    const auto beforeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value()) << log.error().message;
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+    ASSERT_TRUE(resolver->syncPoints().empty());
+
+    const auto afterMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    const TimeStamp t = resolver->resolve(0, kFixtureSerial);
+    EXPECT_EQ(t.source, TimeSource::FileTimeAnchored);
+    // Anchored near "now" (the file's last-write time), within generous slack
+    // for test execution time -- proves the ctime tier fired, not a stale or
+    // zero value.
+    EXPECT_GE(static_cast<int64_t>(t.value), beforeMs - 5000);
+    EXPECT_LE(static_cast<int64_t>(t.value), afterMs + 5000);
 }
 
 // ---------------------------------------------------------------------------
@@ -317,6 +414,41 @@ TEST_F(TimeResolverTest, UnsyncedSysParamsDoesNotEstablishOffset) {
     // mag does NOT land at that value.
     auto t = resolver->resolve(50'000, kFixtureSerial);
     EXPECT_NE(t.value, expectedUnixMsForFixtureWeek(200'045'000ull, 2300));
+}
+
+// Kyle 2026-09-07 (Option A): a log with a SYNCED DID_SYS_PARAMS but NO INS/GNSS
+// record at all (a manufacturing/bench-calibration capture -- the bug report
+// this fix responds to) used to have zero sync points regardless, because
+// DID_SYS_PARAMS wasn't in kToWBearingDids -- its synced ToW was only ever used
+// to calibrate OTHER DIDs' uptime bridge, never pushed as an anchor itself.
+TEST_F(TimeResolverTest, SyncedSysParamsAloneEstablishesSyncPoints) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    for (uint32_t towMs : { 200'000'000u, 200'010'000u, 200'020'000u }) {
+        recs.emplace_back(DID_SYS_PARAMS,
+                          bytesOf(makeSysParams((towMs - 200'000'000u) / 1000.0 + 5.0, towMs)));
+    }
+    f = buildFixture("sysparams_only_synced", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+
+    auto syncs = ISTimeResolver::detectSyncPoints(log.value());
+    ASSERT_FALSE(syncs.empty())
+        << "a synced DID_SYS_PARAMS record should establish a sync point on its own";
+    for (const auto& sp : syncs) {
+        EXPECT_EQ(sp.sourceDid, static_cast<uint32_t>(DID_SYS_PARAMS));
+    }
+
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // Exact match against one of the sync points' own raw .idx timestamp
+    // (== its timeOfWeekMs, the sync-record identity convention) resolves
+    // PayloadToW/Exact -- not FileTimeAnchored/Unknown.
+    const TimeStamp t = resolver->resolve(200'010'000u, kFixtureSerial);
+    EXPECT_EQ(t.source, TimeSource::PayloadToW);
+    EXPECT_EQ(t.confidence, TimeConfidence::Exact);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Extends ISLogReader to read .dat segments (cDeviceLogSerial's chunk-header- framed, already-parsed p_data_hdr_t/payload format) alongside .raw, via internal format-branching rather than a subclass -- ISDeviceLog stores ISLogReader by value in a std::vector, and ISLogReader has a private default ctor + non-virtual dtor, so a literal derived reader class doesn't fit. Per D0082 (Kyle's directive): cDeviceLogSerial/DataChunk.h are consulted only for the on-disk byte layout, never as an interface template.

- New SegmentFormat enum + format() accessor on ISLogReader, recognized by extension at construct() time.
- buildIndexFromScanDat(): walks sChunkHeader-framed chunks of p_data_hdr_t/payload pairs directly (no protocol parsing needed, unlike .raw's is_comm_parse_byte scan). Reuses the .idx v2 schema verbatim -- its on-disk layout has no .raw-specific coupling.
- recordEndOffset() branches for .dat: each record is self-delimiting (p_data_hdr_t.size), computed directly rather than inferred from the next record's offset (a .raw chunk-input artifact).
- deriveDeviceIdDat(): unlike .raw, a .dat record's .idx offset IS its p_data_hdr_t start (no wire framing in between), so this walks the already-built records_ instead of re-parsing chunk headers from scratch -- simpler than the .raw path. Extracted the shared filename-fallback logic (parseSerialFromFilenameStem) to avoid duplicating it a third time.
- ISDeviceLog::fromSegments rejects mixed .raw/.dat segments in one composed device log (same pattern as its existing device-id-mismatch check).
- Fixed ISLogger.h's eLogType enum comment, which had LOGTYPE_DAT/ LOGTYPE_RAW's descriptions backwards relative to DeviceLogSerial.h/ DeviceLogRaw.h's authoritative file docs.
- New tests/test_log_reader_dat.cpp (7 tests): open/header/DID-list parity, sidecar rebuild-and-reuse, mid-chunk truncation, multi-segment rollover, and a record-for-record equivalence test against .raw (decodes the same synthetic wire messages into parsed (hdr, payload) pairs, feeds both writers, asserts both readers agree record-for-record on DID + timestamp).

Full existing suite (627 tests) stays green -- zero .raw regressions from the shared-function branching in construct()/recordEndOffset()/ deriveDeviceId().

RawSeriesBuilder's consumer-side follow-up (bytes() for .dat is the raw on-disk payload, not synthesized wire framing -- 4 call sites there plus derivation_helpers.h's walkPayloads<T> need a format-aware branch to skip the comm-reparse) is SN-8627's scope, not this story.