### PR TITLE
SN-8629: fix ISDeviceLog::fromSegments mixed-domain segment mis-ordering

### DIFF
--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -249,6 +249,10 @@ bool cDeviceLog::OpenNewSaveFile()
 #if LOG_DEBUG_FILE_WRITE
         printf("cDeviceLog::OpenNewSaveFile %s\n", fileName.c_str());
 #endif
+        if (WantsDeviceInfoSidecar())
+        {
+            WriteDeviceInfoSidecar();
+        }
         return true;
     }
     else
@@ -258,6 +262,58 @@ bool cDeviceLog::OpenNewSaveFile()
 #endif
         return false;
     }
+}
+
+bool cDeviceLog::WriteDeviceInfoSidecar()
+{
+    if (m_fileName.empty() || device == nullptr)
+    {
+        return false;
+    }
+
+    const dev_info_t devInfo = device->devInfo;
+
+    is_comm_instance_t comm = {};
+    uint8_t commBuf[PKT_BUF_SIZE];
+    is_comm_init(&comm, commBuf, sizeof(commBuf), NULLPTR);
+
+    uint8_t pktBuf[PKT_BUF_SIZE];
+    std::vector<uint8_t> out;
+
+    int n = is_comm_data_to_buf(pktBuf, sizeof(pktBuf), &comm, DID_DEV_INFO, sizeof(dev_info_t), 0,
+                                 const_cast<dev_info_t*>(&devInfo));
+    if (n > 0)
+    {
+        out.insert(out.end(), pktBuf, pktBuf + n);
+    }
+
+    if (devInfo.hardwareType == IS_HARDWARE_TYPE_GPX)
+    {
+        gpx_flash_cfg_t flashCfg = device->gpxFlashCfg;
+        n = is_comm_data_to_buf(pktBuf, sizeof(pktBuf), &comm, DID_GPX_FLASH_CFG, sizeof(gpx_flash_cfg_t), 0, &flashCfg);
+    }
+    else
+    {
+        nvm_flash_cfg_t flashCfg = device->imxFlashCfg;
+        n = is_comm_data_to_buf(pktBuf, sizeof(pktBuf), &comm, DID_FLASH_CONFIG, sizeof(nvm_flash_cfg_t), 0, &flashCfg);
+    }
+    if (n > 0)
+    {
+        out.insert(out.end(), pktBuf, pktBuf + n);
+    }
+
+    if (out.empty())
+    {
+        return false;
+    }
+
+    cISLogFile dviFile(m_fileName + ".dvi", "wb");
+    if (!dviFile.isOpened())
+    {
+        return false;
+    }
+
+    return dviFile.write(out.data(), out.size()) == out.size();
 }
 
 

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -486,6 +486,13 @@ bool cDeviceLog::finalizeIndex() {
     hdr.total_records       = m_idxTotalRecords;
     hdr.first_timestamp_ms  = m_idxFirstTimestampMs;
     hdr.last_timestamp_ms   = m_idxLastTimestampMs;
+    // SN-8629: ts_units = HostUptimeMs (set above by makeDefaultHeader) would be
+    // a lie if the first/last timestamps landed in different domains -- flag it
+    // Mixed so cross-segment consumers (ISDeviceLog::fromSegments) know these
+    // two values aren't safely comparable against another segment's.
+    if (timestampsLookMixedDomain(hdr.first_timestamp_ms, hdr.last_timestamp_ms)) {
+        hdr.ts_units = static_cast<uint8_t>(TimestampUnits::Mixed);
+    }
     // Preserve the v2.1 flags across the finalize header rewrite (the plain
     // "= FINALIZED" would otherwise drop HAS_LOCAL_DELTA / HAS_CAPTURE_EPOCH).
     hdr.flags               = static_cast<uint8_t>(

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -306,6 +306,37 @@ protected:
     bool OpenNewSaveFile();
 
     /**
+     * @brief Whether this log format wants a one-time ".dvi" device-info sidecar written
+     * alongside each new segment (see WriteDeviceInfoSidecar()).
+     *
+     * Default false. Raw-ISB-wire formats (cDeviceLogRaw, cDeviceLogSerial) override this to
+     * return true; CSV/JSON/KML don't, since a raw-ISB-encoded DID_DEV_INFO/FLASH_CONFIG record
+     * wouldn't mean anything alongside those formats' own on-disk encodings.
+     *
+     * @return true if OpenNewSaveFile() should call WriteDeviceInfoSidecar() for this segment.
+     */
+    virtual bool WantsDeviceInfoSidecar() const { return false; }
+
+    /**
+     * @brief Writes a one-time ".dvi" sidecar (same base name as m_fileName) so a reader that
+     * opens ONLY this segment can still identify the device and its configuration even if this
+     * segment never itself streamed a DID_DEV_INFO/FLASH_CONFIG record (e.g. a mid-session
+     * rollover, or a device that was already configured before logging started).
+     *
+     * Contains, in raw ISB wire format (the same encoding live device data records use): one
+     * DID_DEV_INFO record snapshotting device->devInfo, then one DID_FLASH_CONFIG or
+     * DID_GPX_FLASH_CFG record (whichever matches devInfo.hardwareType) snapshotting
+     * device->imxFlashCfg / device->gpxFlashCfg. Best-effort and non-blocking: reads whatever the
+     * bound device has cached at this instant rather than waiting on flash-config sync, so a
+     * session's very first segment can carry a zeroed flash config if sync hasn't completed yet;
+     * later segments (rotations) will have had time to catch up.
+     *
+     * @return true on success; false (silently) if there's no bound device, no file name has
+     * been set yet, encoding produced nothing, or the `.dvi` file couldn't be created.
+     */
+    bool WriteDeviceInfoSidecar();
+
+    /**
      * @brief Close any currently open read file and open the next one discovered by SetupReadInfo().
      * @return true if a next file was opened; false if every discovered file has already been consumed, or the open failed.
      */

--- a/src/DeviceLogRaw.h
+++ b/src/DeviceLogRaw.h
@@ -74,6 +74,10 @@ public:
 
     cDataChunk m_chunk;     //!< staging buffer for not-yet-flushed raw bytes; written/read with no chunk header (see the file-level documentation)
 
+protected:
+    /** @brief The `.raw` on-disk stream IS raw ISB wire bytes, so a `.dvi` sidecar in that same encoding is meaningful here. */
+    bool WantsDeviceInfoSidecar() const OVERRIDE { return true; }
+
 private:
     /** @brief Initialize `m_comm` and enable the recognized protocols (IS binary data, NMEA, RTCM3, u-blox). */
     void initCommInstance();

--- a/src/DeviceLogSerial.h
+++ b/src/DeviceLogSerial.h
@@ -64,6 +64,10 @@ public:
 
     cDataChunk m_chunk;     //!< staging buffer for not-yet-flushed header/payload pairs; written/read with a full chunk header (see the file-level documentation)
 
+protected:
+    /** @brief The `.dat` chunk framing is internal to this format, but the `.dvi` sidecar is its own self-contained raw-ISB-encoded file (like `.idx`), so it's meaningful here too. */
+    bool WantsDeviceInfoSidecar() const OVERRIDE { return true; }
+
 private:
     /**
      * @brief Pop the next header/payload pair off the front of `m_chunk`.

--- a/src/ISDeviceLog.cpp
+++ b/src/ISDeviceLog.cpp
@@ -9,6 +9,7 @@
 
 #include "ISDeviceLog.h"
 
+#include "ISLogIndex.h"       // SN-8629 timestampsLookMixedDomain()
 #include "ISTimeResolver.h"   // SN-8105 anchored-span accessors
 #include "core/msg_logger.h"
 
@@ -77,14 +78,33 @@ ISExpected<ISDeviceLog>
     // when present (D-01 writer fills this; D-04 scan-rebuild does too)
     // and fall back to the path's lexicographic order otherwise — the
     // writer's filename pattern is timestamp-sortable per D0051.
-    std::sort(readers.begin(), readers.end(),
-        [](const ISLogReader& a, const ISLogReader& b) {
-            const uint64_t aT = a.segmentStartTimestamp();
-            const uint64_t bT = b.segmentStartTimestamp();
-            if (aT && bT && aT != bT) return aT < bT;
-            // Rely on filename-lex ordering as the tiebreaker.
-            return false;  // stable; preserve input order on ties
+    //
+    // SN-8629: a numeric comparison across TWO segments is only meaningful
+    // when both segments' own timestamps are internally self-consistent
+    // (start <= end) — a segment whose first/last landed on different
+    // domains (e.g. one host-uptime, one GPS time-of-week; D0066) fails
+    // that check, and its header value is not safely comparable against
+    // another segment's. Rather than pick and choose per-pair (which is not
+    // provably transitive — sorting requires a strict weak ordering), any
+    // one bad segment disables header-based ordering for the WHOLE
+    // composition; std::stable_sort then leaves everything in the
+    // filename-lexicographic order already established above, which is
+    // always safe (D0051) and correct for the common/comparable case too
+    // (that's the whole premise of the filename pattern being sortable).
+    const bool allSegmentsSelfConsistent = std::all_of(readers.begin(), readers.end(),
+        [](const ISLogReader& r) {
+            return !idx::timestampsLookMixedDomain(r.segmentStartTimestamp(), r.segmentEndTimestamp());
         });
+    if (allSegmentsSelfConsistent) {
+        std::stable_sort(readers.begin(), readers.end(),
+            [](const ISLogReader& a, const ISLogReader& b) {
+                const uint64_t aT = a.segmentStartTimestamp();
+                const uint64_t bT = b.segmentStartTimestamp();
+                if (aT && bT && aT != bT) return aT < bT;
+                // Rely on filename-lex ordering as the tiebreaker.
+                return false;  // stable; preserve input order on ties
+            });
+    }
 
     ISDeviceLog out;
     out.segments_ = std::move(readers);

--- a/src/ISLogIndex.h
+++ b/src/ISLogIndex.h
@@ -78,6 +78,31 @@ enum class HeaderTimeSource : uint8_t {
     Mixed            = 4,
 };
 
+/**
+ * @brief SN-8629: cheap, metadata-free signal that a segment's own
+ * `first_timestamp_ms` / `last_timestamp_ms` are NOT safely comparable
+ * against another segment's.
+ *
+ * `first_timestamp_ms` and `last_timestamp_ms` are whatever the first/last
+ * record's payload-derived timestamp happened to be — which DID landed on
+ * that edge decides the domain (e.g. host-uptime vs GPS time-of-week), and
+ * that can differ between two segments of the very same log (D0066: `.idx`
+ * is mixed-domain by design). `firstMs > lastMs` is direct, in-band proof
+ * that a domain mismatch landed on one of this segment's edges — a
+ * healthy, single-domain-at-the-edges segment is always chronologically
+ * non-decreasing. It does not catch every possible cross-segment mismatch
+ * (two segments can each look internally consistent yet still disagree
+ * with each other), but it catches the failure mode this system actually
+ * produces, without requiring any new per-DID domain classification.
+ *
+ * @param firstMs  Segment's `first_timestamp_ms` (0 = unset/unknown).
+ * @param lastMs   Segment's `last_timestamp_ms` (0 = unset/unknown).
+ * @return  `true` if both are set and `firstMs > lastMs`.
+ */
+inline constexpr bool timestampsLookMixedDomain(uint64_t firstMs, uint64_t lastMs) noexcept {
+    return firstMs != 0 && lastMs != 0 && firstMs > lastMs;
+}
+
 // ----- Record flag bits ----------------------------------------------------
 
 /// Bit 0: this record's payload carried a real GPS time-of-week field

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -616,6 +616,11 @@ void ISLogReader::buildIndexFromScan() {
         header_.first_timestamp_ms  = records_.front().timestamp;
         header_.last_timestamp_ms   = records_.back().timestamp;
         header_.flags |= idx::IS_LOG_IDX_HDR_FLAG_FINALIZED;
+        // SN-8629: see timestampsLookMixedDomain() -- the default HostUptimeMs
+        // (set when this reader's header was seeded) would be a lie here.
+        if (idx::timestampsLookMixedDomain(header_.first_timestamp_ms, header_.last_timestamp_ms)) {
+            header_.ts_units = static_cast<uint8_t>(idx::TimestampUnits::Mixed);
+        }
     }
 }
 

--- a/src/ISLogWriter.cpp
+++ b/src/ISLogWriter.cpp
@@ -283,6 +283,13 @@ ISExpected<void> ISLogWriter::writeFinalHeader() {
     header_.sync_point_count   = syncPointCount_;
     header_.flags             |= idx::IS_LOG_IDX_HDR_FLAG_FINALIZED;
 
+    // SN-8629: override the caller's ts_units (informational, opts.tsUnits)
+    // when first/last prove it can't be a single domain -- see
+    // timestampsLookMixedDomain().
+    if (idx::timestampsLookMixedDomain(header_.first_timestamp_ms, header_.last_timestamp_ms)) {
+        header_.ts_units = static_cast<uint8_t>(idx::TimestampUnits::Mixed);
+    }
+
     idxStream_.flush();
     idxStream_.seekp(0, std::ios::beg);
     if (!idxStream_.good()) {

--- a/tests/test_device_log.cpp
+++ b/tests/test_device_log.cpp
@@ -8,6 +8,7 @@
 #include "com_manager.h"  // first — see test_log_reader.cpp comment
 
 #include "DeviceLog.h"
+#include "ISDevice.h"
 #include "ISDeviceLog.h"
 #include "ISFileManager.h"
 #include "ISLogFile.h"      // cISLogFile (SN-8383/8340 .idx inspection)
@@ -17,7 +18,9 @@
 
 #include <atomic>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <list>
 #include <string>
 #include <vector>
@@ -288,4 +291,204 @@ TEST(ISDeviceLog, WriterStampsV21LocalDeltaAndCaptureEpoch) {
     }
 
     teardown(f);
+}
+
+// ---------------------------------------------------------------------------
+// No Jira card (rolled into SN-8629 at Kyle's request): a log segment that
+// never itself streams a DID_DEV_INFO/FLASH_CONFIG record (a mid-session
+// rollover, or a device that was already configured before logging started)
+// has no way for a reader that opens ONLY that segment to identify the
+// device. Fix: cDeviceLog::OpenNewSaveFile() now writes a one-time ".dvi"
+// sidecar (same base name as the segment) containing a single DID_DEV_INFO
+// record and a single DID_FLASH_CONFIG/DID_GPX_FLASH_CFG record, in raw ISB
+// wire format, snapshotting whatever the bound ISDevice has cached at that
+// instant. Only cDeviceLogRaw/cDeviceLogSerial (the raw-ISB-wire formats)
+// opt in; CSV/JSON/KML don't.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Parses a .dvi (or any raw-ISB-wire byte stream) and returns each
+// DID_DEV_INFO/DID_FLASH_CONFIG/DID_GPX_FLASH_CFG record found, in order.
+struct DviRecord {
+    uint32_t did;
+    std::vector<uint8_t> payload;
+};
+
+std::vector<DviRecord> parseDviFile(const fs::path& path) {
+    std::vector<DviRecord> out;
+    std::ifstream in(path, std::ios::binary);
+    if (!in.is_open()) return out;
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+    is_comm_instance_t comm{};
+    uint8_t commBuf[PKT_BUF_SIZE];
+    is_comm_init(&comm, commBuf, sizeof(commBuf), NULLPTR);
+
+    for (uint8_t b : bytes) {
+        protocol_type_t p = is_comm_parse_byte(&comm, b);
+        if (p != _PTYPE_INERTIAL_SENSE_DATA && p != _PTYPE_INERTIAL_SENSE_CMD) continue;
+        DviRecord rec;
+        rec.did = comm.rxPkt.dataHdr.id;
+        rec.payload.assign(comm.rxPkt.data.ptr, comm.rxPkt.data.ptr + comm.rxPkt.dataHdr.size);
+        out.push_back(std::move(rec));
+    }
+    return out;
+}
+
+// Builds a device with fully-controlled devInfo/flash-config content and logs
+// one small buffer through a fresh cISLogger (LOGTYPE_RAW or LOGTYPE_DAT) so
+// exactly one segment opens, then closes. Returns the segment's base path
+// (without extension) and the fixture directory (caller deletes it).
+struct DviFixture {
+    fs::path directory;
+    fs::path segmentBase;  // directory / basename, no extension
+};
+
+DviFixture buildDviFixture(const char* tag, cISLogger::eLogType logType,
+                           uint8_t hardwareType, uint32_t serial) {
+    DviFixture f;
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf), "/tmp/test_device_log_dvi_%s_%d_%ld",
+                  tag, ::getpid(), static_cast<long>(::time(nullptr)));
+    f.directory = dirBuf;
+    ISFileManager::DeleteDirectory(f.directory.string());
+
+    dev_info_t devInfo{};
+    devInfo.hardwareType = hardwareType;
+    devInfo.serialNumber = serial;
+    devInfo.hardwareVer[0] = 1;
+    devInfo.hardwareVer[1] = 2;
+
+    auto device = std::make_shared<ISDevice>(devInfo);
+    if (hardwareType == IS_HARDWARE_TYPE_GPX) {
+        device->gpxFlashCfg.checksum = 0xABCD1234u;
+    } else {
+        device->imxFlashCfg.checksum = 0xABCD1234u;
+    }
+
+    cISLogger logger;
+    cISLogger::sSaveOptions opts;
+    opts.logType = logType;
+    opts.useSubFolderTimestamp = false;
+    if (!logger.InitSave(f.directory.string(), opts)) return f;
+    auto devLogger = logger.registerDevice(device);
+    if (!devLogger) return f;
+    logger.EnableLogging(true);
+
+    const uint8_t payload[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    if (logType == cISLogger::LOGTYPE_RAW) {
+        logger.LogData(devLogger, sizeof(payload), payload);
+    } else {
+        // LogData(devLogger, int, const uint8_t*) is RAW-only; every other
+        // format (including DAT) takes an already-parsed p_data_hdr_t.
+        p_data_hdr_t hdr{};
+        hdr.id = DID_DIAGNOSTIC_MESSAGE;
+        hdr.size = sizeof(payload);
+        hdr.offset = 0;
+        logger.LogData(devLogger, &hdr, payload);
+    }
+    logger.CloseAllFiles();
+
+    std::vector<ISFileManager::file_info_t> files;
+    const char* ext = (logType == cISLogger::LOGTYPE_RAW) ? "\\.raw$" : "\\.dat$";
+    ISFileManager::GetAllFilesInDirectory(f.directory.string(), true, ext, files);
+    if (!files.empty()) {
+        fs::path p(files.front().name);
+        f.segmentBase = p.parent_path() / p.stem();
+    }
+    return f;
+}
+
+} // namespace
+
+TEST(DeviceInfoSidecar, RawWriterEmitsDviWithDevInfoAndImxFlashConfig) {
+    auto f = buildDviFixture("raw_imx", cISLogger::LOGTYPE_RAW, IS_HARDWARE_TYPE_IMX, 71501u);
+    ASSERT_FALSE(f.segmentBase.empty()) << "fixture failed to produce a segment";
+
+    const fs::path dviPath = fs::path(f.segmentBase.string() + ".dvi");
+    ASSERT_TRUE(fs::exists(dviPath)) << dviPath;
+
+    auto recs = parseDviFile(dviPath);
+    ASSERT_EQ(recs.size(), 2u) << "expected exactly DID_DEV_INFO + DID_FLASH_CONFIG";
+
+    EXPECT_EQ(recs[0].did, static_cast<uint32_t>(DID_DEV_INFO));
+    ASSERT_EQ(recs[0].payload.size(), sizeof(dev_info_t));
+    dev_info_t devInfo{};
+    std::memcpy(&devInfo, recs[0].payload.data(), sizeof(devInfo));
+    EXPECT_EQ(devInfo.serialNumber, 71501u);
+    EXPECT_EQ(devInfo.hardwareType, static_cast<uint8_t>(IS_HARDWARE_TYPE_IMX));
+
+    EXPECT_EQ(recs[1].did, static_cast<uint32_t>(DID_FLASH_CONFIG));
+    ASSERT_EQ(recs[1].payload.size(), sizeof(nvm_flash_cfg_t));
+    nvm_flash_cfg_t flashCfg{};
+    std::memcpy(&flashCfg, recs[1].payload.data(), sizeof(flashCfg));
+    EXPECT_EQ(flashCfg.checksum, 0xABCD1234u);
+
+    ISFileManager::DeleteDirectory(f.directory.string());
+}
+
+TEST(DeviceInfoSidecar, RawWriterEmitsGpxFlashConfigForGpxHardware) {
+    auto f = buildDviFixture("raw_gpx", cISLogger::LOGTYPE_RAW, IS_HARDWARE_TYPE_GPX, 71502u);
+    ASSERT_FALSE(f.segmentBase.empty()) << "fixture failed to produce a segment";
+
+    auto recs = parseDviFile(fs::path(f.segmentBase.string() + ".dvi"));
+    ASSERT_EQ(recs.size(), 2u);
+
+    // DID_DEV_INFO stays DID_DEV_INFO regardless of hardware type -- only the
+    // flash-config DID is conditional (per spec).
+    EXPECT_EQ(recs[0].did, static_cast<uint32_t>(DID_DEV_INFO));
+
+    EXPECT_EQ(recs[1].did, static_cast<uint32_t>(DID_GPX_FLASH_CFG));
+    ASSERT_EQ(recs[1].payload.size(), sizeof(gpx_flash_cfg_t));
+    gpx_flash_cfg_t flashCfg{};
+    std::memcpy(&flashCfg, recs[1].payload.data(), sizeof(flashCfg));
+    EXPECT_EQ(flashCfg.checksum, 0xABCD1234u);
+
+    ISFileManager::DeleteDirectory(f.directory.string());
+}
+
+TEST(DeviceInfoSidecar, DatWriterAlsoEmitsDvi) {
+    auto f = buildDviFixture("dat_imx", cISLogger::LOGTYPE_DAT, IS_HARDWARE_TYPE_IMX, 71503u);
+    ASSERT_FALSE(f.segmentBase.empty()) << "fixture failed to produce a segment";
+
+    const fs::path dviPath = fs::path(f.segmentBase.string() + ".dvi");
+    EXPECT_TRUE(fs::exists(dviPath)) << dviPath << " -- .dat (cDeviceLogSerial) must also opt in";
+
+    auto recs = parseDviFile(dviPath);
+    ASSERT_EQ(recs.size(), 2u);
+    EXPECT_EQ(recs[0].did, static_cast<uint32_t>(DID_DEV_INFO));
+    EXPECT_EQ(recs[1].did, static_cast<uint32_t>(DID_FLASH_CONFIG));
+
+    ISFileManager::DeleteDirectory(f.directory.string());
+}
+
+TEST(DeviceInfoSidecar, NoDviWhenNoDeviceBound) {
+    // A cDeviceLog constructed from bare hdwId/serialNo (no live ISDevice) has
+    // nothing to snapshot -- must silently skip the sidecar, not crash or emit
+    // an empty one.
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf), "/tmp/test_device_log_dvi_nodev_%d_%ld",
+                  ::getpid(), static_cast<long>(::time(nullptr)));
+    const std::string dir = dirBuf;
+    ISFileManager::DeleteDirectory(dir);
+
+    cISLogger logger;
+    cISLogger::sSaveOptions opts;
+    opts.logType = cISLogger::LOGTYPE_RAW;
+    opts.useSubFolderTimestamp = false;
+    ASSERT_TRUE(logger.InitSave(dir, opts));
+    auto devLogger = logger.registerDevice(kIMX5HwId, 71504u);
+    ASSERT_TRUE(devLogger != nullptr);
+    logger.EnableLogging(true);
+
+    const uint8_t payload[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    logger.LogData(devLogger, sizeof(payload), payload);
+    logger.CloseAllFiles();
+
+    std::vector<ISFileManager::file_info_t> dviFiles;
+    ISFileManager::GetAllFilesInDirectory(dir, true, "\\.dvi$", dviFiles);
+    EXPECT_TRUE(dviFiles.empty()) << "no bound ISDevice -- must not create a .dvi";
+
+    ISFileManager::DeleteDirectory(dir);
 }

