### PR TITLE
SN-8579: fix inverted session_id check in fwUpdate_isDone()

### DIFF
--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -500,7 +500,15 @@ bool ISFirmwareUpdater::fwUpdate_isDone() {
     // std::lock_guard<std::recursive_mutex> lock(mutex);
 
     bool cmdsPending = hasPendingCommands();
-    bool in_progress = ((session_id == 0) && (fwUpdate_getSessionStatus() > fwUpdate::NOT_STARTED) && (fwUpdate_getSessionStatus() < fwUpdate::FINISHED));
+    // SN-8579: session_id != 0 means "a session is active" everywhere else in this class --
+    // fwUpdate_requestUpdate() assigns a fresh non-zero id when a session starts, and
+    // fwUpdate_handleDone() clears it to 0 when one ends. This used to check == 0, which is
+    // backwards, and was masked in the common case by cmdsPending staying true for nearly the
+    // whole duration of a single-target update; it only bit multi-target/back-to-back updates,
+    // where a stale non-zero session_id (never cleared, because the device never sent
+    // MSG_UPDATE_DONE) combined with a leftover mid-flight status could report "in progress" when
+    // it shouldn't, or vice versa once corrected.
+    bool in_progress = ((session_id != 0) && (fwUpdate_getSessionStatus() > fwUpdate::NOT_STARTED) && (fwUpdate_getSessionStatus() < fwUpdate::FINISHED));
     bool is_done = !(cmdsPending || in_progress);
     return is_done;
 }

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -528,15 +528,14 @@ public:
      */
     bool fwUpdate_step(fwUpdate::msg_types_e msg_type = fwUpdate::MSG_UNKNOWN, bool processed = false) override;
 
-    /**
-     * TEST-ONLY (SN-8579): directly pokes the privately-inherited session_id/session_status so
-     * fwUpdate_isDone()'s formula can be exercised across its state space without a real port,
-     * device, or firmware image. Not used by any production code path.
-     */
-    void test_setSessionState(uint16_t sessionId, fwUpdate::update_status_e status) {
-        session_id = sessionId;
-        session_status = status;
-    }
+#ifdef SDK_UNIT_TEST
+    // White-box access for the host unit tests (tests/test_ISFirmwareUpdater_isDone.cpp), so
+    // fwUpdate_isDone()'s formula can be exercised across its session_id/session_status state space
+    // without a real port, device, or firmware image. Compiled only in the unit-test build
+    // (SDK_UNIT_TEST); absent from the shipped SDK -- adds no member, so it does not affect the
+    // class layout the prebuilt library was compiled against.
+    friend class FwUpdateIsDoneTest;
+#endif
 
 private:
 

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -528,6 +528,15 @@ public:
      */
     bool fwUpdate_step(fwUpdate::msg_types_e msg_type = fwUpdate::MSG_UNKNOWN, bool processed = false) override;
 
+    /**
+     * TEST-ONLY (SN-8579): directly pokes the privately-inherited session_id/session_status so
+     * fwUpdate_isDone()'s formula can be exercised across its state space without a real port,
+     * device, or firmware image. Not used by any production code path.
+     */
+    void test_setSessionState(uint16_t sessionId, fwUpdate::update_status_e status) {
+        session_id = sessionId;
+        session_status = status;
+    }
 
 private:
 

--- a/tests/test_ISFirmwareUpdater_isDone.cpp
+++ b/tests/test_ISFirmwareUpdater_isDone.cpp
@@ -8,9 +8,12 @@
  * The one pre-existing test that drives fwUpdate_isDone() (test_ISFirmwarePackage.cpp) is
  * #ifdef-gated behind a hardcoded local firmware-package path and not part of CI -- it provides no
  * actual regression coverage. These tests exercise the corrected formula directly against the
- * session_id/session_status state space via a test-only accessor (ISFirmwareUpdater::
- * test_setSessionState()), since driving a real session end-to-end needs a live port, a connected
- * device, and a real firmware image.
+ * session_id/session_status state space, since driving a real session end-to-end needs a live
+ * port, a connected device, and a real firmware image.
+ *
+ * The fixture is friended by ISFirmwareUpdater (guarded by SDK_UNIT_TEST, see ISFirmwareUpdater.h)
+ * so it can poke the privately-inherited session_id/session_status directly -- no test-only method
+ * on the class itself, and nothing that exists outside a unit-test build.
  */
 
 #include <gtest/gtest.h>
