### PR TITLE
SN-8664 Fix LogInspector crash with empty log

### DIFF
--- a/python/inertialsense/logInspector/logInspector.py
+++ b/python/inertialsense/logInspector/logInspector.py
@@ -359,9 +359,12 @@ class LogInspectorWindow(QMainWindow):
         print("\nLoading files from " + directory)
         self.setStatus("Loading...")
         self.log = Log()
-        self.log.load(directory)
+        loaded = self.log.load(directory)
         # Clean up the C++ LogReader's Python parent reference to avoid GIL issues
         self.log.c_log.cleanup()
+        if not loaded:
+            self.setStatus("Failed to load log")
+            return
         print("done loading")
         for mplot in self.mplots:
             mplot.plotter.setLog(self.log)

--- a/python/inertialsense/logInspector/logInspector.py
+++ b/python/inertialsense/logInspector/logInspector.py
@@ -363,6 +363,7 @@ class LogInspectorWindow(QMainWindow):
         # Clean up the C++ LogReader's Python parent reference to avoid GIL issues
         self.log.c_log.cleanup()
         if not loaded:
+            self.log = None
             self.setStatus("Failed to load log")
             return
         print("done loading")

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -78,7 +78,7 @@ class Log:
         # Recover DID_INS_2 from DID_INS_1 before filtering, so a device that only logged
         # DID_INS_1 isn't mistaken for one with no INS solution at all.
         for d in range(self.numDev):
-            if len(self.data[0, DID_INS_2]) == 0 and len(self.data[0, DID_INS_1]) != 0:
+            if len(self.data[d, DID_INS_2]) == 0 and len(self.data[d, DID_INS_1]) != 0:
                 self.ins1ToIns2(d)
 
         # The performance report indexes DID_INS_2 for every device, so a device that never

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -75,6 +75,12 @@ class Log:
                 if dev_serial:
                     self.serials[d] = dev_serial
 
+        # Recover DID_INS_2 from DID_INS_1 before filtering, so a device that only logged
+        # DID_INS_1 isn't mistaken for one with no INS solution at all.
+        for d in range(self.numDev):
+            if len(self.data[0, DID_INS_2]) == 0 and len(self.data[0, DID_INS_1]) != 0:
+                self.ins1ToIns2(d)
+
         # The performance report indexes DID_INS_2 for every device, so a device that never
         # produced an INS solution (e.g. a raw GNSS receiver logged alongside the INS units)
         # has to be dropped here rather than crashing downstream on an empty array.
@@ -115,8 +121,6 @@ class Log:
                 if len(self.data[i, DID_DEV_INFO]):
                     self.refSerials.clear()
                     self.refSerials.append(self.data[i, DID_DEV_INFO]['serialNumber'][0])
-            if len(self.data[0, DID_INS_2]) == 0 and len(self.data[0, DID_INS_1]) != 0:
-                self.ins1ToIns2(i)
             #If you want to view data of log with only refIns:
             if len(self.serials) == 1 and self.refINS == True:
                 return True

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -75,6 +75,20 @@ class Log:
                 if dev_serial:
                     self.serials[d] = dev_serial
 
+        # The performance report indexes DID_INS_2 for every device, so a device that never
+        # produced an INS solution (e.g. a raw GNSS receiver logged alongside the INS units)
+        # has to be dropped here rather than crashing downstream on an empty array.
+        keep = [d for d in range(self.numDev) if len(self.data[d, DID_INS_2])]
+        if len(keep) < self.numDev:
+            dropped = [self.serials[d] for d in range(self.numDev) if d not in keep]
+            print("\033[93m" + "missing DID_INS_2 data: removing device(s) " + str(dropped) + "\033[0m")
+            self.data = self.data[keep]
+            self.serials = [self.serials[d] for d in keep]
+            self.numDev = len(keep)
+            if self.numDev == 0:
+                print("No devices with DID_INS_2 data found in log!!!")
+                return False
+
         for i in range(self.numDev):
             try:
                 self.hardware.append(self.data[i, DID_DEV_INFO]['hardwareVer'][0][0])


### PR DESCRIPTION
This pull request improves the robustness of the `logReader.py` loader by ensuring that only devices with valid INS solution data (`DID_INS_2`) are processed. Devices lacking this data are now excluded early, preventing downstream errors and providing clear feedback to the user.

**Device filtering and error handling:**
* Devices without any `DID_INS_2` (INS solution) data are now identified and removed from further processing to prevent downstream crashes. The code prints a warning listing the dropped devices and gracefully handles the case where no valid devices remain.