--- a/tests/test_log_index.cpp
+++ b/tests/test_log_index.cpp
@@ -21,6 +21,7 @@
 // extern "C").
 #include "com_manager.h"
 #include "DeviceLog.h"
+#include "ISDeviceLog.h"
 #include "ISFileManager.h"
 #include "ISLogFile.h"
 #include "ISLogIndex.h"
@@ -797,5 +798,228 @@ TEST(IdxIntegration, ISLoggerMultiSegmentRotationProducesValidIdxPerSegment) {
 
     for (auto* msg : messages) delete msg;
     ISFileManager::DeleteDirectory(logPath);
+}
+
+// ---------------------------------------------------------------------------
+// SN-8629: ISDeviceLog::fromSegments composed segments out of order because
+// it sorted on header.first_timestamp_ms verbatim -- a raw, unqualified value
+// whose domain (host-uptime vs GPS time-of-week) depends on which DID
+// happened to be the first/last record written to a given segment (D0066).
+// Two fixes, both covered below:
+//   (1) The comparator in ISDeviceLog::fromSegments must not let a
+//       not-safely-comparable header value override filename order.
+//   (2) The writer must qualify first_timestamp_ms/last_timestamp_ms (here:
+//       flag ts_units = Mixed) when it has direct, in-band proof they aren't
+//       in one domain, so the file is honest about it on disk.
+// ---------------------------------------------------------------------------
+
+TEST(TimestampsLookMixedDomain, DetectsInversionOnly) {
+    using namespace inertial_sense::idx;
+    EXPECT_FALSE(timestampsLookMixedDomain(100, 200))   << "ascending -- consistent";
+    EXPECT_FALSE(timestampsLookMixedDomain(100, 100))   << "equal -- consistent";
+    EXPECT_TRUE (timestampsLookMixedDomain(200, 100))   << "first > last -- the SN-8629 signal";
+    EXPECT_FALSE(timestampsLookMixedDomain(0, 100))     << "unset first -- no signal either way";
+    EXPECT_FALSE(timestampsLookMixedDomain(100, 0))     << "unset last -- no signal either way";
+    EXPECT_FALSE(timestampsLookMixedDomain(0, 0))       << "both unset";
+}
+
+TEST(IdxIntegration, WriterFlagsMixedDomainWhenFirstExceedsLast) {
+    // First record is DID_INS_2 (payload timeOfWeek, GPS-ToW domain, ~590M ms)
+    // and the last is DID_IMUS_RAW (payload time, host-uptime domain, ~101K
+    // ms) -- the exact shape of the real SN-63736 capture that reproduced the
+    // bug: the header's first_timestamp_ms ends up numerically LARGER than
+    // its last_timestamp_ms.
+    TestDeviceLog log;
+    const auto basePath = makeTmpPath("mixed");
+    const std::string baseNoExt = basePath.substr(0, basePath.size() - 4);
+    log.prepareForIndexEmissionTest(baseNoExt);
+
+    ins_2_t ins2{};
+    ins2.timeOfWeek = 590000.000;  // -> 590,000,000 ms
+    p_data_hdr_t h1{};
+    h1.id = DID_INS_2;
+    h1.size = sizeof(ins_2_t);
+    log.addIndexRecord(&h1, reinterpret_cast<uint8_t*>(&ins2));
+
+    imus_t imus{};
+    imus.time = 101.000;  // -> 101,000 ms
+    p_data_hdr_t h2{};
+    h2.id = DID_IMUS_RAW;
+    h2.size = sizeof(imus_t);
+    log.addIndexRecord(&h2, reinterpret_cast<uint8_t*>(&imus));
+
+    ASSERT_TRUE(log.writeIndexChunk());
+    ASSERT_TRUE(log.finalizeIndex());
+
+    cISLogFile in(baseNoExt + ".idx", "rb");
+    ASSERT_TRUE(in.isOpened());
+    auto hdrR = readHeader(in);
+    ASSERT_TRUE(hdrR.has_value()) << hdrR.error().message;
+    EXPECT_EQ(hdrR->first_timestamp_ms, 590000000ULL);
+    EXPECT_EQ(hdrR->last_timestamp_ms, 101000ULL);
+    EXPECT_EQ(hdrR->ts_units, static_cast<uint8_t>(TimestampUnits::Mixed))
+        << "first > last is direct proof the two edges aren't one domain -- "
+           "ts_units must say so, not silently claim HostUptimeMs";
+
+    std::remove((baseNoExt + ".idx").c_str());
+}
+
+TEST(IdxIntegration, WriterKeepsDefaultUnitsWhenConsistent) {
+    // Both records are DID_IMUS_RAW (same domain), ascending -- the common,
+    // non-buggy case. ts_units must stay the conservative default; this is
+    // the non-regression half of the SN-8629 AC.
+    TestDeviceLog log;
+    const auto basePath = makeTmpPath("consistent");
+    const std::string baseNoExt = basePath.substr(0, basePath.size() - 4);
+    log.prepareForIndexEmissionTest(baseNoExt);
+
+    imus_t imus1{};
+    imus1.time = 100.000;
+    p_data_hdr_t h1{};
+    h1.id = DID_IMUS_RAW;
+    h1.size = sizeof(imus_t);
+    log.addIndexRecord(&h1, reinterpret_cast<uint8_t*>(&imus1));
+
+    imus_t imus2{};
+    imus2.time = 100.500;
+    p_data_hdr_t h2{};
+    h2.id = DID_IMUS_RAW;
+    h2.size = sizeof(imus_t);
+    log.addIndexRecord(&h2, reinterpret_cast<uint8_t*>(&imus2));
+
+    ASSERT_TRUE(log.writeIndexChunk());
+    ASSERT_TRUE(log.finalizeIndex());
+
+    cISLogFile in(baseNoExt + ".idx", "rb");
+    ASSERT_TRUE(in.isOpened());
+    auto hdrR = readHeader(in);
+    ASSERT_TRUE(hdrR.has_value()) << hdrR.error().message;
+    EXPECT_EQ(hdrR->first_timestamp_ms, 100000ULL);
+    EXPECT_EQ(hdrR->last_timestamp_ms, 100500ULL);
+    EXPECT_EQ(hdrR->ts_units, static_cast<uint8_t>(TimestampUnits::HostUptimeMs))
+        << "consistent first/last must not regress to Mixed";
+
+    std::remove((baseNoExt + ".idx").c_str());
+}
+
+TEST(IdxIntegration, PreFixMixedDomainHeaderStillParses) {
+    // AC A3: "a log written before it [the qualifier fix] still opens." A
+    // pre-fix writer always wrote ts_units = HostUptimeMs, even for a segment
+    // whose first/last were actually mixed-domain (the exact SN-63736 shape).
+    // No on-disk format changed -- only which enum value a healthy writer
+    // now chooses -- so a stale mislabeled header must still parse cleanly.
+    auto h = makeDefaultHeader(0, TimestampUnits::HostUptimeMs, HeaderTimeSource::Mixed);
+    h.first_timestamp_ms = 590000000ULL;  // mixed-domain, but pre-fix writer
+    h.last_timestamp_ms  = 101000ULL;     // never overrides ts_units for this
+    h.flags = IS_LOG_IDX_HDR_FLAG_FINALIZED;
+
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE];
+    serializeHeader(buf, h);
+    auto parsed = parseHeader(buf);
+    ASSERT_TRUE(parsed.has_value()) << "pre-fix (mislabeled) header must still parse";
+    EXPECT_EQ(parsed->ts_units, static_cast<uint8_t>(TimestampUnits::HostUptimeMs));
+    EXPECT_EQ(parsed->first_timestamp_ms, 590000000ULL);
+    EXPECT_EQ(parsed->last_timestamp_ms, 101000ULL);
+}
+
+namespace {
+
+// Builds a finalized, readable .idx + an empty companion .raw (openSegment
+// only needs the .raw to exist; a trusted on-disk .idx never touches its
+// bytes -- see ISLogReader::construct) for one ISDeviceLog::fromSegments
+// ordering test. `records` are (did, payload) pairs written in order.
+std::filesystem::path buildOrderingSegment(
+        const std::string& baseNoExt,
+        std::initializer_list<std::pair<uint32_t, std::vector<uint8_t>>> records) {
+    TestDeviceLog log;
+    log.prepareForIndexEmissionTest(baseNoExt);
+    for (auto& rec : records) {
+        p_data_hdr_t h{};
+        h.id   = rec.first;
+        h.size = static_cast<uint16_t>(rec.second.size());
+        log.addIndexRecord(&h, const_cast<uint8_t*>(rec.second.data()));
+    }
+    log.writeIndexChunk();
+    log.finalizeIndex();
+
+    const std::string rawPath = baseNoExt + ".raw";
+    std::FILE* f = std::fopen(rawPath.c_str(), "wb");  // empty; never read when the .idx is trusted
+    if (f) std::fclose(f);
+    return rawPath;
+}
+
+std::vector<uint8_t> makeIns2(double timeOfWeekSec) {
+    ins_2_t v{};
+    v.timeOfWeek = timeOfWeekSec;
+    std::vector<uint8_t> out(sizeof(v));
+    std::memcpy(out.data(), &v, sizeof(v));
+    return out;
+}
+
+std::vector<uint8_t> makeImusRaw(double timeSec) {
+    imus_t v{};
+    v.time = timeSec;
+    std::vector<uint8_t> out(sizeof(v));
+    std::memcpy(out.data(), &v, sizeof(v));
+    return out;
+}
+
+std::string orderingBasePath(const char* tag, const char* suffix) {
+    char buf[256];
+    std::snprintf(buf, sizeof(buf), "/tmp/test_log_index_order_%s_%d_%ld_SN99001_%s",
+                  tag, ::getpid(), static_cast<long>(::time(nullptr)), suffix);
+    return std::string{buf};
+}
+
+} // namespace
+
+TEST(ISDeviceLog, ComposesInFilenameOrderWhenASegmentIsMixedDomain) {
+    // AC A1. Segment "_0001" reproduces the exact SN-63736 shape: its first
+    // record is DID_INS_2 (ToW domain, ~590M ms) and its last is DID_IMUS_RAW
+    // (uptime domain, ~101K ms) -- first_timestamp_ms > last_timestamp_ms.
+    // Segment "_0002" is a single, consistent, small-valued record. Under the
+    // pre-fix comparator, comparing raw header values head-on (590,000,000 vs
+    // 101,500) placed "_0002" BEFORE "_0001", inverting the filename order
+    // that D0051 guarantees is correct.
+    const auto rawA = buildOrderingSegment(orderingBasePath("a1", "0001"),
+        { {DID_INS_2, makeIns2(590000.000)}, {DID_IMUS_RAW, makeImusRaw(101.000)} });
+    const auto rawB = buildOrderingSegment(orderingBasePath("a1", "0002"),
+        { {DID_IMUS_RAW, makeImusRaw(101.500)} });
+
+    auto dl = ISDeviceLog::fromSegments({ rawA, rawB });
+    ASSERT_TRUE(dl.has_value()) << dl.error().message;
+    ASSERT_EQ(dl->segmentCount(), 2u);
+    EXPECT_EQ(dl->segment(0).segmentStartTimestamp(), 590000000ULL)
+        << "must stay in filename order (_0001 first), not header order";
+    EXPECT_EQ(dl->segment(1).segmentStartTimestamp(), 101500ULL);
+
+    std::remove(rawA.string().c_str());
+    std::remove((rawA.string().substr(0, rawA.string().size() - 4) + ".idx").c_str());
+    std::remove(rawB.string().c_str());
+    std::remove((rawB.string().substr(0, rawB.string().size() - 4) + ".idx").c_str());
+}
+
+TEST(ISDeviceLog, ComposesInTimestampOrderWhenBothSegmentsAreConsistent) {
+    // AC A2 (non-regression). Both segments are internally self-consistent
+    // (single record each), but "_0002" (filename-later) has the SMALLER
+    // timestamp -- filename order and true chronological order disagree, so
+    // this can only pass if header-timestamp ordering is still trusted when
+    // it's safe to, exactly as before SN-8629.
+    const auto rawA = buildOrderingSegment(orderingBasePath("a2", "0001"),
+        { {DID_IMUS_RAW, makeImusRaw(200.000)} });
+    const auto rawB = buildOrderingSegment(orderingBasePath("a2", "0002"),
+        { {DID_IMUS_RAW, makeImusRaw(100.000)} });
+
+    auto dl = ISDeviceLog::fromSegments({ rawA, rawB });
+    ASSERT_TRUE(dl.has_value()) << dl.error().message;
+    ASSERT_EQ(dl->segmentCount(), 2u);
+    EXPECT_EQ(dl->segment(0).segmentStartTimestamp(), 100000ULL)
+        << "both consistent -- must still compose in TIMESTAMP order, not filename order";
+    EXPECT_EQ(dl->segment(1).segmentStartTimestamp(), 200000ULL);
+
+    std::remove(rawA.string().c_str());
+    std::remove((rawA.string().substr(0, rawA.string().size() - 4) + ".idx").c_str());
+    std::remove(rawB.string().c_str());
+    std::remove((rawB.string().substr(0, rawB.string().size() - 4) + ".idx").c_str());
 }
 

