### PR TITLE
SN-8575: Fix to resolve symlinked serial port names on Linux

### DIFF
--- a/src/PortFactory.cpp
+++ b/src/PortFactory.cpp
@@ -108,10 +108,10 @@ std::string SerialPortFactory::resolvePortName(const std::string& pName) {
 
     // realpath() rather than readlink(): udev writes a RELATIVE target (a SYMLINK+="imx5" rule
     // produces /dev/imx5 -> ttyACM0, not -> /dev/ttyACM0), so readlink() alone yields a bare name
-    // that needs a "/dev/" prefix guessed back onto it -- which is how the equivalent block in
-    // InertialSense::BootloadFile() ends up producing "/dev//dev/ttyACM0" for an absolute target.
-    // realpath() also collapses multi-hop chains and always returns an absolute path, which is the
-    // form /sys/class/tty enumeration produces and therefore the form we need to match against.
+    // needing a "/dev/" prefix guessed back onto it -- which then breaks on any alias that IS
+    // absolute, producing "/dev//dev/ttyACM0". realpath() also collapses multi-hop chains and
+    // always returns an absolute path, which is the form /sys/class/tty enumeration produces and
+    // therefore the form we need to match against.
     char resolved[PATH_MAX] = {};
     if (realpath(pName.c_str(), resolved) == nullptr)
         return pName;   // dangling link; leave it for the caller's own existence checks to reject

--- a/src/PortFactory.cpp
+++ b/src/PortFactory.cpp
@@ -15,6 +15,8 @@
 #if PLATFORM_IS_LINUX
 #   include <dirent.h>
 #   include <sys/stat.h>
+#   include <stdlib.h>      // realpath()
+#   include <limits.h>      // PATH_MAX
 #endif
 
 // #define REMOTE_SOCAT_PORTS      // only does anything on linux
@@ -86,7 +88,54 @@ bool SerialPortFactory::validatePort(const std::string& pName, uint16_t pType) {
 #endif
 }
 
+std::string SerialPortFactory::resolvePortName(const std::string& pName) {
+#if !PLATFORM_IS_LINUX
+    // Windows: COM-port aliasing goes through QueryDosDevice, not the filesystem, so there is
+    // nothing here to resolve. Every other platform (Apple, embedded) falls through to the same
+    // no-op -- symlink resolution is only wired up for Linux, which is where SN-8575 was reported
+    // and the only host platform this is verified on. Note this is deliberately NOT "#if WINDOWS /
+    // #else": the POSIX branch below needs headers that are only included for Linux, so treating
+    // "not Windows" as "has a filesystem" would break the build everywhere else.
+    return pName;
+#else
+    // Resolve only something that is actually a symlink on disk. Callers reach here with regex
+    // PATTERNS as well as literal device paths ("*", "(.+)", "/dev/tty(ACM|USB)[0-9]+"); none of
+    // those name a file, so lstat() fails and they take this early return untouched. Gating on the
+    // filesystem rather than on the shape of the string is what keeps pattern matching unaffected.
+    struct stat st = {};
+    if (lstat(pName.c_str(), &st) != 0 || !S_ISLNK(st.st_mode))
+        return pName;
+
+    // realpath() rather than readlink(): udev writes a RELATIVE target (a SYMLINK+="imx5" rule
+    // produces /dev/imx5 -> ttyACM0, not -> /dev/ttyACM0), so readlink() alone yields a bare name
+    // that needs a "/dev/" prefix guessed back onto it -- which is how the equivalent block in
+    // InertialSense::BootloadFile() ends up producing "/dev//dev/ttyACM0" for an absolute target.
+    // realpath() also collapses multi-hop chains and always returns an absolute path, which is the
+    // form /sys/class/tty enumeration produces and therefore the form we need to match against.
+    char resolved[PATH_MAX] = {};
+    if (realpath(pName.c_str(), resolved) == nullptr)
+        return pName;   // dangling link; leave it for the caller's own existence checks to reject
+
+    return std::string(resolved);
+#endif
+}
+
 void SerialPortFactory::locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern, uint16_t pType) {
+    // A caller-supplied path may be a udev alias (/dev/imx5 -> ttyACM0) while getComPorts() below
+    // enumerates canonical /sys/class/tty names only, so an unresolved alias matches nothing no
+    // matter how the regex is written. Resolve before matching. Non-symlinks, patterns included,
+    // pass through untouched. (SN-8575)
+    //
+    // KNOWN LIMITATION: two conventions reach this function. OpenPorts() forwards the caller's
+    // string verbatim (the path SN-8575 reports, and the one this handles), but cltool's -ufpkg
+    // re-discovery loop passes it through utils::globToRegex() first, which escapes regex
+    // metacharacters. An alias containing one -- "/dev/imx5.0" arriving here as "/dev/imx5\.0" --
+    // is no longer a real path, so the lstat() gate above declines to resolve it. Un-escaping a
+    // regex back into a path would be guesswork; the underlying problem is that the two paths
+    // disagree about whether a port specifier is a literal or a pattern, which wants fixing on its
+    // own terms rather than being papered over here.
+    const std::string resolvedPattern = resolvePortName(pattern);
+
     // An unusable pattern must not abort a port scan by throwing out of it. std::regex's constructor
     // throws std::regex_error on any invalid expression, and callers reach this with strings they think
     // of as port SPECIFIERS rather than regexes -- cltool's default "*" (its all-ports token) is a valid
@@ -96,7 +145,7 @@ void SerialPortFactory::locatePorts(std::function<void(PortFactory*, uint16_t, s
     // so loudly enough to be fixed at the call site.
     std::regex matchPattern;
     try {
-        matchPattern.assign(pattern);
+        matchPattern.assign(resolvedPattern);
     } catch (const std::regex_error& e) {
         log_error(IS_LOG_PORT_FACTORY, "locatePorts(): pattern '%s' is not a valid regular expression (%s); "
                                        "matching all ports instead.", pattern.c_str(), e.what());
@@ -302,10 +351,18 @@ bool SerialPortFactory::validate_port__linux(uint16_t pType, const std::string& 
         return true;
 #endif
 
+    // The /sys/class/tty lookup below is keyed on the device's canonical kernel name, so an alias
+    // has to be resolved first: basename("/dev/imx5") is "imx5", and /sys/class/tty/imx5 does not
+    // exist even though the link resolves to a perfectly good device. Note the stat() above already
+    // succeeded for the alias, because stat() follows symlinks -- it is only this sysfs lookup that
+    // needs the canonical name. Reached with an alias via bindPort(), which never goes through
+    // locatePorts(). (SN-8575)
+    const std::string canonical = resolvePortName(pName);
+
     // Resolve the real hardware driver (walks past the kernel >= 6.8 "serial-base"
     // port/ctrl layers). An empty/"port" result means there is no genuine backing
     // driver, so the port is not valid.
-    std::string driver = get_driver__linux(utils::string_format("/sys/class/tty/%s", basename(pName.c_str())));
+    std::string driver = get_driver__linux(utils::string_format("/sys/class/tty/%s", basename(canonical.c_str())));
     if (driver.empty() || driver == "port")
         return false;   // these are not valid ports
 

--- a/src/PortFactory.h
+++ b/src/PortFactory.h
@@ -126,6 +126,25 @@ public:
     bool validatePort(const std::string& pName, uint16_t pType = 0) override;
 
     /**
+     * Resolves a caller-supplied port name to the canonical device path the OS enumerates it under.
+     *
+     * On Linux a serial port is commonly reached through a udev alias -- a rule carrying
+     * SYMLINK+="imx5" yields /dev/imx5 -> ttyACM0 -- but port discovery enumerates canonical kernel
+     * names from /sys/class/tty, and validation keys its sysfs lookup on that same canonical name.
+     * Either one, given an alias, rejects a device that is otherwise perfectly usable (SN-8575).
+     *
+     * Only an existing symlink is resolved. Everything else is returned unchanged: a canonical path,
+     * a name that does not exist, a dangling link, and -- importantly -- a regex pattern such as
+     * "*", "(.+)" or "/dev/tty(ACM|USB)[0-9]+", none of which name a file on disk. Pattern-based
+     * discovery is therefore unaffected. No-op on Windows, where COM-port aliasing is handled by
+     * QueryDosDevice rather than the filesystem.
+     *
+     * @param pName the port name, path, or pattern as supplied by the caller
+     * @return the canonical absolute device path if @p pName is a resolvable symlink, else @p pName
+     */
+    static std::string resolvePortName(const std::string& pName);
+
+    /**
      * Allocates and initializes a serial_port_t for the given port name. Does NOT open the device.
      * @param pName the serial device name/path to bind
      * @param pType additional port-type flags OR'd with PORT_TYPE__UART | PORT_TYPE__COMM

--- a/tests/test_PortFactory.cpp
+++ b/tests/test_PortFactory.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include "gtest_helpers.h"
@@ -22,6 +23,14 @@
 #include "TcpServerPortFactory.h"
 #include "PortManager.h"
 #include "Rtcm3CorrectionServer.h"
+
+// NOTE: must follow the SDK headers -- PLATFORM_IS_LINUX comes from ISConstants.h via those.
+#if PLATFORM_IS_LINUX
+#   include <unistd.h>
+#   include <stdlib.h>
+#   include <limits.h>
+#   include <sys/stat.h>
+#endif
 
 
 // SN-8478: Rtcm3CorrectionServer/cltool silently succeeded when the RTCM3 listener failed to
@@ -165,3 +174,219 @@ TEST(test_PortFactory, serialPortFactory_getComPorts) {
     EXPECT_EQ(count, (int)portNames.size());
     EXPECT_GE(count, 0);
 }
+
+// ---------------------------------------------------------------------------------------------
+// SN-8575: InertialSense::Open() failed for symlinked serial ports on Linux.
+//
+// A udev rule carrying SYMLINK+="imx5" yields /dev/imx5 -> ttyACM0, but port discovery enumerates
+// canonical kernel names from /sys/class/tty and validation keys its sysfs lookup on that same
+// canonical name. Given an alias, both rejected a device that open(2) handles without complaint.
+// SerialPortFactory::resolvePortName() resolves the alias; these tests cover it in three tiers:
+//
+//   1. the resolution logic itself, hermetically -- no device and no root needed
+//   2. non-regression on pattern semantics, which is where the risk in the change actually sits
+//   3. end-to-end against a real tty, skipped when the host has none
+// ---------------------------------------------------------------------------------------------
+
+#if PLATFORM_IS_LINUX
+
+namespace {
+
+/** Private temp directory for one test; removes its recorded entries and itself on destruction. */
+class TempDir {
+public:
+    TempDir() {
+        char tmpl[] = "/tmp/sn8575_portfactory_XXXXXX";
+        const char* d = mkdtemp(tmpl);
+        if (d != nullptr)
+            path_ = d;
+    }
+
+    ~TempDir() {
+        // Reverse order so a chain's intermediate links go before what they point at.
+        for (auto it = entries_.rbegin(); it != entries_.rend(); ++it)
+            unlink(it->c_str());
+        if (!path_.empty())
+            rmdir(path_.c_str());
+    }
+
+    TempDir(const TempDir&) = delete;
+    TempDir& operator=(const TempDir&) = delete;
+
+    bool valid() const { return !path_.empty(); }
+    const std::string& path() const { return path_; }
+
+    /** symlink(target, <dir>/name). @return the link's path, or "" on failure. */
+    std::string link(const std::string& name, const std::string& target) {
+        std::string p = path_ + "/" + name;
+        if (symlink(target.c_str(), p.c_str()) != 0)
+            return "";
+        entries_.push_back(p);
+        return p;
+    }
+
+    /** Creates a small regular file. @return its path. */
+    std::string file(const std::string& name) {
+        std::string p = path_ + "/" + name;
+        std::ofstream(p) << "not-a-device";
+        entries_.push_back(p);
+        return p;
+    }
+
+private:
+    std::string path_;
+    std::vector<std::string> entries_;
+};
+
+/**
+ * realpath() of @p p. Used for expectations rather than comparing against the path we constructed,
+ * because /tmp is itself a symlink on some distributions -- in which case resolvePortName() would
+ * (correctly) return a path that differs from the one the test built.
+ */
+std::string realOf(const std::string& p) {
+    char buf[PATH_MAX] = {};
+    return (realpath(p.c_str(), buf) != nullptr) ? std::string(buf) : std::string();
+}
+
+/** Every port name SerialPortFactory emits for @p pattern. */
+std::vector<std::string> located(const std::string& pattern) {
+    std::vector<std::string> names;
+    SerialPortFactory::getInstance().locatePorts(
+        [&names](PortFactory*, uint16_t, std::string name) { names.push_back(name); },
+        pattern, PORT_TYPE__UART);
+    return names;
+}
+
+} // namespace
+
+
+// --- Tier 1: resolution logic, hermetic -------------------------------------------------------
+
+// udev writes a RELATIVE target: a SYMLINK+="imx5" rule produces /dev/imx5 -> ttyACM0, NOT
+// -> /dev/ttyACM0. This is the form observed on hardware for SN-8575, and the reason
+// resolvePortName() uses realpath() rather than readlink() -- the latter yields a bare name that
+// would need a "/dev/" prefix guessed back onto it.
+TEST(test_PortFactory, resolvePortName_resolvesRelativeSymlink) {
+    TempDir tmp;
+    ASSERT_TRUE(tmp.valid());
+
+    const std::string target = tmp.file("ttyFAKE0");
+    const std::string link = tmp.link("imx5", "ttyFAKE0");     // relative, as udev writes it
+    ASSERT_FALSE(link.empty());
+
+    EXPECT_EQ(SerialPortFactory::resolvePortName(link), realOf(target));
+}
+
+TEST(test_PortFactory, resolvePortName_resolvesAbsoluteSymlink) {
+    TempDir tmp;
+    ASSERT_TRUE(tmp.valid());
+
+    const std::string target = tmp.file("ttyFAKE0");
+    const std::string link = tmp.link("imx5", target);         // absolute target
+    ASSERT_FALSE(link.empty());
+
+    EXPECT_EQ(SerialPortFactory::resolvePortName(link), realOf(target));
+}
+
+// A multi-hop chain must collapse to the final device, not to the next link.
+TEST(test_PortFactory, resolvePortName_resolvesChainedSymlinks) {
+    TempDir tmp;
+    ASSERT_TRUE(tmp.valid());
+
+    const std::string target = tmp.file("ttyFAKE0");
+    ASSERT_FALSE(tmp.link("middle", "ttyFAKE0").empty());
+    const std::string link = tmp.link("imx5", "middle");
+    ASSERT_FALSE(link.empty());
+
+    EXPECT_EQ(SerialPortFactory::resolvePortName(link), realOf(target));
+}
+
+// Anything that is not a symlink comes back byte-identical, so existing callers see no change.
+TEST(test_PortFactory, resolvePortName_leavesNonSymlinkUnchanged) {
+    TempDir tmp;
+    ASSERT_TRUE(tmp.valid());
+
+    const std::string regular = tmp.file("ttyFAKE0");
+    EXPECT_EQ(SerialPortFactory::resolvePortName(regular), regular);
+}
+
+// A dangling link is left alone deliberately: the caller's own existence checks should reject it,
+// rather than resolvePortName() inventing a path for a device that isn't there.
+TEST(test_PortFactory, resolvePortName_leavesDanglingSymlinkUnchanged) {
+    TempDir tmp;
+    ASSERT_TRUE(tmp.valid());
+
+    const std::string link = tmp.link("imx5", "no_such_target");
+    ASSERT_FALSE(link.empty());
+
+    EXPECT_EQ(SerialPortFactory::resolvePortName(link), link);
+}
+
+TEST(test_PortFactory, resolvePortName_leavesNonexistentPathUnchanged) {
+    const std::string missing = "/dev/sn8575_definitely_does_not_exist";
+    EXPECT_EQ(SerialPortFactory::resolvePortName(missing), missing);
+}
+
+// The property that keeps pattern-based discovery working: callers pass regexes through the same
+// argument as literal paths, and a regex never names a file, so the lstat() gate declines it.
+TEST(test_PortFactory, resolvePortName_leavesRegexPatternsUnchanged) {
+    const std::vector<std::string> patterns = {
+        "*",                            // cltool's all-ports token
+        "(.+)",                         // PortManager::discoverPorts()'s own default
+        ".*",                           // what globToRegex() turns "*" into
+        "/dev/tty(ACM|USB)[0-9]+",      // a genuine regex over device names
+        "/dev/ttyACM0,/dev/ttyUSB0",    // a comma-separated list
+        "",                             // empty
+    };
+    for (const auto& p : patterns)
+        EXPECT_EQ(SerialPortFactory::resolvePortName(p), p) << "pattern was mangled: " << p;
+}
+
+
+// --- Tier 2: non-regression on pattern semantics ----------------------------------------------
+
+// The wildcard reaches locatePorts() by two different routes and must behave the same as before on
+// both: verbatim from OpenPorts() as "*", which is an INVALID regex handled by locatePorts()'s
+// regex_error fallback, and as ".*" from cltool via utils::globToRegex(). Both must agree with the
+// explicit match-everything pattern. Correct (if weak) on a host with no serial ports at all.
+TEST(test_PortFactory, locatePorts_wildcardsStillMatchAllPorts) {
+    const std::vector<std::string> all = located("(.+)");
+    TEST_COUT << "host enumerates " << all.size() << " serial port(s)" << std::endl;
+
+    EXPECT_EQ(located("*"), all);      // invalid regex -> fallback path
+    EXPECT_EQ(located(".*"), all);     // globToRegex("*")
+}
+
+TEST(test_PortFactory, locatePorts_nonMatchingPatternYieldsNothing) {
+    EXPECT_TRUE(located("/dev/sn8575_no_such_port_[0-9]+").empty());
+}
+
+
+// --- Tier 3: end-to-end against a real tty, skipped when the host has none --------------------
+
+// The whole bug, start to finish: alias a real port, then assert both gates that used to reject it
+// now accept it. validatePort() covers the bindPort() entry point (which never goes through
+// locatePorts()), and locatePorts() covers Open() and CorrectionService.
+TEST(test_PortFactory, symlinkedPort_isValidatedAndLocated) {
+    const std::vector<std::string> all = located("(.+)");
+    if (all.empty())
+        GTEST_SKIP() << "no serial ports on this host; nothing to alias";
+
+    const std::string canonical = all.front();
+    TEST_COUT << "aliasing " << canonical << std::endl;
+
+    TempDir tmp;
+    ASSERT_TRUE(tmp.valid());
+    const std::string link = tmp.link("imx5", canonical);
+    ASSERT_FALSE(link.empty());
+
+    // Pre-fix both of these failed: validatePort() built /sys/class/tty/imx5/... (missing), and
+    // locatePorts() regex-matched the alias against canonical names it could never equal.
+    EXPECT_TRUE(SerialPortFactory::getInstance().validatePort(link, PORT_TYPE__UART));
+
+    const std::vector<std::string> viaAlias = located(link);
+    ASSERT_EQ(viaAlias.size(), 1u);
+    EXPECT_EQ(viaAlias.front(), canonical);   // reported under its canonical name, not the alias
+}
+
+#endif // PLATFORM_IS_LINUX


### PR DESCRIPTION
Fixes [SN-8575]. Related: inertialsense/inertial-sense-sdk#1283.  Reported by IMX-6 user, but is hardware-independent SDK issue and was reproduced.

`InertialSense::Open()` failed for any serial port reached through a udev alias on Linux — a rule
carrying `SYMLINK+="imx5"` gives `/dev/imx5 -> ttyACM0`, and opening `/dev/imx5` returned `false`
while `/dev/ttyACM0` on the same hardware worked. This resolves such an alias to its canonical
device path before name matching and before the sysfs lookup.

Rebased onto `develop` (`b31483b5`, i.e. after SN-8473's enumeration unification). One commit,
3 files, +304/-3.

## What we found

The report was filed from a source read and had never been run on hardware. It reproduced exactly
as described, and investigation turned up two things the ticket did not have.

**1. There are two independent blockers, not one.** The ticket treated
`validate_port__linux()` as a "separately, would also need" concern. It is a hard second gate,
confirmed failing on its own:

| Gate | Why an alias fails | Reached by |
| --- | --- | --- |
| `SerialPortFactory::locatePorts()` | regex-matches the caller's literal string against names enumerated from `/sys/class/tty`, which are canonical kernel names. An alias can never equal one. | `Open()`, `CorrectionService` |
| `SerialPortFactory::validate_port__linux()` | builds `/sys/class/tty/<basename>` for the driver lookup. `basename("/dev/imx5")` is `imx5`, and `/sys/class/tty/imx5` does not exist. | `bindPort()` |

Fixing only the regex gate would have left `bindPort()` broken — and `bindPort()` is public and
takes a caller-supplied name, which is exactly what `ExampleProjects/Minimal_ISDevice` does with
`argv`. Both gates were measured failing independently on hardware.

Worth noting *why* the second one is easy to miss: `validate_port__linux()`'s first check
(`stat()` + `S_ISCHR`) **passes** for an alias, because `stat()` follows symlinks. Only the sysfs
lookup fails.

**2. `CorrectionService` was a second broken entry point, not mentioned in the ticket.** Its
convenience constructor calls `locatePorts()` with the caller's port name directly and then
`bindPort()`, never touching `Open()`. Verified on hardware: constructing with the alias threw
`std::invalid_argument`, with the canonical name it bound. This is what decided *where* the fix
goes — see below.

## Why this fix

**One new function, `SerialPortFactory::resolvePortName()`, called from the two gates above.**

The alternative of resolving higher up in `InertialSense::OpenPorts()` was ruled out by evidence,
not preference: `CorrectionService` and `bindPort()` both bypass it. `locatePorts()` and
`validate_port__linux()` are where every affected entry point converges.

**Gated on the filesystem, not on the shape of the string.** Callers pass regex *patterns* through
the same argument as literal device paths (`*`, `(.+)`, `/dev/tty(ACM|USB)[0-9]+`). The function
resolves only what `lstat()` reports as an actual symlink, so a pattern — which never names a file —
passes through byte-identical. This is what keeps pattern-based discovery unaffected, and it is
structural rather than heuristic. Everything else is also returned unchanged: canonical paths,
nonexistent names, and dangling links (left for the caller's own existence checks to reject).

**`realpath()` rather than `readlink()`, and hardware drove that choice.** udev writes a *relative*
target — the observed link was `/dev/imx5 -> ttyACM0`, not `-> /dev/ttyACM0`. `readlink()` alone
yields a bare name needing a `/dev/` prefix guessed back onto it, which then breaks on any alias that
*is* absolute, producing `/dev//dev/ttyACM0`. `realpath()` also collapses multi-hop chains and always
returns an absolute path — the form `/sys/class/tty` enumeration produces, and therefore the form we
need to match against.

**On `SerialPortFactory`, not the `PortFactory` base.** `PortFactory` is a pure interface (every
member `virtual` + `= 0` apart from the `onPortAlias()` default), the semantics are
filesystem-specific and only this factory has filesystem names — the others match `host:port` URLs
and mDNS/relay specifiers — and there is no polymorphic call site: everything needing resolution is
already inside `SerialPortFactory`. If TCP hostname or mDNS-instance canonicalization ever becomes a
requirement, promoting this static to a `virtual` with an identity default on the base is a
mechanical refactor. Doing it now would spend an interface decision on speculation and put a new
virtual in front of all five factories plus any third-party ones, which the base class comment
explicitly invites.

**It is `static` (rather than file-local) so the resolution logic is unit-testable in CI without
hardware.** That is what tier 1 below relies on.

## Linux / Windows / other platforms

The whole POSIX body is gated:

```cpp
#if !PLATFORM_IS_LINUX
    return pName;      // no-op
#else
    ... lstat / realpath ...
#endif
```

| Platform | Behavior | Verified |
| --- | --- | --- |
| Linux | resolves aliases | **yes** — hardware + full suite |
| Windows | no-op. COM-port aliasing goes through `QueryDosDevice`, not the filesystem, so there is nothing to resolve. | no Windows host available |
| Apple / embedded | same no-op | not built here |

The guard is deliberately **not** `#if PLATFORM_IS_WINDOWS / #else`, which is how it was first
written. `ISConstants.h` defines three host platforms and `PLATFORM_IS_APPLE` does not imply
`PLATFORM_IS_LINUX`, so "not Windows" would have compiled `lstat`/`realpath`/`PATH_MAX` on Apple and
embedded where those headers are not included — turning an existing weakness into a hard build
error. macOS is not a current target and no work was done to support it; this just avoids *newly*
breaking it. (`validatePort()` and `getComPorts()` in this file are already
`#if WINDOWS / #elif LINUX / #endif` with no `#else`, so they have no return statement on Apple —
a pre-existing condition this PR neither fixes nor worsens.) An in-line comment records why the
guard is shaped this way so it is not "simplified" back later.

`<stdlib.h>`/`<limits.h>` are added to the existing `PLATFORM_IS_LINUX` include guard. They do
currently arrive transitively, but `realpath`'s path in is `<functional>` → `bits/stl_algo.h` →
`<cstdlib>` — a libstdc++ internal that no standard guarantees. This file already includes both
explicitly further down for the same `realpath`/`PATH_MAX` usage, so this follows its own convention.

## How it was tested

**Hardware** — IMX-5.0.6, `SN000525402`, fw `3.1.0-rc.146`, `/dev/ttyACM0` @ 921600, aliased to
`/dev/imx5` by a real udev `SYMLINK+=` rule (not a hand-made link). Every previously failing check
now passes, in the same run, on the same board:

| Check | Before | After |
| --- | --- | --- |
| `locatePorts("/dev/imx5")` | 0 ports | 1 port → `/dev/ttyACM0` |
| `validatePort("/dev/imx5")` | false | true |
| `Open("/dev/imx5", 921600)` | FALSE | TRUE — device identified |
| `CorrectionService("/dev/imx5")` | threw | bound → `/dev/ttyACM0` |

Controls held throughout: the canonical-name open still succeeds, and `open(2)` on the alias still
succeeds — so the failure was never the hardware, the baud rate, or permissions. Ports are still
reported under their canonical names, so enumeration identity is unchanged.

**Unit tests** — 10 new tests in `tests/test_PortFactory.cpp`, three tiers:

1. **Resolution logic, hermetic** (7) — relative link (the form udev writes), absolute link, chained
   link, non-symlink passthrough, dangling link, nonexistent path, and a set of regex patterns
   (`*`, `(.+)`, `.*`, `/dev/tty(ACM|USB)[0-9]+`, comma-list, empty) asserted to come back unmangled.
   Temp-dir symlinks; no device, no root, no network.
2. **Pattern non-regression** (2) — the wildcard reaches `locatePorts()` two ways and both must still
   match everything: verbatim `*` from `OpenPorts()` (an *invalid* regex, handled by the
   `regex_error` fallback) and `.*` from cltool via `utils::globToRegex()`. Plus a matches-nothing
   pattern still yielding nothing.
3. **End-to-end** (1) — alias a real tty, assert both previously failing gates accept it.
   `GTEST_SKIP()` when the host has no serial ports, so it passes on hardware and skips in CI.

| | Baseline (pre-change, same branch) | After |
| --- | --- | --- |
| Tests | 647 | 658 |
| Passed | 643 | 654 |
| Skipped | 4 | 4 (same four, all pre-existing opt-ins) |
| **Failed** | **0** | **0** |

**The tests were confirmed to discriminate.** A test that passes with and without the fix proves
nothing, so this was checked directly: with the two call sites reverted and `resolvePortName()` left
in place, tier 3 failed on **both** assertions (`validatePort` false, `locatePorts` 0 ports — the
original bug exactly) while tiers 1 and 2 passed. The tests fail for the right reason and pass for
the right reason.

## Known limitation (documented, not fixed)

Two conventions reach `locatePorts()`: `OpenPorts()` forwards the caller's string verbatim (the path
this ticket reports — handled), while cltool's `-ufpkg` re-discovery loop passes it through
`utils::globToRegex()` first, which escapes regex metacharacters. An alias containing one —
`/dev/imx5.0` arriving as `/dev/imx5\.0` — is no longer a real path, so the `lstat()` gate declines
it. Effect: during a cltool firmware-update run against a dotted alias, the periodic re-discovery
would not re-find the port.

Not fixed here on purpose. Un-escaping a regex back into a path is guesswork, and the real issue is
that these two paths disagree about whether a port specifier is a literal or a pattern. That wants
addressing on its own terms rather than being papered over inside `resolvePortName()`. Recorded as an
in-line `KNOWN LIMITATION` comment at the call site.

## Out of scope / follow-ups

- **The glob-vs-literal port specifier inconsistency** described under Known limitation above. Two
  call paths disagree about whether a port specifier is a literal path or a regex pattern, which is
  the root of that limitation and the only thing blocking metacharacter-bearing aliases.
- **Re-`Open()` in one process returns `TRUE` while `IsOpen()` reports `false`** and the device
  renders as `(Closed)`. Confirmed independent of this change by pointing both opens at the same
  path (first `IsOpen=true`, second `false`) — a singleton `PortManager` state artifact, visible now
  only because the first open no longer fails. Returning success for a port that is not open looks
  like a genuine inconsistency worth its own ticket.
- **IMX-6 is unverified.** The original report is IMX-6; only IMX-5 was available. The fix is
  entirely host-side path handling and cannot see the device — and after resolution the alias case
  becomes the canonical case, which the reporter states already works on their IMX-6. Their udev rule
  also uses the same `0483:5740` VID:PID as the IMX-5 tested here. Confirmation on IMX-6 would be
  good to have on the record.

## Notes for reviewers

Reproducing the original bug needs a udev alias, and two details in the ticket's recipe will waste
your time:

- Its rule matches `ATTRS{product}=="IMX-6"`. The IMX-5 here reports `"STM32 Virtual ComPort"` with
  the same VID:PID, so that rule matches nothing on this unit. Read the attributes off the device
  with `udevadm info -a -n /dev/ttyACM0` instead of hardcoding a product match.
- The rule is `ACTION=="add"`, but `udevadm trigger` defaults to `--action=change` and so silently
  does nothing. Use `udevadm trigger --action=add`, or replug the board.
  `sudo udevadm test $(udevadm info -q path -n /dev/ttyACM0) 2>&1 | grep -i symlink` distinguishes
  "rule is wrong" from "event never delivered".

Tier 3 of the new tests covers the same ground in-tree without any of that, using whatever tty the
host has.


[SN-8575]: https://inertialsense.atlassian.net/browse/SN-8575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