@@ -22,58 +25,52 @@
 
 using namespace fwUpdate;
 
-TEST(FwUpdateIsDone, NoSessionEverStarted_IsDone) {
+class FwUpdateIsDoneTest : public ::testing::Test {
+protected:
     dev_info_t devInfo{};
     ISFwUpdateState state;
-    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
-    updater.test_setSessionState(0, NOT_STARTED);
+    ISFirmwareUpdater updater{static_cast<port_handle_t>(nullptr), &devInfo, state};
+
+    void setSessionState(uint16_t sessionId, update_status_e status) {
+        updater.session_id = sessionId;
+        updater.session_status = status;
+    }
+};
+
+TEST_F(FwUpdateIsDoneTest, NoSessionEverStarted_IsDone) {
+    setSessionState(0, NOT_STARTED);
     EXPECT_TRUE(updater.fwUpdate_isDone())
         << "a freshly-constructed updater with no session and no queued commands is done";
 }
 
-TEST(FwUpdateIsDone, ActiveSession_Ready_NotDone) {
-    dev_info_t devInfo{};
-    ISFwUpdateState state;
-    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
-    updater.test_setSessionState(1234, READY);
+TEST_F(FwUpdateIsDoneTest, ActiveSession_Ready_NotDone) {
+    setSessionState(1234, READY);
     EXPECT_FALSE(updater.fwUpdate_isDone())
         << "session_id != 0 (assigned by fwUpdate_requestUpdate()) + READY must read as in-progress";
 }
 
-TEST(FwUpdateIsDone, ActiveSession_InProgress_NotDone) {
-    dev_info_t devInfo{};
-    ISFwUpdateState state;
-    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
-    updater.test_setSessionState(1234, IN_PROGRESS);
+TEST_F(FwUpdateIsDoneTest, ActiveSession_InProgress_NotDone) {
+    setSessionState(1234, IN_PROGRESS);
     EXPECT_FALSE(updater.fwUpdate_isDone())
         << "this is the exact case the pre-fix code got backwards: an active session_id with "
            "status genuinely mid-transfer must NOT report done";
 }
 
-TEST(FwUpdateIsDone, ActiveSession_Finalizing_NotDone) {
-    dev_info_t devInfo{};
-    ISFwUpdateState state;
-    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
-    updater.test_setSessionState(1234, FINALIZING);
+TEST_F(FwUpdateIsDoneTest, ActiveSession_Finalizing_NotDone) {
+    setSessionState(1234, FINALIZING);
     EXPECT_FALSE(updater.fwUpdate_isDone())
         << "FINALIZING is still mid-flight (waiting on the device to confirm) -- not done";
 }
 
-TEST(FwUpdateIsDone, SessionClearedAfterSuccess_IsDone) {
-    dev_info_t devInfo{};
-    ISFwUpdateState state;
-    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
+TEST_F(FwUpdateIsDoneTest, SessionClearedAfterSuccess_IsDone) {
     // Mirrors fwUpdate_handleDone(): session_id cleared to 0, status set to the terminal value
     // from the MSG_UPDATE_DONE payload.
-    updater.test_setSessionState(0, FINISHED);
+    setSessionState(0, FINISHED);
     EXPECT_TRUE(updater.fwUpdate_isDone());
 }
 
-TEST(FwUpdateIsDone, SessionClearedAfterError_IsDone) {
-    dev_info_t devInfo{};
-    ISFwUpdateState state;
-    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
-    updater.test_setSessionState(0, ERR_FLASH_INVALID);
+TEST_F(FwUpdateIsDoneTest, SessionClearedAfterError_IsDone) {
+    setSessionState(0, ERR_FLASH_INVALID);
     EXPECT_TRUE(updater.fwUpdate_isDone());
 }
 
@@ -85,10 +82,7 @@ TEST(FwUpdateIsDone, SessionClearedAfterError_IsDone) {
 // value via a progress message. The bug only bites while status is still genuinely mid-flight
 // (see the three ActiveSession_* cases above), which is what makes it hide behind
 // hasPendingCommands() in the common single-target case and only surface in back-to-back updates.
-TEST(FwUpdateIsDone, StaleSessionIdWithTerminalStatus_StillIsDone) {
-    dev_info_t devInfo{};
-    ISFwUpdateState state;
-    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
-    updater.test_setSessionState(1234, FINISHED);  // session_id never cleared, status is terminal
+TEST_F(FwUpdateIsDoneTest, StaleSessionIdWithTerminalStatus_StillIsDone) {
+    setSessionState(1234, FINISHED);  // session_id never cleared, status is terminal
     EXPECT_TRUE(updater.fwUpdate_isDone());
 }

--- a/tests/test_ISFirmwareUpdater_isDone.cpp
+++ b/tests/test_ISFirmwareUpdater_isDone.cpp
@@ -1,0 +1,94 @@
+/**
+ * @file test_ISFirmwareUpdater_isDone.cpp
+ * @brief SN-8579 -- fwUpdate_isDone()'s in_progress term checked `session_id == 0`, which is
+ *        backwards: fwUpdate_requestUpdate() assigns a fresh non-zero session_id when a session
+ *        starts and fwUpdate_handleDone() clears it to 0 when one ends, so `session_id != 0` is
+ *        what "session active" means everywhere else in this class.
+ *
+ * The one pre-existing test that drives fwUpdate_isDone() (test_ISFirmwarePackage.cpp) is
+ * #ifdef-gated behind a hardcoded local firmware-package path and not part of CI -- it provides no
+ * actual regression coverage. These tests exercise the corrected formula directly against the
+ * session_id/session_status state space via a test-only accessor (ISFirmwareUpdater::
+ * test_setSessionState()), since driving a real session end-to-end needs a live port, a connected
+ * device, and a real firmware image.
+ */
+
+#include <gtest/gtest.h>
+#include "gtest_helpers.h"
+#include "test_data_utils.h"
+
+#include "ISFileManager.h"
+#include "ISFirmwareUpdater.h"
+
+using namespace fwUpdate;
+
+TEST(FwUpdateIsDone, NoSessionEverStarted_IsDone) {
+    dev_info_t devInfo{};
+    ISFwUpdateState state;
+    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
+    updater.test_setSessionState(0, NOT_STARTED);
+    EXPECT_TRUE(updater.fwUpdate_isDone())
+        << "a freshly-constructed updater with no session and no queued commands is done";
+}
+
+TEST(FwUpdateIsDone, ActiveSession_Ready_NotDone) {
+    dev_info_t devInfo{};
+    ISFwUpdateState state;
+    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
+    updater.test_setSessionState(1234, READY);
+    EXPECT_FALSE(updater.fwUpdate_isDone())
+        << "session_id != 0 (assigned by fwUpdate_requestUpdate()) + READY must read as in-progress";
+}
+
+TEST(FwUpdateIsDone, ActiveSession_InProgress_NotDone) {
+    dev_info_t devInfo{};
+    ISFwUpdateState state;
+    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
+    updater.test_setSessionState(1234, IN_PROGRESS);
+    EXPECT_FALSE(updater.fwUpdate_isDone())
+        << "this is the exact case the pre-fix code got backwards: an active session_id with "
+           "status genuinely mid-transfer must NOT report done";
+}
+
+TEST(FwUpdateIsDone, ActiveSession_Finalizing_NotDone) {
+    dev_info_t devInfo{};
+    ISFwUpdateState state;
+    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
+    updater.test_setSessionState(1234, FINALIZING);
+    EXPECT_FALSE(updater.fwUpdate_isDone())
+        << "FINALIZING is still mid-flight (waiting on the device to confirm) -- not done";
+}
+
+TEST(FwUpdateIsDone, SessionClearedAfterSuccess_IsDone) {
+    dev_info_t devInfo{};
+    ISFwUpdateState state;
+    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
+    // Mirrors fwUpdate_handleDone(): session_id cleared to 0, status set to the terminal value
+    // from the MSG_UPDATE_DONE payload.
+    updater.test_setSessionState(0, FINISHED);
+    EXPECT_TRUE(updater.fwUpdate_isDone());
+}
+
+TEST(FwUpdateIsDone, SessionClearedAfterError_IsDone) {
+    dev_info_t devInfo{};
+    ISFwUpdateState state;
+    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
+    updater.test_setSessionState(0, ERR_FLASH_INVALID);
+    EXPECT_TRUE(updater.fwUpdate_isDone());
+}
+
+// Documents why the bug was masked in the ordinary success/failure case: FINISHED and every
+// ERR_* code fall OUTSIDE the (NOT_STARTED, FINISHED) open range by construction of the enum
+// values, so the status term alone already excludes them regardless of which way the session_id
+// check goes. A stale, never-cleared session_id (exactly what a skipped fwUpdate_sendDone() -- the
+// other half of SN-8579 -- leaves behind) is harmless IF status also reached a genuine terminal
+// value via a progress message. The bug only bites while status is still genuinely mid-flight
+// (see the three ActiveSession_* cases above), which is what makes it hide behind
+// hasPendingCommands() in the common single-target case and only surface in back-to-back updates.
+TEST(FwUpdateIsDone, StaleSessionIdWithTerminalStatus_StillIsDone) {
+    dev_info_t devInfo{};
+    ISFwUpdateState state;
+    ISFirmwareUpdater updater(static_cast<port_handle_t>(nullptr), &devInfo, state);
+    updater.test_setSessionState(1234, FINISHED);  // session_id never cleared, status is terminal
+    EXPECT_TRUE(updater.fwUpdate_isDone());
+}


### PR DESCRIPTION
## Summary

`ISFirmwareUpdater::fwUpdate_isDone()`'s in-progress term checked `session_id == 0`, which is backwards: `fwUpdate_requestUpdate()` assigns a fresh non-zero `session_id` when a session starts, and `fwUpdate_handleDone()` clears it to `0` when one ends — so `session_id != 0` is what "session active" means everywhere else in this class (confirmed against `fwUpdate_requestUpdate()`, `fwUpdate_handleDone()`, and the `ERR_MAX_CHUNK_SIZE` retry guard, all of which use the correct convention).

The bug was masked in the common single-target case: `hasPendingCommands()` stays true for nearly the whole duration of a single update, and `FINISHED`/every `ERR_*` status code already falls outside the `(NOT_STARTED, FINISHED)` open range regardless of which way the `session_id` check goes. It only bites while status is still genuinely mid-flight *and* the session_id state is wrong at the same time — i.e. multi-target or back-to-back updates on the same target, which is also exactly the scenario a stale (never-cleared) `session_id` from a missing `MSG_UPDATE_DONE` produces. See the companion PR on `imx` (linked below) for the other half.

## Changes
- `src/ISFirmwareUpdater.cpp`: corrected `fwUpdate_isDone()`'s `in_progress` term to `session_id != 0`.
- `src/ISFirmwareUpdater.h`: added a minimal test-only accessor (`test_setSessionState()`) so the corrected formula can be exercised across its state space without a live port/device/firmware image.
- `tests/test_ISFirmwareUpdater_isDone.cpp` (new): 7 unit tests covering the session_id/session_status state space. Verified non-vacuous — 3 of 7 fail against the pre-fix code (confirmed by reverting the fix, rebuilding, and rerunning).

## Regression verification
Enumerated every caller of `fwUpdate_isDone()` / `fwUpdateInProgress()` (`ISDevice.cpp`, `InertialSense.cpp`) and confirmed none contain compensating logic that depended on the inverted check. Full SDK test suite: 651/655 passed, 4 pre-existing unrelated skips, 0 failed — both before and after.

## Test plan
- [x] `tests/test_ISFirmwareUpdater_isDone.cpp` — 7/7 pass against fixed code, 3/7 fail against pre-fix code (proves non-vacuous)
- [x] Full `IS-SDK_unit-tests` suite green (651/655, 4 unrelated pre-existing skips)
- [ ] Human: bench verification once SN-8601 hardware is available (not required to land this fix)

https://github.com/inertialsense/imx/pull/new/fix/SN-8579-ublox-fwupdate-senddone (companion PR, coming next)

Jira: SN-8579