--- a/tests/test_truncated_log.cpp
+++ b/tests/test_truncated_log.cpp
@@ -117,11 +117,30 @@ TEST_F(TruncatedLogTest, MidPacketTruncation_StopsAtLastValidRecord) {
     ASSERT_TRUE(fullR.has_value());
     const std::size_t fullCount = fullR->recordCount();
     ASSERT_GT(fullCount, 100u) << "fixture too small to test truncation meaningfully";
+
+    // Pick a record strictly in the back half of the file whose byte range
+    // spans more than one byte, and cut partway through IT specifically --
+    // not an arbitrary "90% of file size" offset. GenerateRawLogData's
+    // message sizes come from an unseeded std::random_device (test_data_utils.cpp),
+    // so a fixed percentage occasionally landed exactly on a packet boundary
+    // instead of mid-packet, and isTruncated() correctly reported false in
+    // that case -- the test's own premise failed, intermittently, on CI.
+    std::size_t cutOffset = 0;
+    for (std::size_t idx = fullCount / 2; idx < fullCount; ++idx) {
+        const ISRecordView view = fullR->recordAt(idx);
+        const uint64_t start = view.offsetInFile();
+        const uint64_t size  = view.bytes().second;   // == recordEndOffset(idx) - start, per ISLogReader.h
+        if (size > 1) {
+            cutOffset = static_cast<std::size_t>(start + size / 2);
+            break;
+        }
+    }
+    ASSERT_GT(cutOffset, 0u) << "could not find a multi-byte record in the back half to truncate mid-packet";
+
     // Drop the reader to release its mmap before mutating the file.
     fullR = tl::unexpected<ISError>{ ISError{ ISErrorCode::Internal, "drop" } };
 
-    // Truncate the .raw at 90% of its size to land somewhere mid-packet.
-    const std::size_t truncatedSize = (f_.rawBytes * 9) / 10;
+    const std::size_t truncatedSize = cutOffset;
     fs::resize_file(f_.rawFile, truncatedSize);
     // Delete the .idx so the reader rebuilds and exercises the
     // truncation-detection path (the existing .idx still claims the


### PR DESCRIPTION
## Summary
`ISDeviceLog::fromSegments` sorted segments on `header.first_timestamp_ms` verbatim -- a raw, unqualified value whose domain (host-uptime vs GPS time-of-week) depends on which DID happened to land as a segment's first record (`.idx` is mixed-domain by design, D0066). When a rollover boundary put a ToW-domain record first in one segment, its raw value (~590M ms) numerically dwarfed a neighboring segment's host-uptime value (~101M ms), silently overriding the correct, D0051-guaranteed-sortable filename order.

**Fix (1), comparator** (`ISDeviceLog.cpp`): a segment whose own `first_timestamp_ms > last_timestamp_ms` is direct, in-band proof its edges aren't one comparable domain. Any one such segment now disables header-based reordering for the **whole composition** (a single global switch, not a per-pair heuristic -- keeps the comparator a valid strict weak ordering) and falls back to the filename-lexicographic order already established. Always safe per D0051, and a provable no-op for the healthy case.

**Fix (2), writer** (`DeviceLog.cpp`, `ISLogWriter.cpp`, `ISLogReader.cpp`): all three sites that finalize a segment's header unconditionally labeled `ts_units = HostUptimeMs`. They now flag `ts_units = Mixed` via a new `timestampsLookMixedDomain()` helper (`ISLogIndex.h`) when the same first>last signal fires, so the `.idx` is honest on disk instead of silently asserting a domain that isn't true. No on-disk format changed -- only which existing enum value a healthy writer chooses.

Two inventory notes: `InertialSense.cpp` wasn't touched (no `cISSerialPort` involved, unrelated file); this is purely `ISDeviceLog`/`ISLogWriter`/`ISLogReader`/`DeviceLog`/`ISLogIndex`.

## Root-cause verification (not inferred -- reproduced live)
Downloaded the ticket's 4 real attached `.idx` files (SN63736, 2026-09-05) and ran the actual `ISDeviceLog::fromSegments` against them (with empty companion `.raw` files -- a trusted on-disk `.idx` never touches `.raw` bytes):
- **Before fix**: composed as `_0001, _0002, _0004, _0003`; `spanEnd = 101001864` (21,533 ms short of the true end).
- **After fix**: composed as `_0001, _0002, _0003, _0004`; `spanEnd = 101023397` (the true end) -- exactly matching the ticket's ~21.5s symptom.

## Test plan
- [x] AC A1: new `ISDeviceLog.ComposesInFilenameOrderWhenASegmentIsMixedDomain` -- reproduces the exact SN-63736 shape (DID_INS_2 first, DID_IMUS_RAW last) with 2 synthetic segments. **Confirmed this test fails against the pre-fix comparator** (reverted locally, reran, restored) -- not a vacuous test.
- [x] AC A2 (non-regression): new `ISDeviceLog.ComposesInTimestampOrderWhenBothSegmentsAreConsistent` -- two consistent segments whose filename order deliberately disagrees with timestamp order; passes only if header-based reordering still works when safe.
- [x] AC A3: new `IdxIntegration.WriterFlagsMixedDomainWhenFirstExceedsLast` / `WriterKeepsDefaultUnitsWhenConsistent` / `PreFixMixedDomainHeaderStillParses` -- round-trip + backward-compat coverage.
- [x] Full `IS-SDK_unit-tests`: 622 passed, 4 pre-existing skips (unrelated fixtures), 0 failed.
- [ ] AC B3 (human/Kyle): the other two (unaffected) EvalTool captures from the same session aren't attached to the ticket -- only the reproducing one was. Worth a quick confirmation pass with the full archive Kyle has, but the fix is filename-order-preserving by construction so a regression there would be surprising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Addendum: `.dvi` device-info sidecar (no Jira card, rolled in at Kyle's request)

