### PR TITLE
SN-8610: getParentDirectory() returns the parent for relative paths, not the whole path

### DIFF
--- a/src/ISFileManager.cpp
+++ b/src/ISFileManager.cpp
@@ -743,7 +743,9 @@ namespace ISFileManager {
         if (pos == std::string::npos)
             return false;
 
-        parent = std::string(path, 0, pos);
+        // Indexed against realPath, which is what pos was measured on -- a relative input was
+        // absolutised above, so the two strings do not share offsets.
+        parent = std::string(realPath, 0, pos);
         return true;
     }
 


### PR DESCRIPTION
## The bug

`ISFileManager::getParentDirectory()` measures the separator offset against `realPath` — the input absolutised against the working directory — then takes the substring from the original `path`:

```cpp
std::string realPath = path;
if (!isPathAbsolute(path)) {
    realPath = CurrentWorkingDirectory() + path_seperator + path;
}
auto pos = realPath.rfind(path_seperator);
if (pos == std::string::npos)
    return false;

parent = std::string(path, 0, pos);      // <-- indexed against realPath, applied to path
```

For a relative input the two strings don't share offsets. `pos` lands past the end of `path`, `std::string(path, 0, pos)` clamps the length, and `parent` comes back as the **entire path with the filename still attached** — not a directory at all. It returns `true` while doing so.

Absolute inputs are unaffected: `realPath` aliases `path`, so the offset is valid. So this only ever mis-answered for relative paths.

`getPathComponents()` inherits the same value through its `parent` out-param, which its own doc comment describes as "always an absolute path".

## Fix

One line — index the string the offset was measured on.

## Why it's safe

The change is a no-op for absolute paths, and for relative paths it replaces a value that could not have been correct for a function named `getParentDirectory`. Live callers in this repo:

| Call site | Effect |
|---|---|
| `ISFirmwareUpdater.cpp:1901` — `getParentDirectory(manifest_file, parentDir)` | Fixed if ever given a relative manifest path; that parent is used to resolve sibling image paths, so a relative manifest would previously have resolved them against a non-directory |
| `DeviceManager.cpp:701` — `getPathComponents(imgPath, imgDir, …)` | Same, via the inherited out-param |

Both are correct today only when handed absolute paths.

## How it was found

From ci_hdw. Its startup firmware-provenance report classifies a resolved-but-absent image by asking whether the containing directory exists — that distinguishes "this checkout doesn't build that firmware" (the permanent, benign state for IMX-6 and GPX-1 in the IMX repo, which has neither the images nor the toolchains) from "it should be here and isn't". Every relative path answered "no such directory", because the parent came back with the filename attached, so a genuinely missing image was mislabelled as merely unavailable.

Verified against all three states after the fix — image present, image absent with its directory present (`[MISSING]`), and directory absent (`not built in this environment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
