### PR TITLE
SN-8571: audit bare portOpen() call sites; fix portOpenRetry() false-success bug

### DIFF
--- a/src/DeviceFactory.cpp
+++ b/src/DeviceFactory.cpp
@@ -68,9 +68,16 @@ std::unique_ptr<DeviceFactory::ValidationContext> DeviceFactory::beginValidation
         return nullptr;
     }
 
-    // Open port if needed (only when no shared device provided, i.e. standalone/blocking path)
+    if (timeoutMs <= 0)
+        timeoutMs = deviceTimeout;
+
+    // Open port if needed (only when no shared device provided, i.e. standalone/blocking path).
+    // portOpenRetry(), not a bare portOpen(): on an asynchronous transport (TCP) a single portOpen()
+    // call returns PORT_ERROR__NONE while the connect is still in flight, without setting
+    // PORT_FLAG__OPENED -- treating that as "open" would hand stepValidation() a port that isn't
+    // actually connected yet (SN-8571).
     if (!sharedDevice && !portIsOpened(port)) {
-        if (!portValidate(port) || (portOpen(port) != PORT_ERROR__NONE)) {
+        if (!portValidate(port) || (portOpenRetry(port, timeoutMs, 10) != PORT_ERROR__NONE)) {
             portClose(port);
             portInvalidate(port);
             return nullptr;
@@ -82,9 +89,6 @@ std::unique_ptr<DeviceFactory::ValidationContext> DeviceFactory::beginValidation
         log_more_debug(IS_LOG_DEVICE_FACTORY, "beginValidation: port '%s' is not a COMM port (type=0x%04X), skipping.", portName(port), portType(port));
         return nullptr;
     }
-
-    if (timeoutMs <= 0)
-        timeoutMs = deviceTimeout;
 
     // Let the factory decline this port
     if (!onBeginValidation(port, hdwId)) {

--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -20,6 +20,7 @@ bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t
     bool result = false;
     options = (options != OPTIONS_USE_DEFAULTS) ? options : managementOptions;
     options = (options == OPTIONS_USE_DEFAULTS) ? DISCOVERY__DEFAULTS : options;
+    const uint32_t effectiveTimeout = (timeoutMs > 0) ? timeoutMs : DISCOVERY__DEFAULT_TIMEOUT;
 
     // Per-factory validation slot for a single port
     struct FactorySlot {
@@ -66,9 +67,13 @@ bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t
         if (alreadyHandled)
             continue;
 
-        // Open port if needed
+        // Open port if needed. portOpenRetry(), not a bare portOpen(): an asynchronous transport
+        // returns PORT_ERROR__NONE with the connect still in flight and PORT_FLAG__OPENED clear. A
+        // bare call here either (a) skips the port outright on a merely-transient error, or (b) for
+        // a port with an already-known device (below), hands existingDev->validate() a port that
+        // isn't actually connected yet, since validate() itself does not poll (SN-8571).
         if ((!portIsOpened(port) && (options & DISCOVERY__IGNORE_CLOSED_PORTS)) ||
-            (portOpen(port) != PORT_ERROR__NONE))
+            (portOpenRetry(port, effectiveTimeout / 4, 10) != PORT_ERROR__NONE))
             continue;
 
         // Only COMM ports can be validated via ISComm protocol
@@ -92,7 +97,6 @@ bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t
         // asking: an asynchronous transport returns PORT_ERROR__NONE with the connect still in flight
         // and PORT_FLAG__OPENED clear, and validating a port that is not connected yet retires it for
         // the whole pass. A synchronous port opens on the first call and waits for nothing.
-        const uint32_t effectiveTimeout = (timeoutMs > 0) ? timeoutMs : DISCOVERY__DEFAULT_TIMEOUT;
         if (!portIsOpened(port)) {
             if (portOpenRetry(port, effectiveTimeout / 4, 10) != PORT_ERROR__NONE)
                 continue;

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -140,9 +140,13 @@ public:
             factoriesSnapshot = factories;
         }
 
-        // open the port, if needed - if we can't open it, fail.
+        // Open the port if needed - if we can't open it, fail. portOpenRetry(), not a bare
+        // portOpen(): an asynchronous transport returns PORT_ERROR__NONE with the connect still in
+        // flight and PORT_FLAG__OPENED clear, and locateDevice() below assumes an actually-open port
+        // (SN-8571).
+        const uint32_t effectiveTimeout = (timeoutMs > 0) ? timeoutMs : DISCOVERY__DEFAULT_TIMEOUT;
         if ( (!portIsOpened(port) && (options & DISCOVERY__IGNORE_CLOSED_PORTS)) ||
-             (portOpen(port) != PORT_ERROR__NONE) )
+             (portOpenRetry(port, effectiveTimeout / 4, 10) != PORT_ERROR__NONE) )
             return false;
 
 

--- a/src/core/base_port.c
+++ b/src/core/base_port.c
@@ -40,7 +40,15 @@ int portOpenRetry(port_handle_t port, unsigned int timeoutMs, unsigned int retry
         SLEEP_MS(retryDelayMs);
     } while (current_timeMs() < timeout);
     // Final check: the last portOpen() above may have completed the handshake just before we timed out.
-    return portIsOpened(port) ? PORT_ERROR__NONE : lastResult;
+    if (portIsOpened(port))
+        return PORT_ERROR__NONE;
+    // SN-8571: never actually opened. A pending async connect (e.g. tcpPort's non-blocking connect())
+    // can report PORT_ERROR__NONE on every single poll without ever completing within our deadline --
+    // lastResult is then ALSO PORT_ERROR__NONE, which is not "success", it's "still not open after
+    // timeoutMs elapsed". Returning that NONE here would silently tell every caller (including the
+    // fixed call sites in DeviceFactory.cpp/DeviceManager.cpp/.h) that the port opened when it didn't.
+    // Report a genuine timeout instead of echoing back the misleading NONE.
+    return (lastResult != PORT_ERROR__NONE) ? lastResult : PORT_ERROR__TIMEOUT;
 }
 
 /**

--- a/src/core/base_port.h
+++ b/src/core/base_port.h
@@ -476,8 +476,28 @@ static inline uint16_t portStatsReset(port_handle_t port) {
 
 /**
  * Opens or establishes a connection to port. This function may not be supported on all port implementations.
+ *
+ * @warning SN-8571 -- asynchronous transports (e.g. tcpPort) do NOT finish connecting within one
+ * call. A non-blocking connect() reports "in progress" (EINPROGRESS), and that in-progress state is
+ * exactly what this function returns as PORT_ERROR__NONE -- deliberately WITHOUT setting
+ * PORT_FLAG__OPENED (see tcpPortOpen() in core/tcpPort.c). A caller that treats a single
+ * PORT_ERROR__NONE result as "the port is open" will silently operate on a port that isn't actually
+ * connected yet; this exact mistake has caused multiple bench-only failures (SN-8508, SN-8561) that
+ * never showed up over serial, because a synchronous (serial) port DOES set PORT_FLAG__OPENED on
+ * the first call and is unaffected.
+ *
+ * The contract: this call may need to be repeated, checking portIsOpened() after each one, until it
+ * returns true or a deadline elapses -- a sleep between attempts is not enough on its own; only a
+ * fresh portOpen() call advances a pending handshake.
+ *
+ * @b Prefer @b portOpenRetry() -- it implements exactly that polling loop and is the safe default
+ * for nearly every caller. Call this bare function directly only when you need to interleave other
+ * work between polls (see ISDevice::connect() for a worked example), and even then, always gate on
+ * portIsOpened() yourself -- never trust this function's return value alone to mean "open".
+ *
  * @param port the port to open
- * @return a PORT_ERROR__* number, or PORT_ERROR__NONE (0) if no error
+ * @return a PORT_ERROR__* number, or PORT_ERROR__NONE (0) if no error. NOTE: PORT_ERROR__NONE does
+ *         NOT mean the port is open on an asynchronous transport -- see above. Check portIsOpened().
  */
 static inline int portOpen(port_handle_t port) {
     if (!portIsValid(port)) return PORT_ERROR__INVALID;
@@ -491,11 +511,16 @@ static inline int portOpen(port_handle_t port) {
 }
 
 /**
- * Attempts to open the specified port, until a timeout occurs.
+ * Attempts to open the specified port, until a timeout occurs. This is the safe default for
+ * opening a port -- see the @warning on portOpen() above for why a single bare portOpen() call is
+ * not sufficient on an asynchronous transport (SN-8571).
  * @param port the port to open
  * @param timeoutMs the maximum time to wait for the port to open/connect
  * @param retryDelayMs the number of milliseconds to wait between failed open attempts
- * @return PORT_ERROR__NONE if successful, else of PORT_ERROR__* indicating the reason for failure.
+ * @return PORT_ERROR__NONE if the port actually reports open (portIsOpened()) before timeoutMs
+ *         elapses; otherwise a PORT_ERROR__* indicating why -- PORT_ERROR__TIMEOUT specifically
+ *         when every poll returned PORT_ERROR__NONE (still pending) but the port never opened in
+ *         time, so a perpetually-pending async connect cannot be mistaken for success (SN-8571).
  */
 int portOpenRetry(port_handle_t port, unsigned int timeoutMs, unsigned int retryDelayMs);
 

--- a/tests/test_port_open_async_contract.cpp
+++ b/tests/test_port_open_async_contract.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file test_port_open_async_contract.cpp
+ * @brief SN-8571 -- locks in portOpen()'s asynchronous contract (a single call may return
+ *        PORT_ERROR__NONE while a non-blocking connect is still in flight, without setting
+ *        PORT_FLAG__OPENED) and proves portOpenRetry() correctly waits for it.
+ *
+ * Scaffolded on a minimal SDK-layer fake port (a bare base_port_t with a custom portOpen
+ * callback) rather than a real socket/fd -- portable, and it exercises the contract the SDK
+ * itself owns (base_port.h) rather than the host OS's TCP stack timing.
+ */
+
+#include <gtest/gtest.h>
+
+#include "core/base_port.h"
+
+namespace {
+
+// Minimal base_port_t-compatible fake port that simulates an asynchronous connect: the first
+// `pendingCalls` portOpen() calls return PORT_ERROR__NONE without setting PORT_FLAG__OPENED --
+// exactly like tcpPortOpen()'s non-blocking connect() reporting EINPROGRESS -- and only the
+// call after that sets the flag.
+struct fake_async_port_t {
+    base_port_t base = {};
+    int pendingCalls = 0;   //!< portOpen() calls remaining before the simulated handshake completes
+    int openCallCount = 0;  //!< total portOpen() invocations seen, for assertions
+};
+
+int fakeAsyncPortOpen(port_handle_t port) {
+    auto* p = reinterpret_cast<fake_async_port_t*>(port);
+    ++p->openCallCount;
+    if (p->pendingCalls > 0) {
+        --p->pendingCalls;
+        return PORT_ERROR__NONE;   // "connect in progress" -- NONE, but deliberately not open yet
+    }
+    portFlagsSet(port, PORT_FLAG__OPENED);
+    return PORT_ERROR__NONE;
+}
+
+fake_async_port_t makeFakeAsyncPort(int pendingCalls) {
+    fake_async_port_t p;
+    p.base.pnum = 1;
+    p.base.ptype = PORT_TYPE__COMM;
+    p.base.pflags = PORT_FLAG__VALID;   // portIsValid() requires this in addition to the checksum
+    p.base.portOpen = fakeAsyncPortOpen;
+    p.pendingCalls = pendingCalls;
+    portRecalcChksum(&p);
+    return p;
+}
+
+} // namespace
+
+// SN-8571 AC: "A test fails if a delayed-open port is treated as immediately open." This locks
+// in the platform contract a bare portOpen() call relies on callers respecting: on an
+// asynchronous transport, ONE portOpen() call can legitimately return PORT_ERROR__NONE while the
+// port is still not actually open. Any caller that skips the portIsOpened() check after a single
+// portOpen() call is exactly the SN-8571 bug pattern (SN-8508, SN-8561).
+TEST(PortOpenAsyncContract, BareCallDoesNotImplyOpenOnAsyncTransport) {
+    fake_async_port_t port = makeFakeAsyncPort(/*pendingCalls=*/5);
+
+    const int result = portOpen(&port);
+    EXPECT_EQ(result, PORT_ERROR__NONE)
+        << "an in-progress async connect reports NONE, not an error";
+    EXPECT_FALSE(portIsOpened(&port))
+        << "PORT_ERROR__NONE must NOT be treated as \"open\" -- the handshake is still pending";
+}
+
+// The serial (synchronous) case must be unaffected: the port sets PORT_FLAG__OPENED on the very
+// first call, so a bare portOpen() IS sufficient there (SN-8571 AC: "no behaviour change on
+// synchronous transports").
+TEST(PortOpenAsyncContract, BareCallDoesImplyOpenOnSynchronousTransport) {
+    fake_async_port_t port = makeFakeAsyncPort(/*pendingCalls=*/0);  // opens on the first call
+
+    const int result = portOpen(&port);
+    EXPECT_EQ(result, PORT_ERROR__NONE);
+    EXPECT_TRUE(portIsOpened(&port))
+        << "a synchronous port opens on the first call and must report open immediately";
+}
+
+// portOpenRetry() is the fix: it must keep polling a delayed-open port until it actually opens,
+// rather than accepting the first PORT_ERROR__NONE.
+TEST(PortOpenAsyncContract, PortOpenRetryWaitsForDelayedOpen) {
+    fake_async_port_t port = makeFakeAsyncPort(/*pendingCalls=*/5);
+
+    const int result = portOpenRetry(&port, /*timeoutMs=*/1000, /*retryDelayMs=*/1);
+    EXPECT_EQ(result, PORT_ERROR__NONE);
+    EXPECT_TRUE(portIsOpened(&port))
+        << "portOpenRetry() must not return success until the port actually reports open";
+    EXPECT_GE(port.openCallCount, 6)
+        << "portOpenRetry() must re-invoke portOpen() -- a sleep alone never advances the handshake";
+}
+
+// portOpenRetry() must still fail (not hang or false-positive) if the port never actually opens
+// within the timeout.
+TEST(PortOpenAsyncContract, PortOpenRetryTimesOutIfNeverOpens) {
+    fake_async_port_t port = makeFakeAsyncPort(/*pendingCalls=*/1000000);  // never opens in time
+
+    const int result = portOpenRetry(&port, /*timeoutMs=*/20, /*retryDelayMs=*/1);
+    EXPECT_NE(result, PORT_ERROR__NONE);
+    EXPECT_FALSE(portIsOpened(&port));
+}


### PR DESCRIPTION
## Summary
Re-verified the ticket's call-site table against current `develop` tip rather than trusting it as-is (findings below), then fixed the confirmed-bare sites and, along the way, found and fixed a real bug in `portOpenRetry()` itself -- the exact function this ticket wants to be the safe default.

**Corrections to the ticket's table** (both confirmed by tracing the actual code, not assumed):
- `CorrectionService.cpp:96` -- ticket says Unfixed, but `step()` already checks `portIsOpened()` both before *and* after the bare `portOpen()` call, polling via repeated tick invocation -- same pattern the ticket calls Correct for `NtripCorrectionService`. No fix needed.
- `InertialSense.cpp:1072` (was 1031) -- the flagged code is entirely inside a `/* commented-out */` block with its own FIXME already explaining why it stays disabled. Dead code, no fix needed.

**New finding** (header files weren't covered by the original `SDK/src/*.cpp` sweep): `DeviceManager.h:145`, inside `discoverDevice()` (the singular-port sibling of `discoverDevices()`), has the same bare-`portOpen()` bug. Also traced a second consequence inside `discoverDevices()` itself: for a port with an *existing* device record, `existingDev->validate(timeoutMs)` runs right after the bare `portOpen()`, and `validate()` doesn't poll on its own -- a reconnecting async port with a known device failed validation immediately.

**Fixes (commit 1)**:
- `DeviceFactory.cpp:73`, `DeviceManager.cpp:71`, `DeviceManager.h:145` -- replaced bare `portOpen()` with `portOpenRetry()`, matching the `effectiveTimeout / 4, 10` convention already established at `DeviceManager.cpp`'s existing fixed site.
- Documented the async contract at `portOpen()`'s declaration in `base_port.h`, steering readers to `portOpenRetry()` as the safe default.

**Bug found + fixed (commit 2)**: the new regression test caught a real bug in `portOpenRetry()` itself. Its final line, `portIsOpened(port) ? PORT_ERROR__NONE : lastResult`, assumed `lastResult` would be a real error code once the port failed to open -- but an async transport's `portOpen()` returns `PORT_ERROR__NONE` on *every* poll while a connect is merely pending (that's the whole point of the contract), so a port that never actually completes the handshake within `timeoutMs` also has `lastResult == PORT_ERROR__NONE`, and the old code returned that as success. Every caller checking `!= PORT_ERROR__NONE` -- including the three sites just fixed above -- would have silently proceeded on an unopened port in exactly the timeout case `portOpenRetry()` exists to guard against. Fixed to return `PORT_ERROR__TIMEOUT` in that case.

**Out of scope, flagged for separate follow-up (not touched)**:
- `cltool/src/cltool_main.cpp:1637` has a *different* bug: `portOpen(port)` used as a truthy check, but `PORT_ERROR__NONE` is `0`/falsy -- inverted logic, not a polling issue.
- The `imx` repo's `RTKLIB_InertialSense.cpp` (migrated in SN-8473) also has bare `portOpen()` calls -- worth a note for that PR's pending Windows human-verification pass.

## Test plan
- [x] New `test_port_open_async_contract.cpp` (4 tests): a bare `portOpen()` call does not imply open on an async transport but does on a synchronous one (the two SN-8571 ACs), `portOpenRetry()` waits for a delayed open, and `portOpenRetry()` correctly times out (not false-succeeds) when the port never opens -- this last one is what caught the `portOpenRetry()` bug.
- [x] Full `IS-SDK_unit-tests`: 648 passed, 4 pre-existing unrelated skips, 0 failed.
- [x] `cltool` builds clean against the fixed `DeviceFactory`/`DeviceManager`.
- [x] No behavior change on synchronous (serial) transports -- covered explicitly by `BareCallDoesImplyOpenOnSynchronousTransport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)