Separate from the ordering fix above: `cDeviceLog::OpenNewSaveFile()` now writes a one-time `.dvi` sidecar (same base name as the segment) alongside each new `.raw`/`.dat` segment, containing a single `DID_DEV_INFO` record and a single `DID_FLASH_CONFIG`/`DID_GPX_FLASH_CFG` record (raw ISB wire format, same encoding live device data uses). Fixes the case where a segment never itself streams a dev-info/flash-config record (mid-session rollover, or a device already configured before logging started) and a reader opening just that segment has no way to identify it.

- Opt-in via a new `WantsDeviceInfoSidecar()` virtual hook -- only `cDeviceLogRaw`/`cDeviceLogSerial` (the raw-ISB-wire formats) override it; CSV/JSON/KML don't.
- Non-blocking snapshot of whatever the bound `ISDevice` has cached at that instant (`devInfo`/`imxFlashCfg`/`gpxFlashCfg`) -- a session's very first segment can carry a zeroed flash config if sync hasn't completed, later rotations will have caught up.
- Note: the spec said "`DID_GPX_FLASH_CONFIG`" but the actual macro is `DID_GPX_FLASH_CFG` (struct `gpx_flash_cfg_t`) -- used the real name.

### Test plan
- [x] New `DeviceInfoSidecar.*` tests (4): IMX flash config, GPX flash config, `.dat` writer also emits one, no sidecar when no device is bound.
- [x] Full `IS-SDK_unit-tests`: 626 passed, 4 pre-existing unrelated skips, 0 failed.
